### PR TITLE
Fix observed-digest on OCP4.

### DIFF
--- a/pkg/apis/migration/v1alpha1/resource.go
+++ b/pkg/apis/migration/v1alpha1/resource.go
@@ -4,23 +4,34 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"github.com/google/uuid"
 )
 
 const (
+	TouchAnnotation = "openshift.io/touch"
 	VeleroNamespace = "openshift-migration"
 )
 
 // Migration application CR.
 type MigResource interface {
 	// Get a map containing the correlation label.
+	// Correlation labels are used to track any resource
+	// created by the controller.  The includes the application
+	// (global) label and the resource label.
 	GetCorrelationLabels() map[string]string
-	// Get the correlation label (key, value).
+	// Get the resource correlation label.
+	// The label is used to track resources created by the
+	// controller that is related to this resource.
 	GetCorrelationLabel() (string, string)
 	// Get the resource namespace.
 	GetNamespace() string
 	// Get the resource name.
 	GetName() string
 	// Mark the resource as having been reconciled.
+	// Updates the ObservedDigest.
+	// Update the touch annotation. This ensures that the resource
+	// is changed on every reconcile. This needed to support
+	// remote watch event propagation on OCP4.
 	MarkReconciled()
 	// Get whether the resource has been reconciled.
 	HasReconciled() bool
@@ -48,6 +59,11 @@ func (r *MigPlan) GetName() string {
 }
 
 func (r *MigPlan) MarkReconciled() {
+	uuid, _ := uuid.NewUUID()
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations[TouchAnnotation] = uuid.String()
 	r.Status.ObservedDigest = digest(r.Spec)
 }
 
@@ -77,6 +93,11 @@ func (r *MigStorage) GetName() string {
 }
 
 func (r *MigStorage) MarkReconciled() {
+	uuid, _ := uuid.NewUUID()
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations[TouchAnnotation] = uuid.String()
 	r.Status.ObservedDigest = digest(r.Spec)
 }
 
@@ -106,6 +127,11 @@ func (r *MigCluster) GetName() string {
 }
 
 func (r *MigCluster) MarkReconciled() {
+	uuid, _ := uuid.NewUUID()
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations[TouchAnnotation] = uuid.String()
 	r.Status.ObservedDigest = digest(r.Spec)
 }
 
@@ -135,6 +161,11 @@ func (r *MigMigration) GetName() string {
 }
 
 func (r *MigMigration) MarkReconciled() {
+	uuid, _ := uuid.NewUUID()
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations[TouchAnnotation] = uuid.String()
 	r.Status.ObservedDigest = digest(r.Spec)
 }
 


### PR DESCRIPTION
On OCP4, an update on a resource that has not changed is ignored by (most likely) `etcd`.  The remote watch propagation relies on the `Cluster` and `Plan` CRs to change on every reconcile regardless of whether anything changed (or not).  The `Touch` annotation was originally added (in the beginning) to deal with this.

The observed-generation pattern worked on OCP4 because the status is updated to (generation +1) which resulted in the CR being update and `generation` incremented in the case of remote watch events.

The observed-digest pattern updates the status only when the spec has changed.  This broke remote watch propagation on OCP4.

Added the `touch` annotation back.