### PR TITLE
Assume migration-controller SA during 'make run'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ run: generate fmt vet
 	./hack/controller-sa-login.sh
 	KUBECONFIG=$(KUBECONFIG)-${KUBECONFIG_POSTFIX} go run ./cmd/manager/main.go
 
+
+# Run against the configured Kubernetes cluster in ~/.kube/config, skip login to mig-controller SA
+run-skip-sa-login: generate fmt vet
+	go run ./cmd/manager/main.go
+
 # Install CRDs into a cluster
 install: manifests
 	kubectl apply -f config/crds

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/ocpmigrate/mig-controller:latest
 GOOS ?= `go env GOOS`
+KUBECONFIG_POSTFIX ?= mig-controller
 
 ci: all
 
@@ -14,9 +15,10 @@ test: generate fmt vet manifests
 manager: generate fmt vet
 	go build -o bin/manager github.com/konveyor/mig-controller/cmd/manager
 
-# Run against the configured Kubernetes cluster in ~/.kube/config
+# Run against the configured Kubernetes cluster in ~/.kube/config after login as mig controller SA
 run: generate fmt vet
-	go run ./cmd/manager/main.go
+	./hack/controller-sa-login.sh
+	KUBECONFIG=$(KUBECONFIG)-${KUBECONFIG_POSTFIX} go run ./cmd/manager/main.go
 
 # Install CRDs into a cluster
 install: manifests

--- a/hack/controller-sa-login.sh
+++ b/hack/controller-sa-login.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+KUBECONFIG_POSTFIX="mig-controller"
+
+if [ -z "$KUBECONFIG" ]
+then
+      echo "\$KUBECONFIG not set. Aborting migration-controller SA login"
+      exit 1
+fi
+
+# Create copy of original KUBECONFIG that will be logged in with mig-controller SA token
+MIG_KUBECONFIG=$KUBECONFIG-$KUBECONFIG_POSTFIX
+cp $KUBECONFIG $MIG_KUBECONFIG
+
+# Check for existence of migration-controller SA before logging in
+KUBECONFIG=$MIG_KUBECONFIG oc get sa migration-controller -n openshift-migration
+if [ $? -eq 0 ]; then
+    echo "Found migration-controller SA, performing token login..."
+else
+    echo "Missing migration-controller SA in openshift-migration namespace. Verify mig-operator installed SA successfully"
+    exit 2
+fi
+
+# Login to migration controller SA without making changes to original KUBECONFIG
+KUBECONFIG=$MIG_KUBECONFIG \
+oc login --token $(oc sa get-token migration-controller -n openshift-migration)

--- a/hack/controller-sa-login.sh
+++ b/hack/controller-sa-login.sh
@@ -12,9 +12,9 @@ MIG_KUBECONFIG=$KUBECONFIG-$KUBECONFIG_POSTFIX
 cp $KUBECONFIG $MIG_KUBECONFIG
 
 # Check for existence of migration-controller SA before logging in
-KUBECONFIG=$MIG_KUBECONFIG oc get sa migration-controller -n openshift-migration
+KUBECONFIG=$MIG_KUBECONFIG oc get sa migration-controller -n openshift-migration > /dev/null
 if [ $? -eq 0 ]; then
-    echo "Found migration-controller SA, performing token login..."
+    echo "Found migration-controller SA. Performing token login..."
 else
     echo "Missing migration-controller SA in openshift-migration namespace. Verify mig-operator installed SA successfully"
     exit 2
@@ -22,4 +22,4 @@ fi
 
 # Login to migration controller SA without making changes to original KUBECONFIG
 KUBECONFIG=$MIG_KUBECONFIG \
-oc login --token $(oc sa get-token migration-controller -n openshift-migration)
+oc login --token $(oc sa get-token migration-controller -n openshift-migration) > /dev/null


### PR DESCRIPTION
**Purpose**
Don't use currently logged in k8s user credentials during `make run`, instead use `migration-controller` SA so that permission gaps will be spotted quicker

**How it works**
Creates a temporary KUBECONFIG logged in as `migration-controller` SA that the controller will run as when using `make run`. Does _not_ modify your environments KUBECONFIG env var or its content.
 
**Request for feedback**
Will _always_ running as the migration-controller SA make development more cumbersome, should we provide an escape hatch if you want to override and run as the currently logged in user? 

```
$  make run
./hack/conversion-gen-`go env GOOS` --go-header-file ./hack/boilerplate.go.txt --output-file-base zz_conversion_generated -i ./pkg/compat/conversion/...
go generate ./pkg/... ./cmd/...
go fmt ./pkg/... ./cmd/...
go vet ./pkg/... ./cmd/...
./hack/controller-sa-login.sh
Found migration-controller SA. Performing token login...
KUBECONFIG=/Users/dwhatley/.kube/awsconfig-mig-controller go run ./cmd/manager/main.go
{"level":"info","ts":1585860935.230756,"logger":"entrypoint","msg":"setting up prometheus endpoint :2112/metrics"}
{"level":"info","ts":1585860935.231097,"logger":"entrypoint","msg":"setting up client for manager"}
{"level":"info","ts":1585860935.233898,"logger":"entrypoint","msg":"setting up manager"}
```