### PR TITLE
Validate that the service account for the remote cluster has cluster-admin

### DIFF
--- a/pkg/controller/migcluster/remotecluster.go
+++ b/pkg/controller/migcluster/remotecluster.go
@@ -50,7 +50,8 @@ func (r *RemoteClusterSource) run() {
 			if cluster.Status.HasAnyCondition(
 				InvalidURL,
 				InvalidSaSecretRef,
-				InvalidSaToken) {
+				InvalidSaToken,
+				SaTokenNotPrivileged) {
 				continue
 			}
 

--- a/pkg/controller/migcluster/validation.go
+++ b/pkg/controller/migcluster/validation.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	auth "k8s.io/api/authorization/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"net/url"
 	"time"
 
@@ -14,11 +13,11 @@ import (
 
 // Types
 const (
-	InvalidURL          = "InvalidURL"
-	InvalidSaSecretRef  = "InvalidSaSecretRef"
-	InvalidSaToken      = "InvalidSaToken"
-	UnauthorizedSaToken = "UnauthorizedSaToken"
-	TestConnectFailed   = "TestConnectFailed"
+	InvalidURL           = "InvalidURL"
+	InvalidSaSecretRef   = "InvalidSaSecretRef"
+	InvalidSaToken       = "InvalidSaToken"
+	TestConnectFailed    = "TestConnectFailed"
+	SaTokenNotPrivileged = "SaTokenNotPrivileged"
 )
 
 // Categories
@@ -44,14 +43,14 @@ const (
 
 // Messages
 const (
-	ReadyMessage               = "The cluster is ready."
-	MissingURLMessage          = "The `url` is required when `isHostCluster` is false."
-	InvalidSaSecretRefMessage  = "The `serviceAccountSecretRef` must reference a `secret`."
-	InvalidSaTokenMessage      = "The `saToken` not found in `serviceAccountSecretRef` secret."
-	TestConnectFailedMessage   = "Test connect failed: %s"
-	MalformedURLMessage        = "The `url` is malformed."
-	InvalidURLSchemeMessage    = "The `url` scheme must be 'http' or 'https'."
-	UnauthorizedSaTokenMessage = "The service account token is not authorized to perform migrations."
+	ReadyMessage                = "The cluster is ready."
+	MissingURLMessage           = "The `url` is required when `isHostCluster` is false."
+	InvalidSaSecretRefMessage   = "The `serviceAccountSecretRef` must reference a `secret`."
+	InvalidSaTokenMessage       = "The `saToken` not found in `serviceAccountSecretRef` secret."
+	TestConnectFailedMessage    = "Test connect failed: %s"
+	MalformedURLMessage         = "The `url` is malformed."
+	InvalidURLSchemeMessage     = "The `url` scheme must be 'http' or 'https'."
+	SaTokenNotPrivilegedMessage = "The `saToken` has insufficient privileges."
 )
 
 // Validate the asset collection resource.
@@ -73,6 +72,12 @@ func (r ReconcileMigCluster) validate(cluster *migapi.MigCluster) error {
 
 	// Test Connection
 	err = r.testConnection(cluster)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+
+	err = r.validateSaTokenPrivileges(cluster)
 	if err != nil {
 		log.Trace(err)
 		return err
@@ -182,21 +187,6 @@ func (r ReconcileMigCluster) validateSaSecret(cluster *migapi.MigCluster) error 
 		return nil
 	}
 
-	isClusterAdmin, err := r.saIsClusterAdmin(cluster)
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-	if !isClusterAdmin {
-		cluster.Status.SetCondition(migapi.Condition{
-			Type:     UnauthorizedSaToken,
-			Status:   True,
-			Reason:   Unauthorized,
-			Category: Critical,
-			Message:  UnauthorizedSaTokenMessage,
-		})
-	}
-
 	return nil
 }
 
@@ -227,36 +217,42 @@ func (r ReconcileMigCluster) testConnection(cluster *migapi.MigCluster) error {
 	return nil
 }
 
-func (r *ReconcileMigCluster) saIsClusterAdmin(cluster *migapi.MigCluster) (bool, error) {
-	// check for access to all verbs on all resources in all namespaces
-	// in order to determine if the service account has cluster-admin
-	attributes := auth.ResourceAttributes{
-		Group:    "*",
-		Resource: "*",
-		Verb:     "*",
-		Version:  "*",
+func (r *ReconcileMigCluster) validateSaTokenPrivileges(cluster *migapi.MigCluster) error {
+	if cluster.Status.HasCriticalCondition() {
+		return nil
 	}
 
+	// check for access to all verbs on all resources in all namespaces
+	// in order to determine if the service account has cluster-admin
 	sar := auth.SelfSubjectAccessReview{
 		Spec: auth.SelfSubjectAccessReviewSpec{
-			ResourceAttributes: &attributes,
+			ResourceAttributes: &auth.ResourceAttributes{
+				Group:    "*",
+				Resource: "*",
+				Verb:     "*",
+				Version:  "*",
+			},
 		},
 	}
 
 	client, err := cluster.GetClient(r.Client)
 	if err != nil {
-		serr, ok := err.(*errors.StatusError)
-		if ok && serr.ErrStatus.Reason == Unauthorized {
-			return false, nil
-		}
-		return false, err
+		log.Trace(err)
+		return err
 	}
 	err = client.Create(context.TODO(), &sar)
 	if err != nil {
-		return false, err
+		log.Trace(err)
+		return err
 	}
-	if sar.Status.Allowed {
-		return true, nil
+	if !sar.Status.Allowed {
+		cluster.Status.SetCondition(migapi.Condition{
+			Type:     SaTokenNotPrivileged,
+			Status:   True,
+			Reason:   Unauthorized,
+			Category: Critical,
+			Message:  SaTokenNotPrivilegedMessage,
+		})
 	}
-	return false, nil
+	return nil
 }


### PR DESCRIPTION
This performs a SubjectAccessReview on the service account for the remote cluster in order to validate whether the service account has cluster-admin. It does this by requesting rights to all verbs on all resources in all groups and in all namespaces.

Fixes #420 