### PR TITLE
Bug 1782318 - add to scheme in main.go instead of remote watch

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -23,7 +23,9 @@ import (
 	"github.com/konveyor/mig-controller/pkg/apis"
 	"github.com/konveyor/mig-controller/pkg/compat/conversion"
 	"github.com/konveyor/mig-controller/pkg/controller"
+	"github.com/konveyor/mig-controller/pkg/imagescheme"
 	"github.com/konveyor/mig-controller/pkg/webhook"
+	appsv1 "github.com/openshift/api/apps/v1"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -64,15 +66,23 @@ func main() {
 	// Setup Scheme for all resources
 	log.Info("setting up scheme")
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Error(err, "unable add K8s APIs to scheme")
+		log.Error(err, "unable to add K8s APIs to scheme")
 		os.Exit(1)
 	}
 	if err := velerov1.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Error(err, "unable add Velero APIs to scheme")
+		log.Error(err, "unable to add Velero APIs to scheme")
+		os.Exit(1)
+	}
+	if err := imagescheme.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "unable to add OpenShift image APIs to scheme")
+		os.Exit(1)
+	}
+	if err := appsv1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "unable to add OpenShift apps APIs to scheme")
 		os.Exit(1)
 	}
 	if err := clusterregv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Error(err, "unable add Cluster Registry APIs to scheme")
+		log.Error(err, "unable to add Cluster Registry APIs to scheme")
 		os.Exit(1)
 	}
 	if err := conversion.RegisterConversions(mgr.GetScheme()); err != nil {

--- a/pkg/controller/migcluster/remote_watch.go
+++ b/pkg/controller/migcluster/remote_watch.go
@@ -18,10 +18,7 @@ package migcluster
 
 import (
 	"github.com/konveyor/mig-controller/pkg/controller/remotewatcher"
-	"github.com/konveyor/mig-controller/pkg/imagescheme"
 	"github.com/konveyor/mig-controller/pkg/remote"
-	appsv1 "github.com/openshift/api/apps/v1"
-	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -38,22 +35,6 @@ func StartRemoteWatch(r *ReconcileMigCluster, config remote.ManagerConfig) error
 	mgr, err := manager.New(config.RemoteRestConfig, manager.Options{})
 	if err != nil {
 		log.Error(err, "[rWatch] Unable to set up remote watcher controller manager")
-		return err
-	}
-
-	log.Info("[rWatch] Adding Velero to scheme")
-	if err := velerov1.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Error(err, "[rWatch] Unable add Velero APIs to scheme")
-		return err
-	}
-	log.Info("[rWatch] Adding OpenShift imagestream to scheme")
-	if err := imagescheme.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Error(err, "[rWatch] Unable add OpenShift image APIs to scheme")
-		return err
-	}
-	log.Info("[rWatch] Adding OpenShift deploymentconfig to scheme")
-	if err := appsv1.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Error(err, "[rWatch] Unable add OpenShift apps APIs to scheme")
 		return err
 	}
 


### PR DESCRIPTION
DeploymentConfig and ImageStream APIs need to be added to the scheme
in main.go rather than in remote watch. When adding them via remote watch
there's a period of time right at startup where they are unavailable
and trigger reconcile failures.