### PR TITLE
Fix for MigCluster secret being nil

### DIFF
--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -900,7 +900,7 @@ func (r *NfsValidation) init(client k8sclient.Client) error {
 			log.Trace(err)
 			return err
 		}
-		r.restCfg, err = r.cluster.BuildRestConfig(r.client)
+		r.restCfg, err = r.cluster.BuildRestConfig(client)
 		if err != nil {
 			log.Trace(err)
 			return err


### PR DESCRIPTION
Using a correct (local) client instead of a remote client to build a rest config from a secret, which exists on a host cluster only.

Closes #440