### PR TITLE
Exclude incompatible resources on restore

### DIFF
--- a/pkg/apis/migration/v1alpha1/gvk.go
+++ b/pkg/apis/migration/v1alpha1/gvk.go
@@ -30,3 +30,17 @@ func FromGVR(gvr schema.GroupVersionResource) IncompatibleGVK {
 		Kind:    gvr.Resource,
 	}
 }
+
+// ResourceList returns a list of collected resources, which are not supported by an apiServer on a destination cluster
+func (i *Incompatible) ResourceList() (incompatible []string) {
+	for _, ns := range i.Namespaces {
+		for _, gvk := range ns.GVKs {
+			resource := schema.GroupResource{
+				Group:    gvk.Group,
+				Resource: gvk.Kind,
+			}
+			incompatible = append(incompatible, resource.String())
+		}
+	}
+	return
+}

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -223,10 +224,10 @@ func (t *Task) buildRestore(backupName string) (*velero.Restore, error) {
 
 // Update a Restore as desired for the destination cluster.
 func (t *Task) updateRestore(restore *velero.Restore, backupName string) {
-	restorePVs := true
 	restore.Spec = velero.RestoreSpec{
-		BackupName: backupName,
-		RestorePVs: &restorePVs,
+		BackupName:        backupName,
+		RestorePVs:        pointer.BoolPtr(true),
+		ExcludedResources: t.PlanResources.MigPlan.Status.ResourceList(),
 	}
 
 	t.updateNamespaceMapping(restore)


### PR DESCRIPTION
Automatically exclude unsupported resources discovered by GVK compare from the restore on the destination.

Sample additions to velero.Restore resource:
```yaml
  excludedResources:
  - cronjobs.batch
  - scheduledjobs.batch
```
generated from
```yaml
  incompatibleNamespaces:
  - gvks:
    - group: batch
      kind: cronjobs
      version: v2alpha1
    - group: batch
      kind: scheduledjobs
      version: v2alpha1
    name: cron
```