### PR TITLE
Replaced ObservedGeneration with ObservedDigest.

### DIFF
--- a/config/crds/migration_v1alpha1_migcluster.yaml
+++ b/config/crds/migration_v1alpha1_migcluster.yaml
@@ -61,9 +61,8 @@ spec:
           type: object
         status:
           properties:
-            observedGeneration:
-              format: int64
-              type: integer
+            observedDigest:
+              type: string
           type: object
   version: v1alpha1
 status:

--- a/config/crds/migration_v1alpha1_migmigration.yaml
+++ b/config/crds/migration_v1alpha1_migmigration.yaml
@@ -49,9 +49,8 @@ spec:
               items:
                 type: string
               type: array
-            observedGeneration:
-              format: int64
-              type: integer
+            observedDigest:
+              type: string
             phase:
               type: string
             startTimestamp:

--- a/config/crds/migration_v1alpha1_migplan.yaml
+++ b/config/crds/migration_v1alpha1_migplan.yaml
@@ -120,9 +120,8 @@ spec:
                 - gvks
                 type: object
               type: array
-            observedGeneration:
-              format: int64
-              type: integer
+            observedDigest:
+              type: string
           type: object
   version: v1alpha1
 status:

--- a/config/crds/migration_v1alpha1_migstorage.yaml
+++ b/config/crds/migration_v1alpha1_migstorage.yaml
@@ -83,9 +83,8 @@ spec:
           type: object
         status:
           properties:
-            observedGeneration:
-              format: int64
-              type: integer
+            observedDigest:
+              type: string
           type: object
   version: v1alpha1
 status:

--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -56,7 +56,7 @@ type MigClusterSpec struct {
 // MigClusterStatus defines the observed state of MigCluster
 type MigClusterStatus struct {
 	Conditions
-	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	ObservedDigest string `json:"observedDigest,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/migration/v1alpha1/migmigration_types.go
+++ b/pkg/apis/migration/v1alpha1/migmigration_types.go
@@ -41,10 +41,10 @@ type MigMigrationSpec struct {
 type MigMigrationStatus struct {
 	Conditions
 	UnhealthyResources
-	ObservedGeneration int64        `json:"observedGeneration,omitempty"`
-	StartTimestamp     *metav1.Time `json:"startTimestamp,omitempty"`
-	Phase              string       `json:"phase,omitempty"`
-	Errors             []string     `json:"errors,omitempty"`
+	ObservedDigest string       `json:"observedDigest,omitempty"`
+	StartTimestamp *metav1.Time `json:"startTimestamp,omitempty"`
+	Phase          string       `json:"phase,omitempty"`
+	Errors         []string     `json:"errors,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -58,8 +58,8 @@ type MigPlanSpec struct {
 // MigPlanStatus defines the observed state of MigPlan
 type MigPlanStatus struct {
 	Conditions
-	Incompatible       `json:",inline"`
-	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	Incompatible   `json:",inline"`
+	ObservedDigest string `json:"observedDigest,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -44,7 +44,7 @@ type MigStorageSpec struct {
 // MigStorageStatus defines the observed state of MigStorage
 type MigStorageStatus struct {
 	Conditions
-	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	ObservedDigest string `json:"observedDigest,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/migration/v1alpha1/resource.go
+++ b/pkg/apis/migration/v1alpha1/resource.go
@@ -1,5 +1,11 @@
 package v1alpha1
 
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+)
+
 const (
 	VeleroNamespace = "openshift-migration"
 )
@@ -42,11 +48,11 @@ func (r *MigPlan) GetName() string {
 }
 
 func (r *MigPlan) MarkReconciled() {
-	r.Status.ObservedGeneration = r.Generation + 1
+	r.Status.ObservedDigest = digest(r.Spec)
 }
 
 func (r *MigPlan) HasReconciled() bool {
-	return r.Status.ObservedGeneration == r.Generation
+	return r.Status.ObservedDigest == digest(r.Spec)
 }
 
 // Storage
@@ -71,11 +77,11 @@ func (r *MigStorage) GetName() string {
 }
 
 func (r *MigStorage) MarkReconciled() {
-	r.Status.ObservedGeneration = r.Generation + 1
+	r.Status.ObservedDigest = digest(r.Spec)
 }
 
 func (r *MigStorage) HasReconciled() bool {
-	return r.Status.ObservedGeneration == r.Generation
+	return r.Status.ObservedDigest == digest(r.Spec)
 }
 
 // Cluster
@@ -100,11 +106,11 @@ func (r *MigCluster) GetName() string {
 }
 
 func (r *MigCluster) MarkReconciled() {
-	r.Status.ObservedGeneration = r.Generation + 1
+	r.Status.ObservedDigest = digest(r.Spec)
 }
 
 func (r *MigCluster) HasReconciled() bool {
-	return r.Status.ObservedGeneration == r.Generation
+	return r.Status.ObservedDigest == digest(r.Spec)
 }
 
 // Migration
@@ -129,9 +135,19 @@ func (r *MigMigration) GetName() string {
 }
 
 func (r *MigMigration) MarkReconciled() {
-	r.Status.ObservedGeneration = r.Generation + 1
+	r.Status.ObservedDigest = digest(r.Spec)
 }
 
 func (r *MigMigration) HasReconciled() bool {
-	return r.Status.ObservedGeneration == r.Generation
+	return r.Status.ObservedDigest == digest(r.Spec)
+}
+
+//
+// Generate a sha256 hex-digest for an object.
+func digest(object interface{}) string {
+	j, _ := json.Marshal(object)
+	hash := sha256.New()
+	hash.Write(j)
+	digest := hex.EncodeToString(hash.Sum(nil))
+	return digest
 }


### PR DESCRIPTION
The `generation` field is not managed (incremented) in OCP3 so cannot apply the `observedGeneration` pattern.
Instead, generating a SHA256 (hex) digest for the `Spec` and storing in the status as: `observedDigest`.  Gives us most of the same benefits and compatible with older clusters.

Requires: https://github.com/konveyor/mig-operator/pull/291