### PR TITLE
Allowing to delete backup and restore, once migration is cancelled.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -609,10 +609,7 @@
   branch = "konveyor-dev"
   digest = "1:7ee1d20ebea6a6f2472452e10aafc34a530e688287517c5785e95e533d331c72"
   name = "github.com/vmware-tanzu/velero"
-  packages = [
-    "pkg/apis/velero/v1",
-    "pkg/label",
-  ]
+  packages = ["pkg/apis/velero/v1"]
   pruneopts = "T"
   revision = "53b3e5029c9d0ce8c6bbca305f991af0031dbd51"
   source = "github.com/konveyor/velero.git"
@@ -1312,7 +1309,6 @@
     "github.com/prometheus/client_golang/prometheus/promauto",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/vmware-tanzu/velero/pkg/apis/velero/v1",
-    "github.com/vmware-tanzu/velero/pkg/label",
     "golang.org/x/net/context",
     "google.golang.org/api/option",
     "k8s.io/api/apps/v1",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -609,7 +609,10 @@
   branch = "konveyor-dev"
   digest = "1:7ee1d20ebea6a6f2472452e10aafc34a530e688287517c5785e95e533d331c72"
   name = "github.com/vmware-tanzu/velero"
-  packages = ["pkg/apis/velero/v1"]
+  packages = [
+    "pkg/apis/velero/v1",
+    "pkg/label",
+  ]
   pruneopts = "T"
   revision = "53b3e5029c9d0ce8c6bbca305f991af0031dbd51"
   source = "github.com/konveyor/velero.git"
@@ -1309,6 +1312,7 @@
     "github.com/prometheus/client_golang/prometheus/promauto",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/vmware-tanzu/velero/pkg/apis/velero/v1",
+    "github.com/vmware-tanzu/velero/pkg/label",
     "golang.org/x/net/context",
     "google.golang.org/api/option",
     "k8s.io/api/apps/v1",

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -8,6 +8,7 @@ import (
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/pkg/errors"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -230,6 +231,41 @@ func (t *Task) updateRestore(restore *velero.Restore, backupName string) {
 	}
 
 	t.updateNamespaceMapping(restore)
+}
+
+func (t *Task) cleanRestores() error {
+	client, err := t.getDestinationClient()
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	stageRestore, err := t.getStageRestore()
+	if err != nil && !k8serror.IsNotFound(err) {
+		log.Trace(err)
+		return err
+	}
+	if stageRestore != nil {
+		err = client.Delete(context.TODO(), stageRestore)
+		if err != nil && !k8serror.IsNotFound(err) {
+			log.Trace(err)
+			return err
+		}
+	}
+
+	initialRestore, err := t.getFinalRestore()
+	if err != nil && !k8serror.IsNotFound(err) {
+		log.Trace(err)
+		return err
+	}
+	if initialRestore != nil {
+		err = client.Delete(context.TODO(), initialRestore)
+		if err != nil && !k8serror.IsNotFound(err) {
+			log.Trace(err)
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Update namespace mapping for restore

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -240,12 +240,10 @@ func (t *Task) deleteRestores() error {
 		return err
 	}
 
-	labels := t.Owner.GetCorrelationLabels()
-	labels["migmigration"] = string(t.Owner.GetUID())
 	list := velero.RestoreList{}
 	err = client.List(
 		context.TODO(),
-		k8sclient.MatchingLabels(labels),
+		k8sclient.MatchingLabels(t.Owner.GetCorrelationLabels()),
 		&list)
 	if err != nil {
 		log.Trace(err)

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -45,7 +45,8 @@ const (
 	EnsureStagePodsDeleted        = "EnsureStagePodsDeleted"
 	EnsureStagePodsTerminated     = "EnsureStagePodsTerminated"
 	EnsureAnnotationsDeleted      = "EnsureAnnotationsDeleted"
-	BackupDeletionRequested       = "RequestBackupDeletion"
+	DeleteBackups                 = "DeleteBackups"
+	DeleteRestores                = "DeleteRestores"
 	Canceling                     = "Canceling"
 	Cancelled                     = "Cancelled"
 	Completed                     = "Completed"
@@ -117,7 +118,8 @@ var CancelItinerary = Itinerary{
 	{phase: Canceling},
 	{phase: EnsureStagePodsDeleted, flags: HasStagePods},
 	{phase: EnsureAnnotationsDeleted, flags: HasPVs},
-	{phase: BackupDeletionRequested},
+	{phase: DeleteBackups},
+	{phase: DeleteRestores},
 	{phase: Cancelled},
 	{phase: Completed},
 }
@@ -504,12 +506,14 @@ func (t *Task) Run() error {
 			Durable:  true,
 		})
 		t.next()
-	case BackupDeletionRequested:
-		if err := t.cleanBackups(); err != nil {
+	case DeleteBackups:
+		if err := t.deleteBackups(); err != nil {
 			log.Trace(err)
 			return err
 		}
-		if err := t.cleanRestores(); err != nil {
+		t.next()
+	case DeleteRestores:
+		if err := t.deleteRestores(); err != nil {
 			log.Trace(err)
 			return err
 		}


### PR DESCRIPTION
Follow-up on `MIG-118 - Canceling an ongoing migration`, addition to #458, closes #237 

By cancelling migration, controller will remove:
1) backup content from remote storage (including snapshots and PV data captured by restic)
2) backup resources from the source cluster
3) restores from the destination cluster