### PR TITLE
Use v1 for apps. Fix compat with OCP 4.4.

### DIFF
--- a/pkg/compat/client.go
+++ b/pkg/compat/client.go
@@ -2,8 +2,8 @@ package compat
 
 import (
 	"context"
-	appv1 "k8s.io/api/apps/v1"
-	appv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	dapi "k8s.io/client-go/discovery"
@@ -67,17 +67,33 @@ func NewClient(restCfg *rest.Config) (k8sclient.Client, error) {
 // Down convert a resource as needed based on cluster version.
 func (c Client) downConvert(obj runtime.Object) runtime.Object {
 	if c.Minor < 16 {
-		if _, cast := obj.(*appv1.Deployment); cast {
-			return &appv1beta1.Deployment{}
+		// Deployment
+		if _, cast := obj.(*appsv1.Deployment); cast {
+			return &appsv1beta1.Deployment{}
 		}
-		if _, cast := obj.(*appv1.DeploymentList); cast {
-			return &appv1beta1.DeploymentList{}
+		if _, cast := obj.(*appsv1.DeploymentList); cast {
+			return &appsv1beta1.DeploymentList{}
 		}
-		if _, cast := obj.(*appv1.DaemonSet); cast {
+		// DaemonSet
+		if _, cast := obj.(*appsv1.DaemonSet); cast {
 			return &extv1beta1.DaemonSet{}
 		}
-		if _, cast := obj.(*appv1.DaemonSetList); cast {
+		if _, cast := obj.(*appsv1.DaemonSetList); cast {
 			return &extv1beta1.DaemonSetList{}
+		}
+		// ReplicaSet
+		if _, cast := obj.(*appsv1.ReplicaSet); cast {
+			return &extv1beta1.ReplicaSet{}
+		}
+		if _, cast := obj.(*appsv1.ReplicaSetList); cast {
+			return &extv1beta1.ReplicaSetList{}
+		}
+		// StatefulSet
+		if _, cast := obj.(*appsv1.StatefulSet); cast {
+			return &appsv1beta1.StatefulSet{}
+		}
+		if _, cast := obj.(*appsv1.StatefulSetList); cast {
+			return &appsv1beta1.StatefulSetList{}
 		}
 	}
 

--- a/pkg/controller/migmigration/pod.go
+++ b/pkg/controller/migmigration/pod.go
@@ -2,20 +2,19 @@ package migmigration
 
 import (
 	"context"
-	"strconv"
-	"strings"
-
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	pvdr "github.com/konveyor/mig-controller/pkg/cloudprovider"
 	"github.com/konveyor/mig-controller/pkg/pods"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/exec"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"strconv"
+	"strings"
 )
 
 // Delete the running restic pods.
@@ -66,7 +65,7 @@ func (t *Task) haveResticPodsStarted() (bool, error) {
 		return false, err
 	}
 	list := corev1.PodList{}
-	ds := v1beta1.DaemonSet{}
+	ds := appsv1.DaemonSet{}
 	selector := labels.SelectorFromSet(map[string]string{
 		"name": "restic",
 	})

--- a/pkg/controller/migmigration/quiesce.go
+++ b/pkg/controller/migmigration/quiesce.go
@@ -2,11 +2,10 @@ package migmigration
 
 import (
 	"context"
-	appsv1 "github.com/openshift/api/apps/v1"
-	"k8s.io/api/apps/v1beta1"
+	ocappsv1 "github.com/openshift/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
-	extv1b1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,7 +60,7 @@ func (t *Task) quiesceApplications() error {
 // Scales down DeploymentConfig on source cluster
 func (t *Task) scaleDownDeploymentConfigs(client k8sclient.Client) error {
 	for _, ns := range t.sourceNamespaces() {
-		list := appsv1.DeploymentConfigList{}
+		list := ocappsv1.DeploymentConfigList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(
 			context.TODO(),
@@ -91,7 +90,7 @@ func (t *Task) scaleDownDeploymentConfigs(client k8sclient.Client) error {
 func (t *Task) scaleDownDeployments(client k8sclient.Client) error {
 	zero := int32(0)
 	for _, ns := range t.sourceNamespaces() {
-		list := v1beta1.DeploymentList{}
+		list := appsv1.DeploymentList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(
 			context.TODO(),
@@ -121,7 +120,7 @@ func (t *Task) scaleDownDeployments(client k8sclient.Client) error {
 func (t *Task) scaleDownStatefulSets(client k8sclient.Client) error {
 	zero := int32(0)
 	for _, ns := range t.sourceNamespaces() {
-		list := v1beta1.StatefulSetList{}
+		list := appsv1.StatefulSetList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(
 			context.TODO(),
@@ -150,7 +149,7 @@ func (t *Task) scaleDownStatefulSets(client k8sclient.Client) error {
 func (t *Task) scaleDownReplicaSets(client k8sclient.Client) error {
 	zero := int32(0)
 	for _, ns := range t.sourceNamespaces() {
-		list := extv1b1.ReplicaSetList{}
+		list := appsv1.ReplicaSetList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(
 			context.TODO(),
@@ -184,7 +183,7 @@ const (
 // Scales down all DaemonSets.
 func (t *Task) scaleDownDaemonSets(client k8sclient.Client) error {
 	for _, ns := range t.sourceNamespaces() {
-		list := extv1b1.DaemonSetList{}
+		list := appsv1.DaemonSetList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(
 			context.TODO(),


### PR DESCRIPTION
Fixes #432

Using `/apps/v1` instead of `/apps/v1beta1` and `/extensions/v1beta1`.

https://v1-16.docs.kubernetes.io/docs/setup/release/notes/#deprecations-and-removals