### PR TITLE
Pre-create the namespaces to be migrated on the destination cluster

### DIFF
--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -122,6 +122,7 @@ func (r *MigPlan) GetSourceIdentity(client k8sclient.Client) (*migauth.Identity,
 		Token:   srcToken,
 		RestCfg: *srcRestCfg,
 	}
+	srcIdentity.BuildClient()
 	return srcIdentity, nil
 }
 
@@ -147,6 +148,7 @@ func (r *MigPlan) GetDestinationIdentity(client k8sclient.Client) (*migauth.Iden
 		Token:   destToken,
 		RestCfg: *destRestCfg,
 	}
+	destIdentity.BuildClient()
 	return destIdentity, nil
 }
 

--- a/pkg/auth/identity.go
+++ b/pkg/auth/identity.go
@@ -15,12 +15,12 @@ type Authorized map[string]bool
 type Identity struct {
 	Token   string
 	RestCfg rest.Config
-	client  k8sclient.Client
+	Client  k8sclient.Client
 }
 
 func (r *Identity) HasRead(namespaces []string) (Authorized, error) {
 	authorized := Authorized{}
-	err := r.buildClient()
+	err := r.BuildClient()
 	if err != nil {
 		return authorized, err
 	}
@@ -34,7 +34,7 @@ func (r *Identity) HasRead(namespaces []string) (Authorized, error) {
 				},
 			},
 		}
-		err := r.client.Create(context.TODO(), &sar)
+		err := r.Client.Create(context.TODO(), &sar)
 		if err != nil {
 			return authorized, err
 		}
@@ -46,7 +46,7 @@ func (r *Identity) HasRead(namespaces []string) (Authorized, error) {
 
 func (r *Identity) HasMigrate(namespaces []string) (Authorized, error) {
 	authorized := Authorized{}
-	err := r.buildClient()
+	err := r.BuildClient()
 	if err != nil {
 		return authorized, err
 	}
@@ -67,8 +67,8 @@ func (r *Identity) Authenticates(client k8sclient.Client) (bool, error) {
 	return tokenReview.Status.Authenticated, nil
 }
 
-func (r *Identity) buildClient() error {
-	if r.client != nil {
+func (r *Identity) BuildClient() error {
+	if r.Client != nil {
 		return nil
 	}
 	// build client using r.RestCfg and replacing the token with r.Token.
@@ -78,7 +78,6 @@ func (r *Identity) buildClient() error {
 	if err != nil {
 		return err
 	}
-	r.client = client
-
+	r.Client = client
 	return nil
 }

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -8,11 +8,41 @@ import (
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/pkg/errors"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	v1 "k8s.io/api/core/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// Ensure the namespaces to be migrated have been created on
+// the destination cluster. If they don't exist, create them
+// with the destination identity token.
+func (t *Task) ensureNamespacesCreated() error {
+	namespaces := t.PlanResources.MigPlan.GetDestinationNamespaces()
+	client, err := t.getDestinationClient()
+	if err != nil {
+		return err
+	}
+	for _, ns := range namespaces {
+		err := client.Get(context.TODO(), k8sclient.ObjectKey{Name: ns}, &v1.Namespace{})
+		if err != nil {
+			// if the namespace doesn't exist on the destination cluster, then create it.
+			if k8serror.IsNotFound(err) {
+				err := client.Create(context.TODO(), &v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: ns}},
+				)
+				if err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
 
 // Ensure the final restore on the destination cluster has been
 // created  and has the proper settings.

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -24,8 +24,12 @@ func (t *Task) ensureNamespacesCreated() error {
 	if err != nil {
 		return err
 	}
+	id, err := t.PlanResources.MigPlan.GetDestinationIdentity(client)
+	if err != nil {
+		return err
+	}
 	for _, ns := range namespaces {
-		err := client.Get(context.TODO(), k8sclient.ObjectKey{Name: ns}, &v1.Namespace{})
+		err := id.Client.Get(context.TODO(), k8sclient.ObjectKey{Name: ns}, &v1.Namespace{})
 		if err != nil {
 			// if the namespace doesn't exist on the destination cluster, then create it.
 			if k8serror.IsNotFound(err) {

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -35,6 +35,7 @@ const (
 	StageBackupFailed             = "StageBackupFailed"
 	EnsureInitialBackupReplicated = "EnsureInitialBackupReplicated"
 	EnsureStageBackupReplicated   = "EnsureStageBackupReplicated"
+	EnsureNamespacesCreated       = "EnsureNamespacesCreated"
 	EnsureStageRestore            = "EnsureStageRestore"
 	StageRestoreCreated           = "StageRestoreCreated"
 	StageRestoreFailed            = "StageRestoreFailed"
@@ -74,6 +75,7 @@ var StageItinerary = Itinerary{
 	{phase: ResticRestarted, all: HasStagePods},
 	{phase: QuiesceApplications, all: Quiesce},
 	{phase: EnsureQuiesced, all: Quiesce},
+	{phase: EnsureNamespacesCreated},
 	{phase: EnsureStageBackup, all: HasPVs},
 	{phase: StageBackupCreated, all: HasPVs},
 	{phase: EnsureStageBackupReplicated, all: HasPVs},
@@ -99,6 +101,7 @@ var FinalItinerary = Itinerary{
 	{phase: ResticRestarted, all: HasStagePods},
 	{phase: QuiesceApplications, all: Quiesce},
 	{phase: EnsureQuiesced, all: Quiesce},
+	{phase: EnsureNamespacesCreated},
 	{phase: EnsureStageBackup, all: HasPVs},
 	{phase: StageBackupCreated, all: HasPVs},
 	{phase: EnsureStageBackupReplicated, all: HasPVs},
@@ -449,6 +452,13 @@ func (t *Task) Run() error {
 		} else {
 			t.Requeue = NoReQ
 		}
+	case EnsureNamespacesCreated:
+		err := t.ensureNamespacesCreated()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		t.next()
 	case EnsureFinalRestore:
 		backup, err := t.getInitialBackup()
 		if err != nil {


### PR DESCRIPTION
https://github.com/konveyor/mig-controller/issues/393

This might need to change depending on how https://github.com/konveyor/mig-controller/pull/478 and its follow ups shake out.

@dymurray @jortel It seems plausible that the destination cluster might already have namespaces with names matching those to be migrated, in which case EnsureNamespacesCreated will not create them. Do we want to have another step in the itinerary that checks whether the user has permissions in those destination namespaces?