### PR TITLE
Limit velero pod search to expected velero namespace.

### DIFF
--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -982,10 +982,11 @@ func (r *NfsValidation) validate() error {
 // Find a pod suitable for command execution.
 func (r *NfsValidation) findPod() error {
 	list := kapi.PodList{}
+	options := k8sclient.MatchingLabels(map[string]string{"component": "velero"})
+	options.Namespace = migapi.VeleroNamespace
 	err := r.client.List(
 		context.TODO(),
-		k8sclient.MatchingLabels(
-			map[string]string{"component": "velero"}),
+		options,
 		&list)
 	if err != nil {
 		log.Trace(err)


### PR DESCRIPTION
If velero exists in other namespaces using the upstream image, the
validation findPod call may fail if the upstream velero is encountered
last in the list since the upstream image does not include /usr/bin/nc.
Instead we need to filter the velero pod search to only look in the migration
namespace since we know that velero will be from our fork, containing nc.