### PR TITLE
Controller support for snapshot copy

### DIFF
--- a/config/crds/migration_v1alpha1_migplan.yaml
+++ b/config/crds/migration_v1alpha1_migplan.yaml
@@ -62,6 +62,8 @@ spec:
                         type: string
                       action:
                         type: string
+                      copyMethod:
+                        type: string
                       storageClass:
                         type: string
                     type: object
@@ -73,8 +75,13 @@ spec:
                         items:
                           type: string
                         type: array
+                      copyMethods:
+                        items:
+                          type: string
+                        type: array
                     required:
                     - actions
+                    - copyMethods
                     type: object
                 required:
                 - supported

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -680,6 +680,12 @@ const (
 	PvCopyAction = "copy"
 )
 
+// PV Copy Methods.
+const (
+	PvFilesystemCopyMethod = "filesystem"
+	PvSnapshotCopyMethod   = "snapshot"
+)
+
 // Name - The PV name.
 // Capacity - The PV storage capacity.
 // StorageClass - The PV storage class name.
@@ -704,25 +710,30 @@ type PVC struct {
 }
 
 // Supported
-// Actions - The list of supported actions
+// Actions     - The list of supported actions
+// CopyMethods - The list of supported copy methods
 type Supported struct {
-	Actions []string `json:"actions"`
+	Actions     []string `json:"actions"`
+	CopyMethods []string `json:"copyMethods"`
 }
 
 // Selection
 // Action - The PV migration action (move|copy)
 // StorageClass - The PV storage class name to use in the destination cluster.
 // AccessMode   - The PV access mode to use in the destination cluster, if different from src PVC AccessMode
+// CopyMethod   - The PV copy method to use ('filesystem' for restic copy, or 'snapshot' for velero snapshot plugin)
 type Selection struct {
 	Action       string                          `json:"action,omitempty"`
 	StorageClass string                          `json:"storageClass,omitempty"`
 	AccessMode   kapi.PersistentVolumeAccessMode `json:"accessMode,omitempty" protobuf:"bytes,1,rep,name=accessMode,casttype=PersistentVolumeAccessMode"`
+	CopyMethod   string                          `json:"copyMethod,omitempty"`
 }
 
 // Update the PV with another.
 func (r *PV) Update(pv PV) {
 	r.StorageClass = pv.StorageClass
 	r.Supported.Actions = pv.Supported.Actions
+	r.Supported.CopyMethods = pv.Supported.CopyMethods
 	r.Capacity = pv.Capacity
 	r.PVC = pv.PVC
 	if len(r.Supported.Actions) == 1 {

--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -119,13 +119,15 @@ func (r *MigStorage) UpdateBSL(bsl *velero.BackupStorageLocation) {
 }
 
 // Build VSL.
-func (r *MigStorage) BuildVSL() *velero.VolumeSnapshotLocation {
+// planUID param is a workaround for velero, needed until velero
+// restore accepts a VSL attibute when the name differs from the backup
+func (r *MigStorage) BuildVSL(planUID string) *velero.VolumeSnapshotLocation {
 	vsl := &velero.VolumeSnapshotLocation{
 		Spec: velero.VolumeSnapshotLocationSpec{},
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:       r.GetCorrelationLabels(),
-			Namespace:    VeleroNamespace,
-			GenerateName: r.Name + "-",
+			Labels:    r.GetCorrelationLabels(),
+			Namespace: VeleroNamespace,
+			Name:      r.Name + "-" + planUID,
 		},
 	}
 

--- a/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
@@ -672,6 +672,11 @@ func (in *Supported) DeepCopyInto(out *Supported) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.CopyMethods != nil {
+		in, out := &in.CopyMethods, &out.CopyMethods
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controller/migmigration/backup.go
+++ b/pkg/controller/migmigration/backup.go
@@ -329,3 +329,12 @@ func findPVAccessMode(pvList migapi.PersistentVolumes, pvName string) corev1.Per
 	}
 	return ""
 }
+
+func findPVCopyMethod(pvList migapi.PersistentVolumes, pvName string) string {
+	for _, pv := range pvList.List {
+		if pv.Name == pvName {
+			return pv.Selection.CopyMethod
+		}
+	}
+	return ""
+}

--- a/pkg/controller/migplan/storage.go
+++ b/pkg/controller/migplan/storage.go
@@ -131,7 +131,7 @@ func (r PlanStorage) ensureBSL() error {
 
 // Create the velero VolumeSnapshotLocation has been created.
 func (r PlanStorage) ensureVSL() error {
-	newVSL := r.storage.BuildVSL()
+	newVSL := r.storage.BuildVSL(string(r.plan.UID))
 	newVSL.Labels = r.plan.GetCorrelationLabels()
 	foundVSL, err := r.plan.GetVSL(r.targetClient)
 	if err != nil {

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -31,6 +31,9 @@ const (
 	PvNoStorageClassSelection      = "PvNoStorageClassSelection"
 	PvWarnNoCephAvailable          = "PvWarnNoCephAvailable"
 	PvWarnAccessModeUnavailable    = "PvWarnAccessModeUnavailable"
+	PvInvalidCopyMethod            = "PvInvalidCopyMethod"
+	PvNoCopyMethodSelection        = "PvNoCopyMethodSelection"
+	PvWarnCopyMethodSnapshot       = "PvWarnCopyMethodSnapshot"
 	StorageEnsured                 = "StorageEnsured"
 	RegistriesEnsured              = "RegistriesEnsured"
 	PvsDiscovered                  = "PvsDiscovered"
@@ -83,6 +86,9 @@ const (
 	PvNoStorageClassSelectionMessage      = "PV in `persistentVolumes` [] has no `Selected.StorageClass`."
 	PvWarnNoCephAvailableMessage          = "Ceph is not available on destination. If this is desired, please install the rook operator. The following PVs will use the default storage class instead: []"
 	PvWarnAccessModeUnavailableMessage    = "AccessMode for PVC in `persistentVolumes` [] unavailable in chosen storage class"
+	PvInvalidCopyMethodMessage            = "PV in `persistentVolumes` [] has an invalid `copyMethod`."
+	PvNoCopyMethodSelectionMessage        = "PV in `persistentVolumes` [] has no `Selected.CopyMethod`."
+	PvWarnCopyMethodSnapshotMessage       = "CopyMethod for PV in `persistentVolumes` [] is set to `snapshot`. Make sure that the chosen storage class is compatible with the source volume's storage type for Snapshot support."
 	StorageEnsuredMessage                 = "The storage resources have been created."
 	RegistriesEnsuredMessage              = "The migration registry resources have been created."
 	PvsDiscoveredMessage                  = "The `persistentVolumes` list has been updated with discovered PVs."
@@ -472,6 +478,9 @@ func (r ReconcileMigPlan) validatePvSelections(plan *migapi.MigPlan) error {
 	invalidStorageClass := make([]string, 0)
 	invalidAccessMode := make([]string, 0)
 	unavailableAccessMode := make([]string, 0)
+	missingCopyMethod := make([]string, 0)
+	invalidCopyMethod := make([]string, 0)
+	warnCopyMethodSnapshot := make([]string, 0)
 
 	if plan.Status.HasAnyCondition(Suspended) {
 		return nil
@@ -500,7 +509,7 @@ func (r ReconcileMigPlan) validatePvSelections(plan *migapi.MigPlan) error {
 			invalidAction = append(invalidAction, pv.Name)
 			continue
 		}
-		// Don't report StorageClass, AccessMode errors if Action != 'copy'
+		// Don't report StorageClass, AccessMode, CopyMethod errors if Action != 'copy'
 		if pv.Selection.Action != migapi.PvCopyAction {
 			continue
 		}
@@ -530,6 +539,22 @@ func (r ReconcileMigPlan) validatePvSelections(plan *migapi.MigPlan) error {
 				invalidStorageClass = append(invalidStorageClass, pv.Name)
 			}
 		}
+		if pv.Selection.CopyMethod == "" {
+			missingCopyMethod = append(missingCopyMethod, pv.Name)
+		} else {
+			copyMethods := map[string]bool{}
+			for _, m := range pv.Supported.CopyMethods {
+				copyMethods[m] = true
+			}
+			_, found := copyMethods[pv.Selection.CopyMethod]
+			if !found {
+				invalidCopyMethod = append(invalidCopyMethod, pv.Name)
+			} else if pv.Selection.CopyMethod == migapi.PvSnapshotCopyMethod {
+				// Warn if Snapshot is selected
+				warnCopyMethodSnapshot = append(warnCopyMethodSnapshot, pv.Name)
+			}
+		}
+
 	}
 	if len(invalidAction) > 0 {
 		plan.Status.SetCondition(migapi.Condition{
@@ -549,7 +574,6 @@ func (r ReconcileMigPlan) validatePvSelections(plan *migapi.MigPlan) error {
 			Message:  PvNoSupportedActionMessage,
 			Items:    unsupported,
 		})
-		return nil
 	}
 	if len(invalidStorageClass) > 0 {
 		plan.Status.SetCondition(migapi.Condition{
@@ -578,7 +602,6 @@ func (r ReconcileMigPlan) validatePvSelections(plan *migapi.MigPlan) error {
 			Message:  PvNoStorageClassSelectionMessage,
 			Items:    missingStorageClass,
 		})
-		return nil
 	}
 	if len(unavailableAccessMode) > 0 {
 		plan.Status.SetCondition(migapi.Condition{
@@ -588,7 +611,33 @@ func (r ReconcileMigPlan) validatePvSelections(plan *migapi.MigPlan) error {
 			Message:  PvWarnAccessModeUnavailableMessage,
 			Items:    unavailableAccessMode,
 		})
-		return nil
+	}
+	if len(missingCopyMethod) > 0 {
+		plan.Status.SetCondition(migapi.Condition{
+			Type:     PvNoCopyMethodSelection,
+			Status:   True,
+			Category: Error,
+			Message:  PvNoCopyMethodSelectionMessage,
+			Items:    missingCopyMethod,
+		})
+	}
+	if len(invalidCopyMethod) > 0 {
+		plan.Status.SetCondition(migapi.Condition{
+			Type:     PvInvalidCopyMethod,
+			Status:   True,
+			Category: Error,
+			Message:  PvInvalidCopyMethodMessage,
+			Items:    invalidCopyMethod,
+		})
+	}
+	if len(warnCopyMethodSnapshot) > 0 {
+		plan.Status.SetCondition(migapi.Condition{
+			Type:     PvWarnCopyMethodSnapshot,
+			Status:   True,
+			Category: Warn,
+			Message:  PvWarnCopyMethodSnapshotMessage,
+			Items:    warnCopyMethodSnapshot,
+		})
 	}
 
 	return nil


### PR DESCRIPTION
This commit adds support for copying volumes by snapshot
in addition to the basic filesystem-based restic support.
For the migplan persistentVolumes list, add CopyMethods
to Supported and CopyMethod to Selection.

This also depends on velero migration plugin changes to support
snapshot volume copy.