### PR TITLE
App backscaling on demand

### DIFF
--- a/config/crds/migration_v1alpha1_migmigration.yaml
+++ b/config/crds/migration_v1alpha1_migmigration.yaml
@@ -49,6 +49,8 @@ spec:
               items:
                 type: string
               type: array
+            itenerary:
+              type: string
             observedDigest:
               type: string
             phase:

--- a/pkg/apis/migration/v1alpha1/gvk.go
+++ b/pkg/apis/migration/v1alpha1/gvk.go
@@ -51,6 +51,7 @@ func (i *Incompatible) ResourceList() (incompatible []string) {
 	return
 }
 
+// CollectResources collects all namespaced scoped apiResources from the cluster
 func CollectResources(discovery discovery.DiscoveryInterface) ([]*metav1.APIResourceList, error) {
 	resources, err := discovery.ServerResources()
 	if err != nil {
@@ -67,6 +68,7 @@ func CollectResources(discovery discovery.DiscoveryInterface) ([]*metav1.APIReso
 	return resources, nil
 }
 
+// ConvertToGVRList converts provided apiResourceList to list of GroupVersionResources from the server
 func ConvertToGVRList(resourceList []*metav1.APIResourceList) ([]schema.GroupVersionResource, error) {
 	GVRs := []schema.GroupVersionResource{}
 	for _, resourceList := range resourceList {

--- a/pkg/apis/migration/v1alpha1/gvk.go
+++ b/pkg/apis/migration/v1alpha1/gvk.go
@@ -1,11 +1,7 @@
 package v1alpha1
 
 import (
-	"strings"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery"
 )
 
 // Incompatible - list of namespaces containing incompatible resources for migration
@@ -49,75 +45,4 @@ func (i *Incompatible) ResourceList() (incompatible []string) {
 		}
 	}
 	return
-}
-
-// CollectResources collects all namespaced scoped apiResources from the cluster
-func CollectResources(discovery discovery.DiscoveryInterface) ([]*metav1.APIResourceList, error) {
-	resources, err := discovery.ServerResources()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, res := range resources {
-		res.APIResources = namespaced(res.APIResources)
-		res.APIResources = excludeSubresources(res.APIResources)
-		// Some resources appear not to have permissions to list, need to exclude those.
-		res.APIResources = listAllowed(res.APIResources)
-	}
-
-	return resources, nil
-}
-
-// ConvertToGVRList converts provided apiResourceList to list of GroupVersionResources from the server
-func ConvertToGVRList(resourceList []*metav1.APIResourceList) ([]schema.GroupVersionResource, error) {
-	GVRs := []schema.GroupVersionResource{}
-	for _, resourceList := range resourceList {
-		gv, err := schema.ParseGroupVersion(resourceList.GroupVersion)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, resource := range resourceList.APIResources {
-			gvk := gv.WithResource(resource.Name)
-			GVRs = append(GVRs, gvk)
-		}
-	}
-
-	return GVRs, nil
-}
-
-func excludeSubresources(resources []metav1.APIResource) []metav1.APIResource {
-	filteredList := []metav1.APIResource{}
-	for _, res := range resources {
-		if !strings.Contains(res.Name, "/") {
-			filteredList = append(filteredList, res)
-		}
-	}
-
-	return filteredList
-}
-
-func namespaced(resources []metav1.APIResource) []metav1.APIResource {
-	filteredList := []metav1.APIResource{}
-	for _, res := range resources {
-		if res.Namespaced {
-			filteredList = append(filteredList, res)
-		}
-	}
-
-	return filteredList
-}
-
-func listAllowed(resources []metav1.APIResource) []metav1.APIResource {
-	filteredList := []metav1.APIResource{}
-	for _, res := range resources {
-		for _, verb := range res.Verbs {
-			if verb == "list" {
-				filteredList = append(filteredList, res)
-				break
-			}
-		}
-	}
-
-	return filteredList
 }

--- a/pkg/apis/migration/v1alpha1/gvk.go
+++ b/pkg/apis/migration/v1alpha1/gvk.go
@@ -1,6 +1,12 @@
 package v1alpha1
 
-import "k8s.io/apimachinery/pkg/runtime/schema"
+import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+)
 
 // Incompatible - list of namespaces containing incompatible resources for migration
 // which are being selected in the MigPlan
@@ -43,4 +49,73 @@ func (i *Incompatible) ResourceList() (incompatible []string) {
 		}
 	}
 	return
+}
+
+func CollectResources(discovery discovery.DiscoveryInterface) ([]*metav1.APIResourceList, error) {
+	resources, err := discovery.ServerResources()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, res := range resources {
+		res.APIResources = namespaced(res.APIResources)
+		res.APIResources = excludeSubresources(res.APIResources)
+		// Some resources appear not to have permissions to list, need to exclude those.
+		res.APIResources = listAllowed(res.APIResources)
+	}
+
+	return resources, nil
+}
+
+func ConvertToGVRList(resourceList []*metav1.APIResourceList) ([]schema.GroupVersionResource, error) {
+	GVRs := []schema.GroupVersionResource{}
+	for _, resourceList := range resourceList {
+		gv, err := schema.ParseGroupVersion(resourceList.GroupVersion)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, resource := range resourceList.APIResources {
+			gvk := gv.WithResource(resource.Name)
+			GVRs = append(GVRs, gvk)
+		}
+	}
+
+	return GVRs, nil
+}
+
+func excludeSubresources(resources []metav1.APIResource) []metav1.APIResource {
+	filteredList := []metav1.APIResource{}
+	for _, res := range resources {
+		if !strings.Contains(res.Name, "/") {
+			filteredList = append(filteredList, res)
+		}
+	}
+
+	return filteredList
+}
+
+func namespaced(resources []metav1.APIResource) []metav1.APIResource {
+	filteredList := []metav1.APIResource{}
+	for _, res := range resources {
+		if res.Namespaced {
+			filteredList = append(filteredList, res)
+		}
+	}
+
+	return filteredList
+}
+
+func listAllowed(resources []metav1.APIResource) []metav1.APIResource {
+	filteredList := []metav1.APIResource{}
+	for _, res := range resources {
+		for _, verb := range res.Verbs {
+			if verb == "list" {
+				filteredList = append(filteredList, res)
+				break
+			}
+		}
+	}
+
+	return filteredList
 }

--- a/pkg/apis/migration/v1alpha1/labels.go
+++ b/pkg/apis/migration/v1alpha1/labels.go
@@ -1,15 +1,17 @@
 package v1alpha1
 
 import (
+	"strings"
+
 	migref "github.com/konveyor/mig-controller/pkg/reference"
 	"k8s.io/apimachinery/pkg/types"
-	"strings"
 )
 
 // Labels
 const (
-	PartOfLabel = "app.kubernetes.io/part-of" // = Application
-	Application = "openshift-migration"
+	PartOfLabel     = "app.kubernetes.io/part-of" // = Application
+	Application     = "openshift-migration"
+	MigratedByLabel = "migration.openshift.io/migrated-by" // (migmigration UID)
 )
 
 // Build label (key, value) used to correlate CRs.

--- a/pkg/apis/migration/v1alpha1/labels.go
+++ b/pkg/apis/migration/v1alpha1/labels.go
@@ -9,9 +9,8 @@ import (
 
 // Labels
 const (
-	PartOfLabel     = "app.kubernetes.io/part-of" // = Application
-	Application     = "openshift-migration"
-	MigratedByLabel = "migration.openshift.io/migrated-by" // (migmigration UID)
+	PartOfLabel = "app.kubernetes.io/part-of" // = Application
+	Application = "openshift-migration"
 )
 
 // Build label (key, value) used to correlate CRs.

--- a/pkg/apis/migration/v1alpha1/migmigration_types.go
+++ b/pkg/apis/migration/v1alpha1/migmigration_types.go
@@ -92,3 +92,8 @@ func (r *MigMigration) AddErrors(errors []string) {
 		}
 	}
 }
+
+// HasErrors will notify about error presence on the MigMigration resource
+func (r *MigMigration) HasErrors() bool {
+	return len(r.Status.Errors) > 0
+}

--- a/pkg/apis/migration/v1alpha1/migmigration_types.go
+++ b/pkg/apis/migration/v1alpha1/migmigration_types.go
@@ -44,6 +44,7 @@ type MigMigrationStatus struct {
 	ObservedDigest string       `json:"observedDigest,omitempty"`
 	StartTimestamp *metav1.Time `json:"startTimestamp,omitempty"`
 	Phase          string       `json:"phase,omitempty"`
+	Itenerary      string       `json:"itenerary,omitempty"`
 	Errors         []string     `json:"errors,omitempty"`
 }
 

--- a/pkg/apis/migration/v1alpha1/model.go
+++ b/pkg/apis/migration/v1alpha1/model.go
@@ -6,12 +6,7 @@ import (
 
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/rest"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -166,82 +161,4 @@ func GetSecret(client k8sclient.Client, ref *kapi.ObjectReference) (*kapi.Secret
 	}
 
 	return &object, err
-}
-
-// DeleteMigrated - dispatches delete requests for migrated resources
-func DeleteMigrated(config *rest.Config, uid string) error {
-	GVRs, err := getGVRs(config)
-	if err != nil {
-		return err
-	}
-	client, err := dynamic.NewForConfig(config)
-	if err != nil {
-		return err
-	}
-	listOptions := k8sclient.MatchingLabels(map[string]string{
-		MigratedByLabel: uid,
-	}).AsListOptions()
-	foreground := metav1.DeletePropagationForeground
-	deleteOptions := (&k8sclient.DeleteOptions{
-		PropagationPolicy: &foreground,
-	}).AsDeleteOptions()
-
-	for _, gvr := range GVRs {
-		list, err := client.Resource(gvr).List(*listOptions)
-		if err != nil {
-			return err
-		}
-		for _, r := range list.Items {
-			err = client.Resource(gvr).Namespace(r.GetNamespace()).Delete(r.GetName(), deleteOptions)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-// WaitForMigratedDeletion - returns true if all of the migrated resources were deleted
-func WaitForMigratedDeletion(config *rest.Config, uid string) (bool, error) {
-	GVRs, err := getGVRs(config)
-	if err != nil {
-		return false, err
-	}
-	client, err := dynamic.NewForConfig(config)
-	if err != nil {
-		return false, err
-	}
-	listOptions := k8sclient.MatchingLabels(map[string]string{
-		MigratedByLabel: uid,
-	}).AsListOptions()
-	for _, gvr := range GVRs {
-		// Count resource occurences
-		list, err := client.Resource(gvr).List(*listOptions)
-		if err != nil {
-			return false, err
-		}
-		if len(list.Items) > 0 {
-			return false, nil
-		}
-	}
-
-	return true, nil
-}
-
-func getGVRs(config *rest.Config) ([]schema.GroupVersionResource, error) {
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	resourceList, err := CollectResources(discoveryClient)
-	if err != nil {
-		return nil, err
-	}
-	GVRs, err := ConvertToGVRList(resourceList)
-	if err != nil {
-		return nil, err
-	}
-
-	return GVRs, nil
 }

--- a/pkg/compat/client.go
+++ b/pkg/compat/client.go
@@ -21,6 +21,7 @@ import (
 // A smart client.
 // Provides seamless API version compatibility.
 type Client struct {
+	*rest.Config
 	k8sclient.Client
 	dapi.DiscoveryInterface
 	// major k8s version.
@@ -57,6 +58,7 @@ func NewClient(restCfg *rest.Config) (k8sclient.Client, error) {
 		return nil, err
 	}
 	nClient := &Client{
+		Config:             restCfg,
 		Client:             rClient,
 		DiscoveryInterface: dClient,
 		Major:              major,

--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -18,6 +18,10 @@ const (
 	PvStorageClassAnnotation = "openshift.io/target-storage-class" // storageClassName
 	PvAccessModeAnnotation   = "openshift.io/target-access-mode"   // accessMode
 	QuiesceAnnotation        = "openshift.io/migrate-quiesce-pods" // (true|false)
+	QuiesceNodeSelector      = "migration.openshift.io/quiesceDaemonSet"
+	SuspendAnnotation        = "migration.openshift.io/preQuiesceSuspend"
+	ReplicasAnnotation       = "migration.openshift.io/preQuiesceReplicas"
+	NodeSelectorAnnotation   = "migration.openshift.io/preQuiesceNodeSelector"
 )
 
 // Restic Annotations

--- a/pkg/controller/migmigration/migmigration_controller_test.go
+++ b/pkg/controller/migmigration/migmigration_controller_test.go
@@ -90,11 +90,11 @@ func Test_Itineraries(t *testing.T) {
 	stage := StageItinerary
 	common := Itinerary{}
 
-	for i, step := range StageItinerary {
+	for i, step := range StageItinerary.Steps {
 		found := false
-		for _, finalStep := range FinalItinerary[i:] {
+		for _, finalStep := range FinalItinerary.Steps[i:] {
 			if step.phase == finalStep.phase {
-				common = append(common, step)
+				common.Steps = append(common.Steps, step)
 				found = true
 				break
 			}
@@ -104,6 +104,6 @@ func Test_Itineraries(t *testing.T) {
 		}
 	}
 
-	g.Expect(reflect.DeepEqual(stage, common)).To(gomega.BeTrue())
+	g.Expect(reflect.DeepEqual(stage.Steps, common.Steps)).To(gomega.BeTrue())
 
 }

--- a/pkg/controller/migmigration/migmigration_controller_test.go
+++ b/pkg/controller/migmigration/migmigration_controller_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package migmigration
 
 import (
-	"github.com/onsi/gomega"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -86,26 +87,23 @@ func TestReconcile(t *testing.T) {
 // but for not they are expected to be the identical.
 func Test_Itineraries(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	stage := StageItinerary[4 : len(StageItinerary)-1]
+	stage := StageItinerary
+	common := Itinerary{}
 
-	begin := 0
-	for i, step := range FinalItinerary {
-		if step.phase == stage[0].phase {
-			begin = i
-			break
+	for i, step := range StageItinerary {
+		found := false
+		for _, finalStep := range FinalItinerary[i:] {
+			if step.phase == finalStep.phase {
+				common = append(common, step)
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("'%s' is not contained within the final itinerary", step.phase)
 		}
 	}
-	end := 0
-	last := stage[len(stage)-1]
-	for i, step := range FinalItinerary {
-		if step.phase == last.phase {
-			end = i + 1
-			break
-		}
-	}
-	final := FinalItinerary[begin:end]
 
-	g.Expect(begin == 0).To(gomega.BeFalse())
-	g.Expect(end < len(FinalItinerary)).To(gomega.BeTrue())
-	g.Expect(reflect.DeepEqual(stage, final)).To(gomega.BeTrue())
+	g.Expect(reflect.DeepEqual(stage, common)).To(gomega.BeTrue())
+
 }

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -83,6 +83,7 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (time.Du
 
 	// Result
 	migration.Status.Phase = task.Phase
+	migration.Status.Itenerary = task.Itinerary.Name
 
 	// Completed
 	if task.Phase == Completed {

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -302,7 +302,6 @@ func (t *Task) deleteRestores() error {
 		err = client.Delete(context.TODO(), &restore)
 		if err != nil && !k8serror.IsNotFound(err) {
 			log.Trace(err)
-			log.Trace(err)
 			return err
 		}
 	}
@@ -323,6 +322,14 @@ func (t *Task) deleteMigrated() error {
 
 	for _, gvr := range GVRs {
 		for _, ns := range t.destinationNamespaces() {
+			err = client.Resource(gvr).DeleteCollection(&metav1.DeleteOptions{}, *listOptions)
+			if err == nil {
+				continue
+			}
+			if !k8serror.IsMethodNotSupported(err) && !k8serror.IsNotFound(err) {
+				log.Trace(err)
+				return err
+			}
 			list, err := client.Resource(gvr).Namespace(ns).List(*listOptions)
 			if err != nil {
 				log.Trace(err)

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -7,6 +7,7 @@ import (
 
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/konveyor/mig-controller/pkg/compat"
+	"github.com/konveyor/mig-controller/pkg/gvk"
 	"github.com/pkg/errors"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
@@ -384,12 +385,12 @@ func (t *Task) getResourcesForDelete() (dynamic.Interface, []schema.GroupVersion
 		log.Trace(err)
 		return nil, nil, err
 	}
-	resourceList, err := migapi.CollectResources(dstClient)
+	resourceList, err := gvk.CollectResources(dstClient)
 	if err != nil {
 		log.Trace(err)
 		return nil, nil, err
 	}
-	GVRs, err := migapi.ConvertToGVRList(resourceList)
+	GVRs, err := gvk.ConvertToGVRList(resourceList)
 	if err != nil {
 		log.Trace(err)
 		return nil, nil, err

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -64,82 +64,97 @@ const (
 	HasVerify    = 0x08 // Only when the plan has enabled verification
 )
 
-type Itinerary []Step
+type Itinerary struct {
+	Name  string
+	Steps []Step
+}
 
 var StageItinerary = Itinerary{
-	{phase: Created},
-	{phase: Started},
-	{phase: Prepare},
-	{phase: EnsureCloudSecretPropagated},
-	{phase: AnnotateResources, all: HasPVs},
-	{phase: EnsureStagePods, all: HasPVs},
-	{phase: StagePodsCreated, all: HasStagePods},
-	{phase: RestartRestic, all: HasStagePods},
-	{phase: ResticRestarted, all: HasStagePods},
-	{phase: QuiesceApplications, all: Quiesce},
-	{phase: EnsureQuiesced, all: Quiesce},
-	{phase: EnsureStageBackup, all: HasPVs},
-	{phase: StageBackupCreated, all: HasPVs},
-	{phase: EnsureStageBackupReplicated, all: HasPVs},
-	{phase: EnsureStageRestore, all: HasPVs},
-	{phase: StageRestoreCreated, all: HasPVs},
-	{phase: EnsureStagePodsDeleted, all: HasStagePods},
-	{phase: EnsureStagePodsTerminated, all: HasStagePods},
-	{phase: EnsureAnnotationsDeleted, all: HasPVs},
-	{phase: EnsureLabelsDeleted},
-	{phase: Completed},
+	Name: "Stage",
+	Steps: []Step{
+		{phase: Created},
+		{phase: Started},
+		{phase: Prepare},
+		{phase: EnsureCloudSecretPropagated},
+		{phase: AnnotateResources, all: HasPVs},
+		{phase: EnsureStagePods, all: HasPVs},
+		{phase: StagePodsCreated, all: HasStagePods},
+		{phase: RestartRestic, all: HasStagePods},
+		{phase: ResticRestarted, all: HasStagePods},
+		{phase: QuiesceApplications, all: Quiesce},
+		{phase: EnsureQuiesced, all: Quiesce},
+		{phase: EnsureStageBackup, all: HasPVs},
+		{phase: StageBackupCreated, all: HasPVs},
+		{phase: EnsureStageBackupReplicated, all: HasPVs},
+		{phase: EnsureStageRestore, all: HasPVs},
+		{phase: StageRestoreCreated, all: HasPVs},
+		{phase: EnsureStagePodsDeleted, all: HasStagePods},
+		{phase: EnsureStagePodsTerminated, all: HasStagePods},
+		{phase: EnsureAnnotationsDeleted, all: HasPVs},
+		{phase: EnsureLabelsDeleted},
+		{phase: Completed},
+	},
 }
 
 var FinalItinerary = Itinerary{
-	{phase: Created},
-	{phase: Started},
-	{phase: Prepare},
-	{phase: EnsureCloudSecretPropagated},
-	{phase: EnsureInitialBackup},
-	{phase: InitialBackupCreated},
-	{phase: AnnotateResources, all: HasPVs},
-	{phase: EnsureStagePods, all: HasPVs},
-	{phase: StagePodsCreated, all: HasStagePods},
-	{phase: RestartRestic, all: HasStagePods},
-	{phase: ResticRestarted, all: HasStagePods},
-	{phase: QuiesceApplications, all: Quiesce},
-	{phase: EnsureQuiesced, all: Quiesce},
-	{phase: EnsureStageBackup, all: HasPVs},
-	{phase: StageBackupCreated, all: HasPVs},
-	{phase: EnsureStageBackupReplicated, all: HasPVs},
-	{phase: EnsureStageRestore, all: HasPVs},
-	{phase: StageRestoreCreated, all: HasPVs},
-	{phase: EnsureStagePodsDeleted, all: HasStagePods},
-	{phase: EnsureStagePodsTerminated, all: HasStagePods},
-	{phase: EnsureAnnotationsDeleted, all: HasPVs},
-	{phase: EnsureInitialBackupReplicated},
-	{phase: EnsureFinalRestore},
-	{phase: FinalRestoreCreated},
-	{phase: EnsureLabelsDeleted},
-	{phase: Verification, all: HasVerify},
-	{phase: Completed},
+	Name: "Final",
+	Steps: []Step{
+		{phase: Created},
+		{phase: Started},
+		{phase: Prepare},
+		{phase: EnsureCloudSecretPropagated},
+		{phase: EnsureInitialBackup},
+		{phase: InitialBackupCreated},
+		{phase: AnnotateResources, all: HasPVs},
+		{phase: EnsureStagePods, all: HasPVs},
+		{phase: StagePodsCreated, all: HasStagePods},
+		{phase: RestartRestic, all: HasStagePods},
+		{phase: ResticRestarted, all: HasStagePods},
+		{phase: QuiesceApplications, all: Quiesce},
+		{phase: EnsureQuiesced, all: Quiesce},
+		{phase: EnsureStageBackup, all: HasPVs},
+		{phase: StageBackupCreated, all: HasPVs},
+		{phase: EnsureStageBackupReplicated, all: HasPVs},
+		{phase: EnsureStageRestore, all: HasPVs},
+		{phase: StageRestoreCreated, all: HasPVs},
+		{phase: EnsureStagePodsDeleted, all: HasStagePods},
+		{phase: EnsureStagePodsTerminated, all: HasStagePods},
+		{phase: EnsureAnnotationsDeleted, all: HasPVs},
+		{phase: EnsureInitialBackupReplicated},
+		{phase: EnsureFinalRestore},
+		{phase: FinalRestoreCreated},
+		{phase: EnsureLabelsDeleted},
+		{phase: Verification, all: HasVerify},
+		{phase: Completed},
+	},
 }
 
 var CancelItinerary = Itinerary{
-	{phase: Canceling},
-	{phase: DeleteBackups},
-	{phase: DeleteRestores},
-	{phase: EnsureStagePodsDeleted, all: HasStagePods},
-	{phase: EnsureAnnotationsDeleted, all: HasPVs},
-	{phase: DeleteMigrated},
-	{phase: EnsureMigratedDeleted},
-	{phase: UnQuiesceApplications, all: Quiesce},
-	{phase: Canceled},
-	{phase: Completed},
+	Name: "Cancel",
+	Steps: []Step{
+		{phase: Canceling},
+		{phase: DeleteBackups},
+		{phase: DeleteRestores},
+		{phase: EnsureStagePodsDeleted, all: HasStagePods},
+		{phase: EnsureAnnotationsDeleted, all: HasPVs},
+		{phase: DeleteMigrated},
+		{phase: EnsureMigratedDeleted},
+		{phase: UnQuiesceApplications, all: Quiesce},
+		{phase: Canceled},
+		{phase: Completed},
+	},
 }
 
 var FailedItinerary = Itinerary{
-	{phase: EnsureStagePodsDeleted, all: HasStagePods},
-	{phase: EnsureAnnotationsDeleted, all: HasPVs},
-	{phase: DeleteMigrated},
-	{phase: EnsureMigratedDeleted},
-	{phase: UnQuiesceApplications, all: Quiesce},
-	{phase: Completed},
+	Name: "Failed",
+	Steps: []Step{
+		{phase: EnsureStagePodsDeleted, all: HasStagePods},
+		{phase: EnsureAnnotationsDeleted, all: HasPVs},
+		{phase: DeleteMigrated},
+		{phase: EnsureMigratedDeleted},
+		{phase: UnQuiesceApplications, all: Quiesce},
+		{phase: Completed},
+	},
 }
 
 // Step
@@ -156,8 +171,8 @@ type Step struct {
 // Returns: phase, n, total.
 func (r Itinerary) progressReport(phase string) (string, int, int) {
 	n := 0
-	total := len(r)
-	for i, step := range r {
+	total := len(r.Steps)
+	for i, step := range r.Steps {
 		if step.phase == phase {
 			n = i + 1
 			break
@@ -202,12 +217,11 @@ func (t *Task) Run() error {
 	t.Log.Info("[RUN]", "stage", t.stage(), "phase", t.Phase)
 
 	t.init()
-	step := t.setStep()
 
 	// Run the current phase.
 	switch t.Phase {
 	case Created, Started:
-		t.next(step)
+		t.next()
 	case Prepare:
 		err := t.ensureStagePodsDeleted()
 		if err != nil {
@@ -219,7 +233,7 @@ func (t *Task) Run() error {
 			log.Trace(err)
 			return err
 		}
-		t.next(step)
+		t.next()
 	case EnsureCloudSecretPropagated:
 		count := 0
 		for _, cluster := range t.getBothClusters() {
@@ -235,7 +249,7 @@ func (t *Task) Run() error {
 			}
 		}
 		if count == 2 {
-			t.next(step)
+			t.next()
 		} else {
 			t.Requeue = PollReQ
 		}
@@ -246,7 +260,7 @@ func (t *Task) Run() error {
 			return err
 		}
 		t.Requeue = NoReQ
-		t.next(step)
+		t.next()
 	case InitialBackupCreated:
 		backup, err := t.ensureInitialBackup()
 		if err != nil {
@@ -265,7 +279,7 @@ func (t *Task) Run() error {
 			if len(reasons) > 0 {
 				t.fail(InitialBackupFailed, reasons)
 			} else {
-				t.next(step)
+				t.next()
 			}
 		} else {
 			t.Requeue = NoReQ
@@ -276,14 +290,14 @@ func (t *Task) Run() error {
 			log.Trace(err)
 			return err
 		}
-		t.next(step)
+		t.next()
 	case EnsureStagePods:
 		_, err := t.ensureStagePodsCreated()
 		if err != nil {
 			log.Trace(err)
 			return err
 		}
-		t.next(step)
+		t.next()
 	case StagePodsCreated:
 		started, err := t.ensureStagePodsStarted()
 		if err != nil {
@@ -291,7 +305,7 @@ func (t *Task) Run() error {
 			return err
 		}
 		if started {
-			t.next(step)
+			t.next()
 		} else {
 			t.Requeue = NoReQ
 		}
@@ -302,7 +316,7 @@ func (t *Task) Run() error {
 			return err
 		}
 		t.Requeue = PollReQ
-		t.next(step)
+		t.next()
 	case ResticRestarted:
 		started, err := t.haveResticPodsStarted()
 		if err != nil {
@@ -310,7 +324,7 @@ func (t *Task) Run() error {
 			return err
 		}
 		if started {
-			t.next(step)
+			t.next()
 		} else {
 			t.Requeue = PollReQ
 		}
@@ -320,7 +334,7 @@ func (t *Task) Run() error {
 			log.Trace(err)
 			return err
 		}
-		t.next(step)
+		t.next()
 	case EnsureQuiesced:
 		quiesced, err := t.ensureQuiescedPodsTerminated()
 		if err != nil {
@@ -328,7 +342,7 @@ func (t *Task) Run() error {
 			return err
 		}
 		if quiesced {
-			t.next(step)
+			t.next()
 		} else {
 			t.Requeue = PollReQ
 		}
@@ -338,7 +352,7 @@ func (t *Task) Run() error {
 			log.Trace(err)
 			return err
 		}
-		t.next(step)
+		t.next()
 	case EnsureStageBackup:
 		_, err := t.ensureStageBackup()
 		if err != nil {
@@ -346,7 +360,7 @@ func (t *Task) Run() error {
 			return err
 		}
 		t.Requeue = 0
-		t.next(step)
+		t.next()
 	case StageBackupCreated:
 		backup, err := t.ensureStageBackup()
 		if err != nil {
@@ -365,7 +379,7 @@ func (t *Task) Run() error {
 			if len(reasons) > 0 {
 				t.fail(StageBackupFailed, reasons)
 			} else {
-				t.next(step)
+				t.next()
 			}
 		} else {
 			t.Requeue = NoReQ
@@ -385,7 +399,7 @@ func (t *Task) Run() error {
 			return err
 		}
 		if replicated {
-			t.next(step)
+			t.next()
 		} else {
 			t.Requeue = NoReQ
 		}
@@ -404,7 +418,7 @@ func (t *Task) Run() error {
 			return err
 		}
 		t.Requeue = NoReQ
-		t.next(step)
+		t.next()
 	case StageRestoreCreated:
 		restore, err := t.ensureStageRestore()
 		if err != nil {
@@ -424,7 +438,7 @@ func (t *Task) Run() error {
 			if len(reasons) > 0 {
 				t.fail(StageRestoreFailed, reasons)
 			} else {
-				t.next(step)
+				t.next()
 			}
 		} else {
 			t.Requeue = NoReQ
@@ -435,7 +449,7 @@ func (t *Task) Run() error {
 			log.Trace(err)
 			return err
 		}
-		t.next(step)
+		t.next()
 	case EnsureStagePodsTerminated:
 		terminated, err := t.ensureStagePodsTerminated()
 		if err != nil {
@@ -443,7 +457,7 @@ func (t *Task) Run() error {
 			return err
 		}
 		if terminated {
-			t.next(step)
+			t.next()
 		} else {
 			t.Requeue = PollReQ
 		}
@@ -455,7 +469,7 @@ func (t *Task) Run() error {
 				return err
 			}
 		}
-		t.next(step)
+		t.next()
 	case EnsureLabelsDeleted:
 		if !t.keepAnnotations() {
 			err := t.deleteLabels()
@@ -464,7 +478,7 @@ func (t *Task) Run() error {
 				return err
 			}
 		}
-		t.next(step)
+		t.next()
 	case EnsureInitialBackupReplicated:
 		backup, err := t.getInitialBackup()
 		if err != nil {
@@ -480,7 +494,7 @@ func (t *Task) Run() error {
 			return err
 		}
 		if replicated {
-			t.next(step)
+			t.next()
 		} else {
 			t.Requeue = NoReQ
 		}
@@ -499,7 +513,7 @@ func (t *Task) Run() error {
 			return err
 		}
 		t.Requeue = NoReQ
-		t.next(step)
+		t.next()
 	case FinalRestoreCreated:
 		restore, err := t.ensureFinalRestore()
 		if err != nil {
@@ -518,7 +532,7 @@ func (t *Task) Run() error {
 			if len(reasons) > 0 {
 				t.fail(FinalRestoreFailed, reasons)
 			} else {
-				t.next(step)
+				t.next()
 			}
 		} else {
 			t.Requeue = NoReQ
@@ -530,7 +544,7 @@ func (t *Task) Run() error {
 			return err
 		}
 		if completed {
-			t.next(step)
+			t.next()
 		} else {
 			t.Requeue = PollReQ
 		}
@@ -543,14 +557,14 @@ func (t *Task) Run() error {
 			Message:  CancelInProgressMessage,
 			Durable:  true,
 		})
-		t.next(step)
+		t.next()
 	case DeleteMigrated:
 		err := t.deleteMigrated()
 		if err != nil {
 			log.Trace(err)
 			return err
 		}
-		t.next(step)
+		t.next()
 	case EnsureMigratedDeleted:
 		deleted, err := t.ensureMigratedResourcesDeleted()
 		if err != nil {
@@ -558,7 +572,7 @@ func (t *Task) Run() error {
 			return err
 		}
 		if deleted {
-			t.next(step)
+			t.next()
 		} else {
 			t.Requeue = PollReQ
 		}
@@ -567,13 +581,13 @@ func (t *Task) Run() error {
 			log.Trace(err)
 			return err
 		}
-		t.next(step)
+		t.next()
 	case DeleteRestores:
 		if err := t.deleteRestores(); err != nil {
 			log.Trace(err)
 			return err
 		}
-		t.next(step)
+		t.next()
 	case Canceled:
 		t.Owner.Status.DeleteCondition(Canceling)
 		t.Owner.Status.SetCondition(migapi.Condition{
@@ -584,11 +598,11 @@ func (t *Task) Run() error {
 			Message:  CanceledMessage,
 			Durable:  true,
 		})
-		t.next(step)
+		t.next()
 	// Out of tree states - needs to be triggered manually with t.fail(...)
 	case InitialBackupFailed, FinalRestoreFailed, StageBackupFailed, StageRestoreFailed:
 		t.Requeue = NoReQ
-		t.next(step)
+		t.next()
 	case Completed:
 	}
 
@@ -612,12 +626,15 @@ func (t *Task) init() {
 	} else {
 		t.Itinerary = FinalItinerary
 	}
+	if t.Owner.Status.Itenerary != t.Itinerary.Name {
+		t.Phase = t.Itinerary.Steps[0].phase
+	}
 }
 
-// Set the step which will be executed.
-func (t *Task) setStep() int {
+// Advance the task to the next phase.
+func (t *Task) next() {
 	current := -1
-	for i, step := range t.Itinerary {
+	for i, step := range t.Itinerary.Steps {
 		if step.phase != t.Phase {
 			continue
 		}
@@ -625,21 +642,11 @@ func (t *Task) setStep() int {
 		break
 	}
 	if current == -1 {
-		if t.failed() || t.canceled() {
-			current = 0
-		} else {
-			current = len(t.Itinerary) - 1
-		}
-		t.Phase = t.Itinerary[current].phase
+		t.Phase = Completed
+		return
 	}
-
-	return current
-}
-
-// Advance the task to the next phase.
-func (t *Task) next(currentPhaseIndex int) {
-	for n := currentPhaseIndex + 1; n < len(t.Itinerary); n++ {
-		next := t.Itinerary[n]
+	for n := current + 1; n < len(t.Itinerary.Steps); n++ {
+		next := t.Itinerary.Steps[n]
 		if !t.allFlags(next) {
 			continue
 		}

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -30,7 +30,7 @@ const (
 	ResticRestarted               = "ResticRestarted"
 	QuiesceApplications           = "QuiesceApplications"
 	EnsureQuiesced                = "EnsureQuiesced"
-	ReactivateApplications        = "ReactivateApplications"
+	UnQuiesceApplications         = "UnQuiesceApplications"
 	EnsureStageBackup             = "EnsureStageBackup"
 	StageBackupCreated            = "StageBackupCreated"
 	StageBackupFailed             = "StageBackupFailed"
@@ -119,7 +119,7 @@ var CancelItinerary = Itinerary{
 	{phase: Canceling},
 	{phase: EnsureStagePodsDeleted, all: HasStagePods},
 	{phase: EnsureAnnotationsDeleted, all: HasPVs},
-	{phase: ReactivateApplications, all: Quiesce},
+	{phase: UnQuiesceApplications, all: Quiesce},
 	{phase: DeleteBackups},
 	{phase: DeleteRestores},
 	{phase: Canceled},
@@ -129,7 +129,7 @@ var CancelItinerary = Itinerary{
 var FailedItinerary = Itinerary{
 	{phase: EnsureStagePodsDeleted, all: HasStagePods},
 	{phase: EnsureAnnotationsDeleted, all: HasPVs},
-	{phase: ReactivateApplications, all: Quiesce},
+	{phase: UnQuiesceApplications, all: Quiesce},
 	{phase: Completed},
 }
 
@@ -322,7 +322,7 @@ func (t *Task) Run() error {
 		} else {
 			t.Requeue = PollReQ
 		}
-	case ReactivateApplications:
+	case UnQuiesceApplications:
 		err := t.unQuiesceApplications()
 		if err != nil {
 			log.Trace(err)

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -552,7 +552,7 @@ func (t *Task) Run() error {
 		}
 		t.next(step)
 	case EnsureMigratedDeleted:
-		deleted, err := t.waitForDeleteMigrated()
+		deleted, err := t.ensureMigratedResourcesDeleted()
 		if err != nil {
 			log.Trace(err)
 			return err

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -323,7 +323,7 @@ func (t *Task) Run() error {
 			t.Requeue = PollReQ
 		}
 	case ReactivateApplications:
-		err := t.reactivateApplications()
+		err := t.unQuiesceApplications()
 		if err != nil {
 			log.Trace(err)
 			return err

--- a/pkg/controller/migplan/gvk.go
+++ b/pkg/controller/migplan/gvk.go
@@ -1,30 +1,12 @@
 package migplan
 
 import (
-	"strings"
-
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"github.com/konveyor/mig-controller/pkg/compat"
+	"github.com/konveyor/mig-controller/pkg/gvk"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-var crdGVR = schema.GroupVersionResource{
-	Group:    "apiextensions.k8s.io",
-	Version:  "v1beta1", // Should become v1 after 1.17, needs downscaling
-	Resource: "customresourcedefinitions",
-}
-
-// Compare is a store for discovery and dynamic clients to do GVK compare
-type Compare struct {
-	Plan         *migapi.MigPlan
-	SrcDiscovery discovery.DiscoveryInterface
-	DstDiscovery discovery.DiscoveryInterface
-	SrcClient    dynamic.Interface
-}
 
 func (r ReconcileMigPlan) compareGVK(plan *migapi.MigPlan) error {
 	// No spec chage this time
@@ -49,30 +31,42 @@ func (r ReconcileMigPlan) compareGVK(plan *migapi.MigPlan) error {
 	return nil
 }
 
-func (r ReconcileMigPlan) newGVKCompare(plan *migapi.MigPlan) (*Compare, error) {
-	gvkCompare := &Compare{
-		Plan: plan,
+func (r ReconcileMigPlan) newGVKCompare(plan *migapi.MigPlan) (*gvk.Compare, error) {
+	srcCluster, err := plan.GetSourceCluster(r)
+	if err != nil {
+		log.Trace(err)
+		return nil, err
 	}
-
-	err := gvkCompare.NewSourceDiscovery(r)
+	dstCluster, err := plan.GetDestinationCluster(r)
 	if err != nil {
 		log.Trace(err)
 		return nil, err
 	}
 
-	err = gvkCompare.NewDestinationDiscovery(r)
+	src, err := srcCluster.GetClient(r)
+	if err != nil {
+		log.Trace(err)
+		return nil, err
+	}
+	srcClient := src.(compat.Client)
+	dst, err := dstCluster.GetClient(r)
+	if err != nil {
+		log.Trace(err)
+		return nil, err
+	}
+	dstClient := dst.(compat.Client)
+	dynamicClient, err := dynamic.NewForConfig(srcClient.Config)
 	if err != nil {
 		log.Trace(err)
 		return nil, err
 	}
 
-	err = gvkCompare.NewSourceClient(r)
-	if err != nil {
-		log.Trace(err)
-		return nil, err
-	}
-
-	return gvkCompare, nil
+	return &gvk.Compare{
+		Plan:         plan,
+		SrcClient:    dynamicClient,
+		DstDiscovery: dstClient,
+		SrcDiscovery: srcClient,
+	}, nil
 }
 
 func reportGVK(plan *migapi.MigPlan, incompatibleMapping map[string][]schema.GroupVersionResource) {
@@ -116,233 +110,4 @@ func clustersReady(plan *migapi.MigPlan) bool {
 		SourceClusterNotReady,
 	}
 	return !plan.Status.HasAnyCondition(clustersNotReadyConditions...)
-}
-
-// Compare GVKs on both clusters, find incompatible GVKs
-// and check each plan source namespace for existence of incompatible GVKs
-func (r *Compare) Compare() (map[string][]schema.GroupVersionResource, error) {
-	srcResourceList, err := migapi.CollectResources(r.SrcDiscovery)
-	if err != nil {
-		log.Trace(err)
-		return nil, err
-	}
-
-	dstResourceList, err := migapi.CollectResources(r.DstDiscovery)
-	if err != nil {
-		log.Trace(err)
-		return nil, err
-	}
-
-	srcResourceList, err = r.excludeCRDs(srcResourceList)
-	if err != nil {
-		log.Trace(err)
-		return nil, err
-	}
-
-	resourcesDiff := compareResources(srcResourceList, dstResourceList)
-	incompatibleGVKs, err := migapi.ConvertToGVRList(resourcesDiff)
-	if err != nil {
-		log.Trace(err)
-		return nil, err
-	}
-
-	return r.collectIncompatibleMapping(incompatibleGVKs)
-}
-
-// NewSourceDiscovery initializes source discovery client for a source cluster
-func (r *Compare) NewSourceDiscovery(c client.Client) error {
-	srcCluster, err := r.Plan.GetSourceCluster(c)
-	if err != nil {
-		return err
-	}
-
-	discovery, err := r.getDiscovery(c, srcCluster)
-	if err != nil {
-		return err
-	}
-
-	r.SrcDiscovery = discovery
-
-	return nil
-}
-
-// NewDestinationDiscovery initializes destination discovery client forom a destination cluster
-func (r *Compare) NewDestinationDiscovery(c client.Client) error {
-	dstCluster, err := r.Plan.GetDestinationCluster(c)
-	if err != nil {
-		return err
-	}
-
-	discovery, err := r.getDiscovery(c, dstCluster)
-	if err != nil {
-		return err
-	}
-
-	r.DstDiscovery = discovery
-
-	return nil
-}
-
-// NewSourceClient initializes source discovery client for a source cluster
-func (r *Compare) NewSourceClient(c client.Client) error {
-	srcCluster, err := r.Plan.GetSourceCluster(c)
-	if err != nil {
-		return err
-	}
-
-	client, err := r.getClient(c, srcCluster)
-	if err != nil {
-		return err
-	}
-
-	r.SrcClient = client
-
-	return nil
-}
-
-func (r *Compare) getDiscovery(c client.Client, cluster *migapi.MigCluster) (*discovery.DiscoveryClient, error) {
-	config, err := cluster.BuildRestConfig(c)
-	if err != nil {
-		return nil, err
-	}
-
-	return discovery.NewDiscoveryClientForConfig(config)
-}
-
-func (r *Compare) getClient(c client.Client, cluster *migapi.MigCluster) (dynamic.Interface, error) {
-	config, err := cluster.BuildRestConfig(c)
-	if err != nil {
-		return nil, err
-	}
-
-	return dynamic.NewForConfig(config)
-}
-
-func (r *Compare) collectIncompatibleMapping(incompatibleResources []schema.GroupVersionResource) (map[string][]schema.GroupVersionResource, error) {
-	incompatibleNamespaces := map[string][]schema.GroupVersionResource{}
-	for _, gvk := range incompatibleResources {
-		namespaceOccurence, err := r.occurIn(gvk)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, namespace := range namespaceOccurence {
-			if inNamespaces(namespace, r.Plan.GetSourceNamespaces()) {
-				_, exist := incompatibleNamespaces[namespace]
-				if exist {
-					incompatibleNamespaces[namespace] = append(incompatibleNamespaces[namespace], gvk)
-				} else {
-					incompatibleNamespaces[namespace] = []schema.GroupVersionResource{gvk}
-				}
-			}
-		}
-	}
-
-	return incompatibleNamespaces, nil
-}
-
-func (r *Compare) occurIn(gvr schema.GroupVersionResource) ([]string, error) {
-	namespacesOccurred := []string{}
-	options := metav1.ListOptions{}
-	resourceList, err := r.SrcClient.Resource(gvr).List(options)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, res := range resourceList.Items {
-		if !inNamespaces(res.GetNamespace(), namespacesOccurred) {
-			namespacesOccurred = append(namespacesOccurred, res.GetNamespace())
-		}
-	}
-
-	return namespacesOccurred, nil
-}
-
-func (r *Compare) excludeCRDs(resources []*metav1.APIResourceList) ([]*metav1.APIResourceList, error) {
-	options := metav1.ListOptions{}
-	crdList, err := r.SrcClient.Resource(crdGVR).List(options)
-	if err != nil {
-		return nil, err
-	}
-
-	crdGroups := []string{}
-	groupPath := []string{"spec", "group"}
-	for _, crd := range crdList.Items {
-		group, _, err := unstructured.NestedString(crd.Object, groupPath...)
-		if err != nil {
-			return nil, err
-		}
-		crdGroups = append(crdGroups, group)
-	}
-
-	updatedLists := []*metav1.APIResourceList{}
-	for _, resourceList := range resources {
-		if !isCRDGroup(resourceList.GroupVersion, crdGroups) {
-			updatedLists = append(updatedLists, resourceList)
-		}
-	}
-
-	return updatedLists, nil
-}
-
-func resourceExist(resource metav1.APIResource, resources []metav1.APIResource) bool {
-	for _, resourceItem := range resources {
-		if resource.Name == resourceItem.Name {
-			return true
-		}
-	}
-
-	return false
-}
-
-func compareResources(src []*metav1.APIResourceList, dst []*metav1.APIResourceList) []*metav1.APIResourceList {
-	missingResources := []*metav1.APIResourceList{}
-	for _, srcList := range src {
-		missing := []metav1.APIResource{}
-		for _, resource := range srcList.APIResources {
-			if !resourceExist(resource, fingResourceList(srcList.GroupVersion, dst)) {
-				missing = append(missing, resource)
-			}
-		}
-
-		if len(missing) > 0 {
-			missingList := &metav1.APIResourceList{
-				GroupVersion: srcList.GroupVersion,
-				APIResources: missing,
-			}
-			missingResources = append(missingResources, missingList)
-		}
-	}
-
-	return missingResources
-}
-
-func fingResourceList(groupVersion string, list []*metav1.APIResourceList) []metav1.APIResource {
-	for _, l := range list {
-		if l.GroupVersion == groupVersion {
-			return l.APIResources
-		}
-	}
-
-	return nil
-}
-
-func inNamespaces(item string, namespaces []string) bool {
-	for _, ns := range namespaces {
-		if item == ns {
-			return true
-		}
-	}
-
-	return false
-}
-
-func isCRDGroup(group string, crdGroups []string) bool {
-	for _, crdGroup := range crdGroups {
-		if strings.HasPrefix(group, crdGroup) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -1,0 +1,254 @@
+package gvk
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var crdGVR = schema.GroupVersionResource{
+	Group:    "apiextensions.k8s.io",
+	Version:  "v1beta1", // Should become v1 after 1.17, needs downscaling
+	Resource: "customresourcedefinitions",
+}
+
+// Compare is a store for discovery and dynamic clients to do GVK compare
+type Compare struct {
+	Plan         *migapi.MigPlan
+	SrcDiscovery discovery.DiscoveryInterface
+	DstDiscovery discovery.DiscoveryInterface
+	SrcClient    dynamic.Interface
+}
+
+// Compare GVKs on both clusters, find incompatible GVKs
+// and check each plan source namespace for existence of incompatible GVKs
+func (r *Compare) Compare() (map[string][]schema.GroupVersionResource, error) {
+	srcResourceList, err := CollectResources(r.SrcDiscovery)
+	if err != nil {
+		return nil, err
+	}
+
+	dstResourceList, err := CollectResources(r.DstDiscovery)
+	if err != nil {
+		return nil, err
+	}
+
+	srcResourceList, err = r.excludeCRDs(srcResourceList)
+	if err != nil {
+		return nil, err
+	}
+
+	resourcesDiff := compareResources(srcResourceList, dstResourceList)
+	incompatibleGVKs, err := ConvertToGVRList(resourcesDiff)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.collectIncompatibleMapping(incompatibleGVKs)
+}
+
+// CollectResources collects all namespaced scoped apiResources from the cluster
+func CollectResources(discovery discovery.DiscoveryInterface) ([]*metav1.APIResourceList, error) {
+	resources, err := discovery.ServerResources()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, res := range resources {
+		res.APIResources = namespaced(res.APIResources)
+		res.APIResources = excludeSubresources(res.APIResources)
+		// Some resources appear not to have permissions to list, need to exclude those.
+		res.APIResources = listAllowed(res.APIResources)
+	}
+
+	return resources, nil
+}
+
+// ConvertToGVRList converts provided apiResourceList to list of GroupVersionResources from the server
+func ConvertToGVRList(resourceList []*metav1.APIResourceList) ([]schema.GroupVersionResource, error) {
+	GVRs := []schema.GroupVersionResource{}
+	for _, resourceList := range resourceList {
+		gv, err := schema.ParseGroupVersion(resourceList.GroupVersion)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, resource := range resourceList.APIResources {
+			gvk := gv.WithResource(resource.Name)
+			GVRs = append(GVRs, gvk)
+		}
+	}
+
+	return GVRs, nil
+}
+
+func excludeSubresources(resources []metav1.APIResource) []metav1.APIResource {
+	filteredList := []metav1.APIResource{}
+	for _, res := range resources {
+		if !strings.Contains(res.Name, "/") {
+			filteredList = append(filteredList, res)
+		}
+	}
+
+	return filteredList
+}
+
+func namespaced(resources []metav1.APIResource) []metav1.APIResource {
+	filteredList := []metav1.APIResource{}
+	for _, res := range resources {
+		if res.Namespaced {
+			filteredList = append(filteredList, res)
+		}
+	}
+
+	return filteredList
+}
+
+func listAllowed(resources []metav1.APIResource) []metav1.APIResource {
+	filteredList := []metav1.APIResource{}
+	for _, res := range resources {
+		for _, verb := range res.Verbs {
+			if verb == "list" {
+				filteredList = append(filteredList, res)
+				break
+			}
+		}
+	}
+
+	return filteredList
+}
+
+func (r *Compare) collectIncompatibleMapping(incompatibleResources []schema.GroupVersionResource) (map[string][]schema.GroupVersionResource, error) {
+	incompatibleNamespaces := map[string][]schema.GroupVersionResource{}
+	for _, gvk := range incompatibleResources {
+		namespaceOccurence, err := r.occurIn(gvk)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, namespace := range namespaceOccurence {
+			if inNamespaces(namespace, r.Plan.GetSourceNamespaces()) {
+				_, exist := incompatibleNamespaces[namespace]
+				if exist {
+					incompatibleNamespaces[namespace] = append(incompatibleNamespaces[namespace], gvk)
+				} else {
+					incompatibleNamespaces[namespace] = []schema.GroupVersionResource{gvk}
+				}
+			}
+		}
+	}
+
+	return incompatibleNamespaces, nil
+}
+
+func (r *Compare) occurIn(gvr schema.GroupVersionResource) ([]string, error) {
+	namespacesOccurred := []string{}
+	options := metav1.ListOptions{}
+	resourceList, err := r.SrcClient.Resource(gvr).List(options)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, res := range resourceList.Items {
+		if !inNamespaces(res.GetNamespace(), namespacesOccurred) {
+			namespacesOccurred = append(namespacesOccurred, res.GetNamespace())
+		}
+	}
+
+	return namespacesOccurred, nil
+}
+
+func (r *Compare) excludeCRDs(resources []*metav1.APIResourceList) ([]*metav1.APIResourceList, error) {
+	options := metav1.ListOptions{}
+	crdList, err := r.SrcClient.Resource(crdGVR).List(options)
+	if err != nil {
+		return nil, err
+	}
+
+	crdGroups := []string{}
+	groupPath := []string{"spec", "group"}
+	for _, crd := range crdList.Items {
+		group, _, err := unstructured.NestedString(crd.Object, groupPath...)
+		if err != nil {
+			return nil, err
+		}
+		crdGroups = append(crdGroups, group)
+	}
+
+	updatedLists := []*metav1.APIResourceList{}
+	for _, resourceList := range resources {
+		if !isCRDGroup(resourceList.GroupVersion, crdGroups) {
+			updatedLists = append(updatedLists, resourceList)
+		}
+	}
+
+	return updatedLists, nil
+}
+
+func resourceExist(resource metav1.APIResource, resources []metav1.APIResource) bool {
+	for _, resourceItem := range resources {
+		if resource.Name == resourceItem.Name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func compareResources(src []*metav1.APIResourceList, dst []*metav1.APIResourceList) []*metav1.APIResourceList {
+	missingResources := []*metav1.APIResourceList{}
+	for _, srcList := range src {
+		missing := []metav1.APIResource{}
+		for _, resource := range srcList.APIResources {
+			if !resourceExist(resource, fingResourceList(srcList.GroupVersion, dst)) {
+				missing = append(missing, resource)
+			}
+		}
+
+		if len(missing) > 0 {
+			missingList := &metav1.APIResourceList{
+				GroupVersion: srcList.GroupVersion,
+				APIResources: missing,
+			}
+			missingResources = append(missingResources, missingList)
+		}
+	}
+
+	return missingResources
+}
+
+func fingResourceList(groupVersion string, list []*metav1.APIResourceList) []metav1.APIResource {
+	for _, l := range list {
+		if l.GroupVersion == groupVersion {
+			return l.APIResources
+		}
+	}
+
+	return nil
+}
+
+func inNamespaces(item string, namespaces []string) bool {
+	for _, ns := range namespaces {
+		if item == ns {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isCRDGroup(group string, crdGroups []string) bool {
+	for _, crdGroup := range crdGroups {
+		if strings.HasPrefix(group, crdGroup) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
- Cancel process now starts immediately, once the spec field is set.
- Added `FailedItinerary` to handle failing process during migration.
- Refactored `t.next` to account current step as an argument (allows to change phase before executing current one)
- Added app reactivation on failure/cancellation
- Added better failure handling process
- Added app cleanup on destination by label `migration.openshift.io/migrated-by: <migration-uid>`

Needs a change in the operator repo: https://github.com/konveyor/mig-operator/pull/293

Visually will add annotations with resources state before quiescence takes place
```
    annotations:
      migration.openshift.io/preQuiesceReplicas: "2"
```
Those annotations will be removed only when an application will be re-activated by a `Failed` migration, or migration being `Cancelled` 

Requires to have `delete` permissions to all resources with the SA token used to communicate to the remote cluster.

[Demo](https://drive.google.com/open?id=1WbBMZXnrX-lpackfXveZ_aKKcc5iWmrZ)

Closes https://github.com/konveyor/mig-controller/issues/157

This is a necessary step needed to close #237 completely.