### PR TITLE
Ignore cancelled final migration in validation step

### DIFF
--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -48,7 +48,7 @@ const (
 	DeleteBackups                 = "DeleteBackups"
 	DeleteRestores                = "DeleteRestores"
 	Canceling                     = "Canceling"
-	Cancelled                     = "Cancelled"
+	Canceled                      = "Canceled"
 	Completed                     = "Completed"
 )
 
@@ -120,7 +120,7 @@ var CancelItinerary = Itinerary{
 	{phase: EnsureAnnotationsDeleted, flags: HasPVs},
 	{phase: DeleteBackups},
 	{phase: DeleteRestores},
-	{phase: Cancelled},
+	{phase: Canceled},
 	{phase: Completed},
 }
 
@@ -519,14 +519,14 @@ func (t *Task) Run() error {
 			return err
 		}
 		t.next()
-	case Cancelled:
+	case Canceled:
 		t.Owner.Status.DeleteCondition(Canceling)
 		t.Owner.Status.SetCondition(migapi.Condition{
 			Type:     Canceled,
 			Status:   True,
 			Reason:   Cancel,
 			Category: Advisory,
-			Message:  CancelledMessage,
+			Message:  CanceledMessage,
 			Durable:  true,
 		})
 		t.next()
@@ -635,9 +635,9 @@ func (t *Task) UID() string {
 	return string(t.Owner.UID)
 }
 
-// Get whether the migration is cancelled.
+// Get whether the migration is canceled.
 func (t *Task) canceled() bool {
-	return t.Owner.Spec.Canceled || t.Owner.Status.HasAnyCondition(Canceled, Cancelling)
+	return t.Owner.Spec.Canceled || t.Owner.Status.HasAnyCondition(Canceled, Canceling)
 }
 
 // Get whether the migration is stage.

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -11,10 +11,8 @@ const (
 	InvalidPlanRef      = "InvalidPlanRef"
 	PlanNotReady        = "PlanNotReady"
 	PlanClosed          = "PlanClosed"
-	Cancelling          = "Cancelling"
 	HasFinalMigration   = "HasFinalMigration"
 	Postponed           = "Postponed"
-	Canceled            = "Canceled"
 	Running             = "Running"
 	Succeeded           = "Succeeded"
 	Failed              = "Failed"
@@ -50,7 +48,7 @@ const (
 	PlanClosedMessage          = "The associated migration plan is closed."
 	HasFinalMigrationMessage   = "The associated MigPlan already has a final migration."
 	PostponedMessage           = "Postponed %d seconds to ensure migrations run serially and in order."
-	CancelledMessage           = "The migration has been cancelled."
+	CanceledMessage            = "The migration has been canceled."
 	CancelInProgressMessage    = "The migration is being canceled."
 	RunningMessage             = "Step: %d/%d"
 	FailedMessage              = "The migration has failed.  See: Errors."
@@ -152,8 +150,8 @@ func (r ReconcileMigMigration) validateFinalMigration(plan *migapi.MigPlan, migr
 	}
 	hasCondition := false
 	for _, m := range migrations {
-		// ignore cancelled
-		if m.Spec.Stage || m.Spec.Canceled || m.UID == migration.UID {
+		// ignore canceled
+		if m.UID == migration.UID || m.Spec.Stage || m.Spec.Canceled {
 			continue
 		}
 		// Stage

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -152,10 +152,8 @@ func (r ReconcileMigMigration) validateFinalMigration(plan *migapi.MigPlan, migr
 	}
 	hasCondition := false
 	for _, m := range migrations {
-		if m.UID == migration.UID {
-			continue
-		}
-		if !!m.Spec.Stage {
+		// ignore cancelled
+		if m.Spec.Stage || m.Spec.Canceled || m.UID == migration.UID {
 			continue
 		}
 		// Stage


### PR DESCRIPTION
- Prevent from blocking non-cancelled final migration from being executed.
- Also includes some spelling fixes, required by @vconzola's UX design

Issue was discovered while testing a fix for https://github.com/konveyor/mig-ui/issues/753