### PR TITLE
Ensure the stage pods have actually terminated after deletion

### DIFF
--- a/pkg/controller/migmigration/pod.go
+++ b/pkg/controller/migmigration/pod.go
@@ -296,9 +296,49 @@ func (t *Task) ensureStagePodsDeleted() error {
 		}
 	}
 
-	t.Owner.Status.DeleteCondition(StagePodsCreated)
-
 	return nil
+}
+
+// Ensure the deleted stage pods have finished terminating
+func (t *Task) ensureStagePodsTerminated() (bool, error) {
+	clients, namespaceList, err := t.getBothClientsWithNamespaces()
+	if err != nil {
+		log.Trace(err)
+		return false, err
+	}
+
+	terminatedPhases := map[corev1.PodPhase]bool{
+		corev1.PodSucceeded: true,
+		corev1.PodFailed:    true,
+		corev1.PodUnknown:   true,
+	}
+	cLabel, _ := t.Owner.GetCorrelationLabel()
+	for i, client := range clients {
+		podList := corev1.PodList{}
+		for _, ns := range namespaceList[i] {
+			options := k8sclient.InNamespace(ns)
+			err := client.List(context.TODO(), options, &podList)
+			if err != nil {
+				return false, err
+			}
+			for _, pod := range podList.Items {
+				if pod.Labels == nil {
+					continue
+				}
+				// doesn't belong to us
+				if _, found := pod.Labels[cLabel]; !found {
+					continue
+				}
+				// looks like it's terminated
+				if terminatedPhases[pod.Status.Phase] {
+					continue
+				}
+				return false, nil
+			}
+		}
+	}
+	t.Owner.Status.DeleteCondition(StagePodsCreated)
+	return true, nil
 }
 
 // Find all velero pods on the specified cluster.


### PR DESCRIPTION
Adds a phase to the itineraries following EnsureStagePodsDeleted to ensure that the stage pods have actually terminated successfully before moving on. This is intended to fix #409, where the restore occasionally fails with a multi-attach error on RWO volumes because the stage pod has not yet terminated and released the volume. I haven't been able to personally reproduce the race condition.