### PR TITLE
Single openshift-migration namespace and finalizers removed.

### DIFF
--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -88,41 +88,6 @@ func init() {
 	SchemeBuilder.Register(&MigCluster{}, &MigClusterList{})
 }
 
-// Ensure finalizer.
-func (r *MigCluster) EnsureFinalizer() bool {
-	if !FinalizerEnabled {
-		return false
-	}
-	if r.Finalizers == nil {
-		r.Finalizers = []string{}
-	}
-	for _, f := range r.Finalizers {
-		if f == Finalizer {
-			return false
-		}
-	}
-	r.Finalizers = append(r.Finalizers, Finalizer)
-	return true
-}
-
-// Delete finalizer.
-func (r *MigCluster) DeleteFinalizer() bool {
-	if r.Finalizers == nil {
-		r.Finalizers = []string{}
-	}
-	deleted := false
-	kept := []string{}
-	for _, f := range r.Finalizers {
-		if f == Finalizer {
-			deleted = true
-			continue
-		}
-		kept = append(kept, f)
-	}
-	r.Finalizers = kept
-	return deleted
-}
-
 // Get the service account secret.
 // Returns `nil` when the reference cannot be resolved.
 func (m *MigCluster) GetServiceAccountSecret(client k8sclient.Client) (*kapi.Secret, error) {

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -80,41 +80,6 @@ func init() {
 	SchemeBuilder.Register(&MigPlan{}, &MigPlanList{})
 }
 
-// Ensure finalizer.
-func (r *MigPlan) EnsureFinalizer() bool {
-	if !FinalizerEnabled {
-		return false
-	}
-	if r.Finalizers == nil {
-		r.Finalizers = []string{}
-	}
-	for _, f := range r.Finalizers {
-		if f == Finalizer {
-			return false
-		}
-	}
-	r.Finalizers = append(r.Finalizers, Finalizer)
-	return true
-}
-
-// Delete finalizer.
-func (r *MigPlan) DeleteFinalizer() bool {
-	if r.Finalizers == nil {
-		r.Finalizers = []string{}
-	}
-	deleted := false
-	kept := []string{}
-	for _, f := range r.Finalizers {
-		if f == Finalizer {
-			deleted = true
-			continue
-		}
-		kept = append(kept, f)
-	}
-	r.Finalizers = kept
-	return deleted
-}
-
 // GetSourceCluster - Get the referenced source cluster.
 // Returns `nil` when the reference cannot be resolved.
 func (r *MigPlan) GetSourceCluster(client k8sclient.Client) (*MigCluster, error) {

--- a/pkg/apis/migration/v1alpha1/resource.go
+++ b/pkg/apis/migration/v1alpha1/resource.go
@@ -5,10 +5,8 @@ import (
 )
 
 const (
-	TouchAnnotation  = "touch"
-	FinalizerEnabled = true
-	Finalizer        = "openshift.io/migration"
-	VeleroNamespace  = "openshift-migration"
+	TouchAnnotation = "touch"
+	VeleroNamespace = "openshift-migration"
 )
 
 // Migration application CR.


### PR DESCRIPTION
Removed finalizers.
Migration controller maintains _OwnerReference_ to MigPlan.