### PR TITLE
Revert "Revert "App backscaling on demand (#458)" (#497)"

### DIFF
--- a/config/crds/migration_v1alpha1_migmigration.yaml
+++ b/config/crds/migration_v1alpha1_migmigration.yaml
@@ -49,6 +49,8 @@ spec:
               items:
                 type: string
               type: array
+            itenerary:
+              type: string
             observedDigest:
               type: string
             phase:

--- a/pkg/apis/migration/v1alpha1/gvk.go
+++ b/pkg/apis/migration/v1alpha1/gvk.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
-import "k8s.io/apimachinery/pkg/runtime/schema"
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
 
 // Incompatible - list of namespaces containing incompatible resources for migration
 // which are being selected in the MigPlan

--- a/pkg/apis/migration/v1alpha1/labels.go
+++ b/pkg/apis/migration/v1alpha1/labels.go
@@ -1,9 +1,10 @@
 package v1alpha1
 
 import (
+	"strings"
+
 	migref "github.com/konveyor/mig-controller/pkg/reference"
 	"k8s.io/apimachinery/pkg/types"
-	"strings"
 )
 
 // Labels

--- a/pkg/apis/migration/v1alpha1/migmigration_types.go
+++ b/pkg/apis/migration/v1alpha1/migmigration_types.go
@@ -44,6 +44,7 @@ type MigMigrationStatus struct {
 	ObservedDigest string       `json:"observedDigest,omitempty"`
 	StartTimestamp *metav1.Time `json:"startTimestamp,omitempty"`
 	Phase          string       `json:"phase,omitempty"`
+	Itenerary      string       `json:"itenerary,omitempty"`
 	Errors         []string     `json:"errors,omitempty"`
 }
 
@@ -91,4 +92,9 @@ func (r *MigMigration) AddErrors(errors []string) {
 			r.Status.Errors = append(r.Status.Errors, error)
 		}
 	}
+}
+
+// HasErrors will notify about error presence on the MigMigration resource
+func (r *MigMigration) HasErrors() bool {
+	return len(r.Status.Errors) > 0
 }

--- a/pkg/apis/migration/v1alpha1/model.go
+++ b/pkg/apis/migration/v1alpha1/model.go
@@ -2,11 +2,12 @@ package v1alpha1
 
 import (
 	"context"
+	"strconv"
+
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
 )
 
 //

--- a/pkg/compat/client.go
+++ b/pkg/compat/client.go
@@ -21,6 +21,7 @@ import (
 // A smart client.
 // Provides seamless API version compatibility.
 type Client struct {
+	*rest.Config
 	k8sclient.Client
 	dapi.DiscoveryInterface
 	// major k8s version.
@@ -57,6 +58,7 @@ func NewClient(restCfg *rest.Config) (k8sclient.Client, error) {
 		return nil, err
 	}
 	nClient := &Client{
+		Config:             restCfg,
 		Client:             rClient,
 		DiscoveryInterface: dClient,
 		Major:              major,

--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -7,6 +7,8 @@ import (
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -18,6 +20,10 @@ const (
 	PvStorageClassAnnotation = "openshift.io/target-storage-class" // storageClassName
 	PvAccessModeAnnotation   = "openshift.io/target-access-mode"   // accessMode
 	QuiesceAnnotation        = "openshift.io/migrate-quiesce-pods" // (true|false)
+	QuiesceNodeSelector      = "migration.openshift.io/quiesceDaemonSet"
+	SuspendAnnotation        = "migration.openshift.io/preQuiesceSuspend"
+	ReplicasAnnotation       = "migration.openshift.io/preQuiesceReplicas"
+	NodeSelectorAnnotation   = "migration.openshift.io/preQuiesceNodeSelector"
 )
 
 // Restic Annotations
@@ -46,6 +52,10 @@ const (
 	// Designated as a `final` Restore.
 	// The value is the Task.UID().
 	FinalRestoreLabel = "migration-final-restore"
+	// Identifies the resource as migrated by us
+	// for easy search or application rollback.
+	// The value is the Task.UID().
+	MigratedByLabel = "migration.openshift.io/migrated-by" // (migmigration UID)
 )
 
 // Set of Service Accounts.
@@ -474,6 +484,47 @@ func (t *Task) deleteNamespaceLabels(client k8sclient.Client, namespaceList []st
 			return err
 		}
 	}
+	return nil
+}
+
+// deleteLabels will delete all migration.openshift.io/migrated-by labels
+// from the application upon successful completion
+func (t *Task) deleteLabels() error {
+	client, GVRs, err := t.getResourcesForDelete()
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+
+	listOptions := k8sclient.MatchingLabels(map[string]string{
+		MigratedByLabel: string(t.Owner.UID),
+	}).AsListOptions()
+
+	for _, gvr := range GVRs {
+		for _, ns := range t.destinationNamespaces() {
+			list, err := client.Resource(gvr).Namespace(ns).List(*listOptions)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+			for _, r := range list.Items {
+				labels := r.GetLabels()
+				delete(labels, MigratedByLabel)
+				r.SetLabels(labels)
+				_, err = client.Resource(gvr).Namespace(ns).Update(&r, metav1.UpdateOptions{})
+				if err != nil {
+					// The part touches the application on the destination side, fail safe to ensure
+					// this won't block the migration
+					if k8serror.IsMethodNotSupported(err) {
+						continue
+					}
+					log.Trace(err)
+					return err
+				}
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/controller/migmigration/migmigration_controller_test.go
+++ b/pkg/controller/migmigration/migmigration_controller_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package migmigration
 
 import (
-	"github.com/onsi/gomega"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -86,26 +87,23 @@ func TestReconcile(t *testing.T) {
 // but for not they are expected to be the identical.
 func Test_Itineraries(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	stage := StageItinerary[4 : len(StageItinerary)-1]
+	stage := StageItinerary
+	common := Itinerary{}
 
-	begin := 0
-	for i, step := range FinalItinerary {
-		if step.phase == stage[0].phase {
-			begin = i
-			break
+	for i, step := range StageItinerary.Steps {
+		found := false
+		for _, finalStep := range FinalItinerary.Steps[i:] {
+			if step.phase == finalStep.phase {
+				common.Steps = append(common.Steps, step)
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("'%s' is not contained within the final itinerary", step.phase)
 		}
 	}
-	end := 0
-	last := stage[len(stage)-1]
-	for i, step := range FinalItinerary {
-		if step.phase == last.phase {
-			end = i + 1
-			break
-		}
-	}
-	final := FinalItinerary[begin:end]
 
-	g.Expect(begin == 0).To(gomega.BeFalse())
-	g.Expect(end < len(FinalItinerary)).To(gomega.BeTrue())
-	g.Expect(reflect.DeepEqual(stage, final)).To(gomega.BeTrue())
+	g.Expect(reflect.DeepEqual(stage.Steps, common.Steps)).To(gomega.BeTrue())
+
 }

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -83,6 +83,7 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (time.Du
 
 	// Result
 	migration.Status.Phase = task.Phase
+	migration.Status.Itenerary = task.Itinerary.Name
 
 	// Completed
 	if task.Phase == Completed {

--- a/pkg/controller/migmigration/quiesce.go
+++ b/pkg/controller/migmigration/quiesce.go
@@ -2,6 +2,8 @@ package migmigration
 
 import (
 	"context"
+	"encoding/json"
+	"strconv"
 
 	ocappsv1 "github.com/openshift/api/apps/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -19,37 +21,83 @@ func (t *Task) quiesceApplications() error {
 		log.Trace(err)
 		return err
 	}
-	err = t.suspendCronJobs(client)
+	err = t.quiesceCronJobs(client)
 	if err != nil {
 		log.Trace(err)
 		return err
 	}
-	err = t.scaleDownDeploymentConfigs(client)
+	err = t.quiesceDeploymentConfigs(client)
 	if err != nil {
 		log.Trace(err)
 		return err
 	}
-	err = t.scaleDownDeployments(client)
+	err = t.quiesceDeployments(client)
 	if err != nil {
 		log.Trace(err)
 		return err
 	}
-	err = t.scaleDownStatefulSets(client)
+	err = t.quiesceStatefulSets(client)
 	if err != nil {
 		log.Trace(err)
 		return err
 	}
-	err = t.scaleDownReplicaSets(client)
+	err = t.quiesceReplicaSets(client)
 	if err != nil {
 		log.Trace(err)
 		return err
 	}
-	err = t.scaleDownDaemonSets(client)
+	err = t.quiesceDaemonSets(client)
 	if err != nil {
 		log.Trace(err)
 		return err
 	}
-	err = t.scaleDownJobs(client)
+	err = t.quiesceJobs(client)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+
+	return nil
+}
+
+// All quiesce undo functionality should be put here
+func (t *Task) unQuiesceApplications() error {
+	client, err := t.getSourceClient()
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	err = t.unQuiesceCronJobs(client)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	err = t.unQuiesceDeploymentConfigs(client)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	err = t.unQuiesceDeployments(client)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	err = t.unQuiesceStatefulSets(client)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	err = t.unQuiesceReplicaSets(client)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	err = t.unQuiesceDaemonSets(client)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	err = t.unQuiesceJobs(client)
 	if err != nil {
 		log.Trace(err)
 		return err
@@ -59,7 +107,7 @@ func (t *Task) quiesceApplications() error {
 }
 
 // Scales down DeploymentConfig on source cluster
-func (t *Task) scaleDownDeploymentConfigs(client k8sclient.Client) error {
+func (t *Task) quiesceDeploymentConfigs(client k8sclient.Client) error {
 	for _, ns := range t.sourceNamespaces() {
 		list := ocappsv1.DeploymentConfigList{}
 		options := k8sclient.InNamespace(ns)
@@ -72,9 +120,13 @@ func (t *Task) scaleDownDeploymentConfigs(client k8sclient.Client) error {
 			return err
 		}
 		for _, dc := range list.Items {
+			if dc.Annotations == nil {
+				dc.Annotations = make(map[string]string)
+			}
 			if dc.Spec.Replicas == 0 {
 				continue
 			}
+			dc.Annotations[ReplicasAnnotation] = strconv.FormatInt(int64(dc.Spec.Replicas), 10)
 			dc.Spec.Replicas = 0
 			err = client.Update(context.TODO(), &dc)
 			if err != nil {
@@ -87,8 +139,47 @@ func (t *Task) scaleDownDeploymentConfigs(client k8sclient.Client) error {
 	return nil
 }
 
+// Scales DeploymentConfig back up on source cluster
+func (t *Task) unQuiesceDeploymentConfigs(client k8sclient.Client) error {
+	for _, ns := range t.sourceNamespaces() {
+		list := ocappsv1.DeploymentConfigList{}
+		options := k8sclient.InNamespace(ns)
+		err := client.List(
+			context.TODO(),
+			options,
+			&list)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		for _, dc := range list.Items {
+			if dc.Annotations == nil {
+				continue
+			}
+			replicas, exist := dc.Annotations[ReplicasAnnotation]
+			if !exist {
+				continue
+			}
+			number, err := strconv.Atoi(replicas)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+			delete(dc.Annotations, ReplicasAnnotation)
+			dc.Spec.Replicas = int32(number)
+			err = client.Update(context.TODO(), &dc)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
 // Scales down all Deployments
-func (t *Task) scaleDownDeployments(client k8sclient.Client) error {
+func (t *Task) quiesceDeployments(client k8sclient.Client) error {
 	zero := int32(0)
 	for _, ns := range t.sourceNamespaces() {
 		list := appsv1.DeploymentList{}
@@ -102,9 +193,13 @@ func (t *Task) scaleDownDeployments(client k8sclient.Client) error {
 			return err
 		}
 		for _, deployment := range list.Items {
-			if deployment.Spec.Replicas == &zero {
+			if deployment.Annotations == nil {
+				deployment.Annotations = make(map[string]string)
+			}
+			if *deployment.Spec.Replicas == zero {
 				continue
 			}
+			deployment.Annotations[ReplicasAnnotation] = strconv.FormatInt(int64(*deployment.Spec.Replicas), 10)
 			deployment.Spec.Replicas = &zero
 			err = client.Update(context.TODO(), &deployment)
 			if err != nil {
@@ -117,8 +212,48 @@ func (t *Task) scaleDownDeployments(client k8sclient.Client) error {
 	return nil
 }
 
+// Scales all Deployments back up
+func (t *Task) unQuiesceDeployments(client k8sclient.Client) error {
+	for _, ns := range t.sourceNamespaces() {
+		list := appsv1.DeploymentList{}
+		options := k8sclient.InNamespace(ns)
+		err := client.List(
+			context.TODO(),
+			options,
+			&list)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		for _, deployment := range list.Items {
+			if deployment.Annotations == nil {
+				deployment.Annotations = make(map[string]string)
+			}
+			replicas, exist := deployment.Annotations[ReplicasAnnotation]
+			if !exist {
+				continue
+			}
+			number, err := strconv.Atoi(replicas)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+			delete(deployment.Annotations, ReplicasAnnotation)
+			restoredReplicas := int32(number)
+			deployment.Spec.Replicas = &restoredReplicas
+			err = client.Update(context.TODO(), &deployment)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
 // Scales down all StatefulSets.
-func (t *Task) scaleDownStatefulSets(client k8sclient.Client) error {
+func (t *Task) quiesceStatefulSets(client k8sclient.Client) error {
 	zero := int32(0)
 	for _, ns := range t.sourceNamespaces() {
 		list := appsv1.StatefulSetList{}
@@ -132,9 +267,13 @@ func (t *Task) scaleDownStatefulSets(client k8sclient.Client) error {
 			return err
 		}
 		for _, set := range list.Items {
-			if set.Spec.Replicas == &zero {
+			if set.Annotations == nil {
+				set.Annotations = make(map[string]string)
+			}
+			if *set.Spec.Replicas == zero {
 				continue
 			}
+			set.Annotations[ReplicasAnnotation] = strconv.FormatInt(int64(*set.Spec.Replicas), 10)
 			set.Spec.Replicas = &zero
 			err = client.Update(context.TODO(), &set)
 			if err != nil {
@@ -146,8 +285,47 @@ func (t *Task) scaleDownStatefulSets(client k8sclient.Client) error {
 	return nil
 }
 
+// Scales all StatefulSets back up
+func (t *Task) unQuiesceStatefulSets(client k8sclient.Client) error {
+	for _, ns := range t.sourceNamespaces() {
+		list := appsv1.StatefulSetList{}
+		options := k8sclient.InNamespace(ns)
+		err := client.List(
+			context.TODO(),
+			options,
+			&list)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		for _, set := range list.Items {
+			if set.Annotations == nil {
+				continue
+			}
+			replicas, exist := set.Annotations[ReplicasAnnotation]
+			if !exist {
+				continue
+			}
+			number, err := strconv.Atoi(replicas)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+			delete(set.Annotations, ReplicasAnnotation)
+			restoredReplicas := int32(number)
+			set.Spec.Replicas = &restoredReplicas
+			err = client.Update(context.TODO(), &set)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // Scales down all ReplicaSets.
-func (t *Task) scaleDownReplicaSets(client k8sclient.Client) error {
+func (t *Task) quiesceReplicaSets(client k8sclient.Client) error {
 	zero := int32(0)
 	for _, ns := range t.sourceNamespaces() {
 		list := appsv1.ReplicaSetList{}
@@ -161,9 +339,13 @@ func (t *Task) scaleDownReplicaSets(client k8sclient.Client) error {
 			return err
 		}
 		for _, set := range list.Items {
-			if set.Spec.Replicas == &zero {
+			if set.Annotations == nil {
+				set.Annotations = make(map[string]string)
+			}
+			if *set.Spec.Replicas == zero {
 				continue
 			}
+			set.Annotations[ReplicasAnnotation] = strconv.FormatInt(int64(*set.Spec.Replicas), 10)
 			set.Spec.Replicas = &zero
 			err = client.Update(context.TODO(), &set)
 			if err != nil {
@@ -175,14 +357,47 @@ func (t *Task) scaleDownReplicaSets(client k8sclient.Client) error {
 	return nil
 }
 
-// values to support nodeSelector-based DaemonSet quiesce
-const (
-	quiesceNodeSelector    = "openshift.io/quiesceDaemonSet"
-	quiesceNodeSelectorVal = "quiesce"
-)
+// Scales all ReplicaSets back up
+func (t *Task) unQuiesceReplicaSets(client k8sclient.Client) error {
+	for _, ns := range t.sourceNamespaces() {
+		list := appsv1.ReplicaSetList{}
+		options := k8sclient.InNamespace(ns)
+		err := client.List(
+			context.TODO(),
+			options,
+			&list)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		for _, set := range list.Items {
+			if set.Annotations == nil {
+				continue
+			}
+			replicas, exist := set.Annotations[ReplicasAnnotation]
+			if !exist {
+				continue
+			}
+			number, err := strconv.Atoi(replicas)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+			delete(set.Annotations, ReplicasAnnotation)
+			restoredReplicas := int32(number)
+			set.Spec.Replicas = &restoredReplicas
+			err = client.Update(context.TODO(), &set)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+		}
+	}
+	return nil
+}
 
 // Scales down all DaemonSets.
-func (t *Task) scaleDownDaemonSets(client k8sclient.Client) error {
+func (t *Task) quiesceDaemonSets(client k8sclient.Client) error {
 	for _, ns := range t.sourceNamespaces() {
 		list := appsv1.DaemonSetList{}
 		options := k8sclient.InNamespace(ns)
@@ -195,12 +410,60 @@ func (t *Task) scaleDownDaemonSets(client k8sclient.Client) error {
 			return err
 		}
 		for _, set := range list.Items {
+			if set.Annotations == nil {
+				set.Annotations = make(map[string]string)
+			}
 			if set.Spec.Template.Spec.NodeSelector == nil {
-				set.Spec.Template.Spec.NodeSelector = make(map[string]string)
-			} else if set.Spec.Template.Spec.NodeSelector[quiesceNodeSelector] == quiesceNodeSelectorVal {
+				set.Spec.Template.Spec.NodeSelector = map[string]string{}
+			} else if _, exist := set.Spec.Template.Spec.NodeSelector[QuiesceNodeSelector]; exist {
 				continue
 			}
-			set.Spec.Template.Spec.NodeSelector[quiesceNodeSelector] = quiesceNodeSelectorVal
+			selector, err := json.Marshal(set.Spec.Template.Spec.NodeSelector)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+			set.Annotations[NodeSelectorAnnotation] = string(selector)
+			set.Spec.Template.Spec.NodeSelector[QuiesceNodeSelector] = "true"
+			err = client.Update(context.TODO(), &set)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Scales all DaemonSets back up
+func (t *Task) unQuiesceDaemonSets(client k8sclient.Client) error {
+	for _, ns := range t.sourceNamespaces() {
+		list := appsv1.DaemonSetList{}
+		options := k8sclient.InNamespace(ns)
+		err := client.List(
+			context.TODO(),
+			options,
+			&list)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		for _, set := range list.Items {
+			if set.Annotations == nil {
+				continue
+			}
+			selector, exist := set.Annotations[NodeSelectorAnnotation]
+			if !exist {
+				continue
+			}
+			nodeSelector := map[string]string{}
+			err := json.Unmarshal([]byte(selector), &nodeSelector)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+			delete(set.Annotations, NodeSelectorAnnotation)
+			set.Spec.Template.Spec.NodeSelector = nodeSelector
 			err = client.Update(context.TODO(), &set)
 			if err != nil {
 				log.Trace(err)
@@ -212,9 +475,7 @@ func (t *Task) scaleDownDaemonSets(client k8sclient.Client) error {
 }
 
 // Suspends all CronJobs
-// Using unstructured because OCP 3.7 supports batch/v2alpha1 which is
-// not supported in newer versions such as OCP 3.11.
-func (t *Task) suspendCronJobs(client k8sclient.Client) error {
+func (t *Task) quiesceCronJobs(client k8sclient.Client) error {
 	for _, ns := range t.sourceNamespaces() {
 		list := batchv1beta.CronJobList{}
 		options := k8sclient.InNamespace(ns)
@@ -224,9 +485,13 @@ func (t *Task) suspendCronJobs(client k8sclient.Client) error {
 			return err
 		}
 		for _, r := range list.Items {
-			if r.Spec.Suspend != nil && *r.Spec.Suspend {
+			if r.Annotations == nil {
+				r.Annotations = make(map[string]string)
+			}
+			if r.Spec.Suspend == pointer.BoolPtr(true) {
 				continue
 			}
+			r.Annotations[SuspendAnnotation] = "true"
 			r.Spec.Suspend = pointer.BoolPtr(true)
 			err = client.Update(context.TODO(), &r)
 			if err != nil {
@@ -239,8 +504,38 @@ func (t *Task) suspendCronJobs(client k8sclient.Client) error {
 	return nil
 }
 
+// Undo quiescence on all CronJobs
+func (t *Task) unQuiesceCronJobs(client k8sclient.Client) error {
+	for _, ns := range t.sourceNamespaces() {
+		list := batchv1beta.CronJobList{}
+		options := k8sclient.InNamespace(ns)
+		err := client.List(context.TODO(), options, &list)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		for _, r := range list.Items {
+			if r.Annotations == nil {
+				continue
+			}
+			if _, exist := r.Annotations[SuspendAnnotation]; !exist {
+				continue
+			}
+			delete(r.Annotations, SuspendAnnotation)
+			r.Spec.Suspend = pointer.BoolPtr(false)
+			err = client.Update(context.TODO(), &r)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
 // Scales down all Jobs
-func (t *Task) scaleDownJobs(client k8sclient.Client) error {
+func (t *Task) quiesceJobs(client k8sclient.Client) error {
 	zero := int32(0)
 	for _, ns := range t.sourceNamespaces() {
 		list := batchv1.JobList{}
@@ -254,10 +549,54 @@ func (t *Task) scaleDownJobs(client k8sclient.Client) error {
 			return err
 		}
 		for _, job := range list.Items {
+			if job.Annotations == nil {
+				job.Annotations = make(map[string]string)
+			}
 			if job.Spec.Parallelism == &zero {
 				continue
 			}
+			job.Annotations[ReplicasAnnotation] = strconv.FormatInt(int64(*job.Spec.Parallelism), 10)
 			job.Spec.Parallelism = &zero
+			err = client.Update(context.TODO(), &job)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Scales all Jobs back up
+func (t *Task) unQuiesceJobs(client k8sclient.Client) error {
+	for _, ns := range t.sourceNamespaces() {
+		list := batchv1.JobList{}
+		options := k8sclient.InNamespace(ns)
+		err := client.List(
+			context.TODO(),
+			options,
+			&list)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		for _, job := range list.Items {
+			if job.Annotations == nil {
+				continue
+			}
+			replicas, exist := job.Annotations[ReplicasAnnotation]
+			if !exist {
+				continue
+			}
+			number, err := strconv.Atoi(replicas)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+			delete(job.Annotations, ReplicasAnnotation)
+			parallelReplicas := int32(number)
+			job.Spec.Parallelism = &parallelReplicas
 			err = client.Update(context.TODO(), &job)
 			if err != nil {
 				log.Trace(err)
@@ -301,6 +640,9 @@ func (t *Task) ensureQuiescedPodsTerminated() (bool, error) {
 			return false, err
 		}
 		for _, pod := range list.Items {
+			if pod.Annotations == nil {
+				pod.Annotations = make(map[string]string)
+			}
 			if _, found := skippedPhases[pod.Status.Phase]; found {
 				continue
 			}

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -34,6 +34,7 @@ const (
 	ResticRestarted               = "ResticRestarted"
 	QuiesceApplications           = "QuiesceApplications"
 	EnsureQuiesced                = "EnsureQuiesced"
+	UnQuiesceApplications         = "UnQuiesceApplications"
 	EnsureStageBackup             = "EnsureStageBackup"
 	StageBackupCreated            = "StageBackupCreated"
 	StageBackupFailed             = "StageBackupFailed"
@@ -49,6 +50,9 @@ const (
 	EnsureStagePodsDeleted        = "EnsureStagePodsDeleted"
 	EnsureStagePodsTerminated     = "EnsureStagePodsTerminated"
 	EnsureAnnotationsDeleted      = "EnsureAnnotationsDeleted"
+	EnsureLabelsDeleted           = "EnsureLabelsDeleted"
+	EnsureMigratedDeleted         = "EnsureMigratedDeleted"
+	DeleteMigrated                = "DeleteMigrated"
 	DeleteBackups                 = "DeleteBackups"
 	DeleteRestores                = "DeleteRestores"
 	Canceling                     = "Canceling"
@@ -64,72 +68,101 @@ const (
 	HasVerify    = 0x08 // Only when the plan has enabled verification
 )
 
-type Itinerary []Step
+type Itinerary struct {
+	Name  string
+	Steps []Step
+}
 
 var StageItinerary = Itinerary{
-	{phase: Created},
-	{phase: Started},
-	{phase: Prepare},
-	{phase: EnsureCloudSecretPropagated},
-	{phase: AnnotateResources, all: HasPVs},
-	{phase: EnsureStagePods, all: HasPVs},
-	{phase: StagePodsCreated, all: HasStagePods},
-	{phase: RestartRestic, all: HasStagePods},
-	{phase: ResticRestarted, all: HasStagePods},
-	{phase: QuiesceApplications, all: Quiesce},
-	{phase: EnsureQuiesced, all: Quiesce},
-	{phase: EnsureStageBackup, all: HasPVs},
-	{phase: StageBackupCreated, all: HasPVs},
-	{phase: EnsureStageBackupReplicated, all: HasPVs},
-	{phase: EnsureStageRestore, all: HasPVs},
-	{phase: StageRestoreCreated, all: HasPVs},
-	{phase: EnsureStagePodsDeleted, all: HasStagePods},
-	{phase: EnsureStagePodsTerminated, all: HasStagePods},
-	{phase: EnsureAnnotationsDeleted, all: HasPVs},
-	{phase: Completed},
+	Name: "Stage",
+	Steps: []Step{
+		{phase: Created},
+		{phase: Started},
+		{phase: Prepare},
+		{phase: EnsureCloudSecretPropagated},
+		{phase: AnnotateResources, all: HasPVs},
+		{phase: EnsureStagePods, all: HasPVs},
+		{phase: StagePodsCreated, all: HasStagePods},
+		{phase: RestartRestic, all: HasStagePods},
+		{phase: ResticRestarted, all: HasStagePods},
+		{phase: QuiesceApplications, all: Quiesce},
+		{phase: EnsureQuiesced, all: Quiesce},
+		{phase: EnsureStageBackup, all: HasPVs},
+		{phase: StageBackupCreated, all: HasPVs},
+		{phase: EnsureStageBackupReplicated, all: HasPVs},
+		{phase: EnsureStageRestore, all: HasPVs},
+		{phase: StageRestoreCreated, all: HasPVs},
+		{phase: EnsureStagePodsDeleted, all: HasStagePods},
+		{phase: EnsureStagePodsTerminated, all: HasStagePods},
+		{phase: EnsureAnnotationsDeleted, all: HasPVs},
+		{phase: EnsureLabelsDeleted},
+		{phase: Completed},
+	},
 }
 
 var FinalItinerary = Itinerary{
-	{phase: Created},
-	{phase: Started},
-	{phase: Prepare},
-	{phase: EnsureCloudSecretPropagated},
-	{phase: PreBackupHooks},
-	{phase: EnsureInitialBackup},
-	{phase: InitialBackupCreated},
-	{phase: AnnotateResources, all: HasPVs},
-	{phase: EnsureStagePods, all: HasPVs},
-	{phase: StagePodsCreated, all: HasStagePods},
-	{phase: RestartRestic, all: HasStagePods},
-	{phase: ResticRestarted, all: HasStagePods},
-	{phase: QuiesceApplications, all: Quiesce},
-	{phase: EnsureQuiesced, all: Quiesce},
-	{phase: EnsureStageBackup, all: HasPVs},
-	{phase: StageBackupCreated, all: HasPVs},
-	{phase: EnsureStageBackupReplicated, all: HasPVs},
-	{phase: EnsureStageRestore, all: HasPVs},
-	{phase: StageRestoreCreated, all: HasPVs},
-	{phase: EnsureStagePodsDeleted, all: HasStagePods},
-	{phase: EnsureStagePodsTerminated, all: HasStagePods},
-	{phase: EnsureAnnotationsDeleted, all: HasPVs},
-	{phase: EnsureInitialBackupReplicated},
-	{phase: EnsureFinalRestore},
-	{phase: PostBackupHooks},
-	{phase: PreRestoreHooks},
-	{phase: FinalRestoreCreated},
-	{phase: PostRestoreHooks},
-	{phase: Verification, all: HasVerify},
-	{phase: Completed},
+	Name: "Final",
+	Steps: []Step{
+		{phase: Created},
+		{phase: Started},
+		{phase: Prepare},
+		{phase: EnsureCloudSecretPropagated},
+		{phase: PreBackupHooks},
+		{phase: EnsureInitialBackup},
+		{phase: InitialBackupCreated},
+		{phase: AnnotateResources, all: HasPVs},
+		{phase: EnsureStagePods, all: HasPVs},
+		{phase: StagePodsCreated, all: HasStagePods},
+		{phase: RestartRestic, all: HasStagePods},
+		{phase: ResticRestarted, all: HasStagePods},
+		{phase: QuiesceApplications, all: Quiesce},
+		{phase: EnsureQuiesced, all: Quiesce},
+		{phase: EnsureStageBackup, all: HasPVs},
+		{phase: StageBackupCreated, all: HasPVs},
+		{phase: EnsureStageBackupReplicated, all: HasPVs},
+		{phase: EnsureStageRestore, all: HasPVs},
+		{phase: StageRestoreCreated, all: HasPVs},
+		{phase: EnsureStagePodsDeleted, all: HasStagePods},
+		{phase: EnsureStagePodsTerminated, all: HasStagePods},
+		{phase: EnsureAnnotationsDeleted, all: HasPVs},
+		{phase: EnsureInitialBackupReplicated},
+		{phase: PostBackupHooks},
+		{phase: PreRestoreHooks},
+		{phase: EnsureFinalRestore},
+		{phase: FinalRestoreCreated},
+		{phase: EnsureLabelsDeleted},
+		{phase: PostRestoreHooks},
+		{phase: Verification, all: HasVerify},
+		{phase: Completed},
+	},
 }
 
 var CancelItinerary = Itinerary{
-	{phase: Canceling},
-	{phase: EnsureStagePodsDeleted, all: HasStagePods},
-	{phase: EnsureAnnotationsDeleted, all: HasPVs},
-	{phase: DeleteBackups},
-	{phase: DeleteRestores},
-	{phase: Canceled},
-	{phase: Completed},
+	Name: "Cancel",
+	Steps: []Step{
+		{phase: Canceling},
+		{phase: DeleteBackups},
+		{phase: DeleteRestores},
+		{phase: EnsureStagePodsDeleted, all: HasStagePods},
+		{phase: EnsureAnnotationsDeleted, all: HasPVs},
+		{phase: DeleteMigrated},
+		{phase: EnsureMigratedDeleted},
+		{phase: UnQuiesceApplications, all: Quiesce},
+		{phase: Canceled},
+		{phase: Completed},
+	},
+}
+
+var FailedItinerary = Itinerary{
+	Name: "Failed",
+	Steps: []Step{
+		{phase: EnsureStagePodsDeleted, all: HasStagePods},
+		{phase: EnsureAnnotationsDeleted, all: HasPVs},
+		{phase: DeleteMigrated},
+		{phase: EnsureMigratedDeleted},
+		{phase: UnQuiesceApplications, all: Quiesce},
+		{phase: Completed},
+	},
 }
 
 // Step
@@ -146,8 +179,8 @@ type Step struct {
 // Returns: phase, n, total.
 func (r Itinerary) progressReport(phase string) (string, int, int) {
 	n := 0
-	total := len(r)
-	for i, step := range r {
+	total := len(r.Steps)
+	for i, step := range r.Steps {
 		if step.phase == phase {
 			n = i + 1
 			break
@@ -263,7 +296,7 @@ func (t *Task) Run() error {
 		}
 		if completed {
 			if len(reasons) > 0 {
-				t.failed(InitialBackupFailed, reasons)
+				t.fail(InitialBackupFailed, reasons)
 			} else {
 				t.next()
 			}
@@ -332,6 +365,13 @@ func (t *Task) Run() error {
 		} else {
 			t.Requeue = PollReQ
 		}
+	case UnQuiesceApplications:
+		err := t.unQuiesceApplications()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		t.next()
 	case EnsureStageBackup:
 		_, err := t.ensureStageBackup()
 		if err != nil {
@@ -356,7 +396,7 @@ func (t *Task) Run() error {
 		}
 		if completed {
 			if len(reasons) > 0 {
-				t.failed(StageBackupFailed, reasons)
+				t.fail(StageBackupFailed, reasons)
 			} else {
 				t.next()
 			}
@@ -437,7 +477,7 @@ func (t *Task) Run() error {
 		if completed {
 			t.setResticConditions(restore)
 			if len(reasons) > 0 {
-				t.failed(StageRestoreFailed, reasons)
+				t.fail(StageRestoreFailed, reasons)
 			} else {
 				t.next()
 			}
@@ -465,6 +505,15 @@ func (t *Task) Run() error {
 	case EnsureAnnotationsDeleted:
 		if !t.keepAnnotations() {
 			err := t.deleteAnnotations()
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+		}
+		t.next()
+	case EnsureLabelsDeleted:
+		if !t.keepAnnotations() {
+			err := t.deleteLabels()
 			if err != nil {
 				log.Trace(err)
 				return err
@@ -522,7 +571,7 @@ func (t *Task) Run() error {
 		}
 		if completed {
 			if len(reasons) > 0 {
-				t.failed(FinalRestoreFailed, reasons)
+				t.fail(FinalRestoreFailed, reasons)
 			} else {
 				t.next()
 			}
@@ -561,6 +610,24 @@ func (t *Task) Run() error {
 			Durable:  true,
 		})
 		t.next()
+	case DeleteMigrated:
+		err := t.deleteMigrated()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		t.next()
+	case EnsureMigratedDeleted:
+		deleted, err := t.ensureMigratedResourcesDeleted()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if deleted {
+			t.next()
+		} else {
+			t.Requeue = PollReQ
+		}
 	case DeleteBackups:
 		if err := t.deleteBackups(); err != nil {
 			log.Trace(err)
@@ -584,22 +651,9 @@ func (t *Task) Run() error {
 			Durable:  true,
 		})
 		t.next()
-	case StageBackupFailed, StageRestoreFailed:
-		err := t.ensureStagePodsDeleted()
-		if err != nil {
-			log.Trace(err)
-			return err
-		}
-		if !t.keepAnnotations() {
-			err = t.deleteAnnotations()
-			if err != nil {
-				log.Trace(err)
-				return err
-			}
-		}
+	// Out of tree states - needs to be triggered manually with t.fail(...)
+	case InitialBackupFailed, FinalRestoreFailed, StageBackupFailed, StageRestoreFailed:
 		t.Requeue = NoReQ
-		t.next()
-	case InitialBackupFailed, FinalRestoreFailed:
 		t.next()
 	case Completed:
 	}
@@ -615,19 +669,24 @@ func (t *Task) Run() error {
 // Initialize.
 func (t *Task) init() {
 	t.Requeue = FastReQ
-	if t.canceled() {
+	if t.failed() {
+		t.Itinerary = FailedItinerary
+	} else if t.canceled() {
 		t.Itinerary = CancelItinerary
 	} else if t.stage() {
 		t.Itinerary = StageItinerary
 	} else {
 		t.Itinerary = FinalItinerary
 	}
+	if t.Owner.Status.Itenerary != t.Itinerary.Name {
+		t.Phase = t.Itinerary.Steps[0].phase
+	}
 }
 
 // Advance the task to the next phase.
 func (t *Task) next() {
 	current := -1
-	for i, step := range t.Itinerary {
+	for i, step := range t.Itinerary.Steps {
 		if step.phase != t.Phase {
 			continue
 		}
@@ -635,15 +694,11 @@ func (t *Task) next() {
 		break
 	}
 	if current == -1 {
-		if t.canceled() {
-			t.Phase = CancelItinerary[0].phase
-		} else {
-			t.Phase = Completed
-		}
+		t.Phase = Completed
 		return
 	}
-	for n := current + 1; n < len(t.Itinerary); n++ {
-		next := t.Itinerary[n]
+	for n := current + 1; n < len(t.Itinerary.Steps); n++ {
+		next := t.Itinerary.Steps[n]
 		if !t.allFlags(next) {
 			continue
 		}
@@ -692,8 +747,8 @@ func (t *Task) anyFlags(step Step) bool {
 	return step.any == uint8(0)
 }
 
-// Phase failed.
-func (t *Task) failed(nextPhase string, reasons []string) {
+// Phase fail.
+func (t *Task) fail(nextPhase string, reasons []string) {
 	t.addErrors(reasons)
 	t.Phase = nextPhase
 	t.Owner.AddErrors(t.Errors)
@@ -719,7 +774,12 @@ func (t *Task) UID() string {
 	return string(t.Owner.UID)
 }
 
-// Get whether the migration is canceled.
+// Get whether the migration has failed
+func (t *Task) failed() bool {
+	return t.Owner.HasErrors()
+}
+
+// Get whether the migration is cancelled.
 func (t *Task) canceled() bool {
 	return t.Owner.Spec.Canceled || t.Owner.Status.HasAnyCondition(Canceled, Canceling)
 }

--- a/pkg/controller/migplan/gvk.go
+++ b/pkg/controller/migplan/gvk.go
@@ -1,30 +1,12 @@
 package migplan
 
 import (
-	"strings"
-
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"github.com/konveyor/mig-controller/pkg/compat"
+	"github.com/konveyor/mig-controller/pkg/gvk"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-var crdGVR = schema.GroupVersionResource{
-	Group:    "apiextensions.k8s.io",
-	Version:  "v1beta1", // Should become v1 after 1.17, needs downscaling
-	Resource: "customresourcedefinitions",
-}
-
-// Compare is a store for discovery and dynamic clients to do GVK compare
-type Compare struct {
-	Plan         *migapi.MigPlan
-	SrcDiscovery discovery.DiscoveryInterface
-	DstDiscovery discovery.DiscoveryInterface
-	SrcClient    dynamic.Interface
-}
 
 func (r ReconcileMigPlan) compareGVK(plan *migapi.MigPlan) error {
 	// No spec chage this time
@@ -49,30 +31,42 @@ func (r ReconcileMigPlan) compareGVK(plan *migapi.MigPlan) error {
 	return nil
 }
 
-func (r ReconcileMigPlan) newGVKCompare(plan *migapi.MigPlan) (*Compare, error) {
-	gvkCompare := &Compare{
-		Plan: plan,
+func (r ReconcileMigPlan) newGVKCompare(plan *migapi.MigPlan) (*gvk.Compare, error) {
+	srcCluster, err := plan.GetSourceCluster(r)
+	if err != nil {
+		log.Trace(err)
+		return nil, err
 	}
-
-	err := gvkCompare.NewSourceDiscovery(r)
+	dstCluster, err := plan.GetDestinationCluster(r)
 	if err != nil {
 		log.Trace(err)
 		return nil, err
 	}
 
-	err = gvkCompare.NewDestinationDiscovery(r)
+	src, err := srcCluster.GetClient(r)
+	if err != nil {
+		log.Trace(err)
+		return nil, err
+	}
+	srcClient := src.(compat.Client)
+	dst, err := dstCluster.GetClient(r)
+	if err != nil {
+		log.Trace(err)
+		return nil, err
+	}
+	dstClient := dst.(compat.Client)
+	dynamicClient, err := dynamic.NewForConfig(srcClient.Config)
 	if err != nil {
 		log.Trace(err)
 		return nil, err
 	}
 
-	err = gvkCompare.NewSourceClient(r)
-	if err != nil {
-		log.Trace(err)
-		return nil, err
-	}
-
-	return gvkCompare, nil
+	return &gvk.Compare{
+		Plan:         plan,
+		SrcClient:    dynamicClient,
+		DstDiscovery: dstClient,
+		SrcDiscovery: srcClient,
+	}, nil
 }
 
 func reportGVK(plan *migapi.MigPlan, incompatibleMapping map[string][]schema.GroupVersionResource) {
@@ -116,302 +110,4 @@ func clustersReady(plan *migapi.MigPlan) bool {
 		SourceClusterNotReady,
 	}
 	return !plan.Status.HasAnyCondition(clustersNotReadyConditions...)
-}
-
-// Compare GVKs on both clusters, find incompatible GVKs
-// and check each plan source namespace for existence of incompatible GVKs
-func (r *Compare) Compare() (map[string][]schema.GroupVersionResource, error) {
-	srcResourceList, err := collectResources(r.SrcDiscovery)
-	if err != nil {
-		log.Trace(err)
-		return nil, err
-	}
-
-	dstResourceList, err := collectResources(r.DstDiscovery)
-	if err != nil {
-		log.Trace(err)
-		return nil, err
-	}
-
-	srcResourceList, err = r.excludeCRDs(srcResourceList)
-	if err != nil {
-		log.Trace(err)
-		return nil, err
-	}
-
-	resourcesDiff := compareResources(srcResourceList, dstResourceList)
-	incompatibleGVKs, err := incompatibleResources(resourcesDiff)
-	if err != nil {
-		log.Trace(err)
-		return nil, err
-	}
-
-	return r.collectIncompatibleMapping(incompatibleGVKs)
-}
-
-// NewSourceDiscovery initializes source discovery client for a source cluster
-func (r *Compare) NewSourceDiscovery(c client.Client) error {
-	srcCluster, err := r.Plan.GetSourceCluster(c)
-	if err != nil {
-		return err
-	}
-
-	discovery, err := r.getDiscovery(c, srcCluster)
-	if err != nil {
-		return err
-	}
-
-	r.SrcDiscovery = discovery
-
-	return nil
-}
-
-// NewDestinationDiscovery initializes destination discovery client forom a destination cluster
-func (r *Compare) NewDestinationDiscovery(c client.Client) error {
-	dstCluster, err := r.Plan.GetDestinationCluster(c)
-	if err != nil {
-		return err
-	}
-
-	discovery, err := r.getDiscovery(c, dstCluster)
-	if err != nil {
-		return err
-	}
-
-	r.DstDiscovery = discovery
-
-	return nil
-}
-
-// NewSourceClient initializes source discovery client for a source cluster
-func (r *Compare) NewSourceClient(c client.Client) error {
-	srcCluster, err := r.Plan.GetSourceCluster(c)
-	if err != nil {
-		return err
-	}
-
-	client, err := r.getClient(c, srcCluster)
-	if err != nil {
-		return err
-	}
-
-	r.SrcClient = client
-
-	return nil
-}
-
-func (r *Compare) getDiscovery(c client.Client, cluster *migapi.MigCluster) (*discovery.DiscoveryClient, error) {
-	config, err := cluster.BuildRestConfig(c)
-	if err != nil {
-		return nil, err
-	}
-
-	return discovery.NewDiscoveryClientForConfig(config)
-}
-
-func (r *Compare) getClient(c client.Client, cluster *migapi.MigCluster) (dynamic.Interface, error) {
-	config, err := cluster.BuildRestConfig(c)
-	if err != nil {
-		return nil, err
-	}
-
-	return dynamic.NewForConfig(config)
-}
-
-func (r *Compare) collectIncompatibleMapping(incompatibleResources []schema.GroupVersionResource) (map[string][]schema.GroupVersionResource, error) {
-	incompatibleNamespaces := map[string][]schema.GroupVersionResource{}
-	for _, gvk := range incompatibleResources {
-		namespaceOccurence, err := r.occurIn(gvk)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, namespace := range namespaceOccurence {
-			if inNamespaces(namespace, r.Plan.GetSourceNamespaces()) {
-				_, exist := incompatibleNamespaces[namespace]
-				if exist {
-					incompatibleNamespaces[namespace] = append(incompatibleNamespaces[namespace], gvk)
-				} else {
-					incompatibleNamespaces[namespace] = []schema.GroupVersionResource{gvk}
-				}
-			}
-		}
-	}
-
-	return incompatibleNamespaces, nil
-}
-
-func (r *Compare) occurIn(gvr schema.GroupVersionResource) ([]string, error) {
-	namespacesOccurred := []string{}
-	options := metav1.ListOptions{}
-	resourceList, err := r.SrcClient.Resource(gvr).List(options)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, res := range resourceList.Items {
-		if !inNamespaces(res.GetNamespace(), namespacesOccurred) {
-			namespacesOccurred = append(namespacesOccurred, res.GetNamespace())
-		}
-	}
-
-	return namespacesOccurred, nil
-}
-
-func collectResources(discovery discovery.DiscoveryInterface) ([]*metav1.APIResourceList, error) {
-	resources, err := discovery.ServerResources()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, res := range resources {
-		res.APIResources = namespaced(res.APIResources)
-		res.APIResources = excludeSubresources(res.APIResources)
-		// Some resources appear not to have permissions to list, need to exclude those.
-		res.APIResources = listAllowed(res.APIResources)
-	}
-
-	return resources, nil
-}
-
-func incompatibleResources(resourceDiff []*metav1.APIResourceList) ([]schema.GroupVersionResource, error) {
-	incompatibleGVKs := []schema.GroupVersionResource{}
-	for _, resourceList := range resourceDiff {
-		gv, err := schema.ParseGroupVersion(resourceList.GroupVersion)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, resource := range resourceList.APIResources {
-			gvk := gv.WithResource(resource.Name)
-			incompatibleGVKs = append(incompatibleGVKs, gvk)
-		}
-	}
-
-	return incompatibleGVKs, nil
-}
-
-func (r *Compare) excludeCRDs(resources []*metav1.APIResourceList) ([]*metav1.APIResourceList, error) {
-	options := metav1.ListOptions{}
-	crdList, err := r.SrcClient.Resource(crdGVR).List(options)
-	if err != nil {
-		return nil, err
-	}
-
-	crdGroups := []string{}
-	groupPath := []string{"spec", "group"}
-	for _, crd := range crdList.Items {
-		group, _, err := unstructured.NestedString(crd.Object, groupPath...)
-		if err != nil {
-			return nil, err
-		}
-		crdGroups = append(crdGroups, group)
-	}
-
-	updatedLists := []*metav1.APIResourceList{}
-	for _, resourceList := range resources {
-		if !isCRDGroup(resourceList.GroupVersion, crdGroups) {
-			updatedLists = append(updatedLists, resourceList)
-		}
-	}
-
-	return updatedLists, nil
-}
-
-func excludeSubresources(resources []metav1.APIResource) []metav1.APIResource {
-	filteredList := []metav1.APIResource{}
-	for _, res := range resources {
-		if !strings.Contains(res.Name, "/") {
-			filteredList = append(filteredList, res)
-		}
-	}
-
-	return filteredList
-}
-
-func namespaced(resources []metav1.APIResource) []metav1.APIResource {
-	filteredList := []metav1.APIResource{}
-	for _, res := range resources {
-		if res.Namespaced {
-			filteredList = append(filteredList, res)
-		}
-	}
-
-	return filteredList
-}
-
-func listAllowed(resources []metav1.APIResource) []metav1.APIResource {
-	filteredList := []metav1.APIResource{}
-	for _, res := range resources {
-		for _, verb := range res.Verbs {
-			if verb == "list" {
-				filteredList = append(filteredList, res)
-				break
-			}
-		}
-	}
-
-	return filteredList
-}
-
-func resourceExist(resource metav1.APIResource, resources []metav1.APIResource) bool {
-	for _, resourceItem := range resources {
-		if resource.Name == resourceItem.Name {
-			return true
-		}
-	}
-
-	return false
-}
-
-func compareResources(src []*metav1.APIResourceList, dst []*metav1.APIResourceList) []*metav1.APIResourceList {
-	missingResources := []*metav1.APIResourceList{}
-	for _, srcList := range src {
-		missing := []metav1.APIResource{}
-		for _, resource := range srcList.APIResources {
-			if !resourceExist(resource, fingResourceList(srcList.GroupVersion, dst)) {
-				missing = append(missing, resource)
-			}
-		}
-
-		if len(missing) > 0 {
-			missingList := &metav1.APIResourceList{
-				GroupVersion: srcList.GroupVersion,
-				APIResources: missing,
-			}
-			missingResources = append(missingResources, missingList)
-		}
-	}
-
-	return missingResources
-}
-
-func fingResourceList(groupVersion string, list []*metav1.APIResourceList) []metav1.APIResource {
-	for _, l := range list {
-		if l.GroupVersion == groupVersion {
-			return l.APIResources
-		}
-	}
-
-	return nil
-}
-
-func inNamespaces(item string, namespaces []string) bool {
-	for _, ns := range namespaces {
-		if item == ns {
-			return true
-		}
-	}
-
-	return false
-}
-
-func isCRDGroup(group string, crdGroups []string) bool {
-	for _, crdGroup := range crdGroups {
-		if strings.HasPrefix(group, crdGroup) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -1,0 +1,254 @@
+package gvk
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var crdGVR = schema.GroupVersionResource{
+	Group:    "apiextensions.k8s.io",
+	Version:  "v1beta1", // Should become v1 after 1.17, needs downscaling
+	Resource: "customresourcedefinitions",
+}
+
+// Compare is a store for discovery and dynamic clients to do GVK compare
+type Compare struct {
+	Plan         *migapi.MigPlan
+	SrcDiscovery discovery.DiscoveryInterface
+	DstDiscovery discovery.DiscoveryInterface
+	SrcClient    dynamic.Interface
+}
+
+// Compare GVKs on both clusters, find incompatible GVKs
+// and check each plan source namespace for existence of incompatible GVKs
+func (r *Compare) Compare() (map[string][]schema.GroupVersionResource, error) {
+	srcResourceList, err := CollectResources(r.SrcDiscovery)
+	if err != nil {
+		return nil, err
+	}
+
+	dstResourceList, err := CollectResources(r.DstDiscovery)
+	if err != nil {
+		return nil, err
+	}
+
+	srcResourceList, err = r.excludeCRDs(srcResourceList)
+	if err != nil {
+		return nil, err
+	}
+
+	resourcesDiff := compareResources(srcResourceList, dstResourceList)
+	incompatibleGVKs, err := ConvertToGVRList(resourcesDiff)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.collectIncompatibleMapping(incompatibleGVKs)
+}
+
+// CollectResources collects all namespaced scoped apiResources from the cluster
+func CollectResources(discovery discovery.DiscoveryInterface) ([]*metav1.APIResourceList, error) {
+	resources, err := discovery.ServerResources()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, res := range resources {
+		res.APIResources = namespaced(res.APIResources)
+		res.APIResources = excludeSubresources(res.APIResources)
+		// Some resources appear not to have permissions to list, need to exclude those.
+		res.APIResources = listAllowed(res.APIResources)
+	}
+
+	return resources, nil
+}
+
+// ConvertToGVRList converts provided apiResourceList to list of GroupVersionResources from the server
+func ConvertToGVRList(resourceList []*metav1.APIResourceList) ([]schema.GroupVersionResource, error) {
+	GVRs := []schema.GroupVersionResource{}
+	for _, resourceList := range resourceList {
+		gv, err := schema.ParseGroupVersion(resourceList.GroupVersion)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, resource := range resourceList.APIResources {
+			gvk := gv.WithResource(resource.Name)
+			GVRs = append(GVRs, gvk)
+		}
+	}
+
+	return GVRs, nil
+}
+
+func excludeSubresources(resources []metav1.APIResource) []metav1.APIResource {
+	filteredList := []metav1.APIResource{}
+	for _, res := range resources {
+		if !strings.Contains(res.Name, "/") {
+			filteredList = append(filteredList, res)
+		}
+	}
+
+	return filteredList
+}
+
+func namespaced(resources []metav1.APIResource) []metav1.APIResource {
+	filteredList := []metav1.APIResource{}
+	for _, res := range resources {
+		if res.Namespaced {
+			filteredList = append(filteredList, res)
+		}
+	}
+
+	return filteredList
+}
+
+func listAllowed(resources []metav1.APIResource) []metav1.APIResource {
+	filteredList := []metav1.APIResource{}
+	for _, res := range resources {
+		for _, verb := range res.Verbs {
+			if verb == "list" {
+				filteredList = append(filteredList, res)
+				break
+			}
+		}
+	}
+
+	return filteredList
+}
+
+func (r *Compare) collectIncompatibleMapping(incompatibleResources []schema.GroupVersionResource) (map[string][]schema.GroupVersionResource, error) {
+	incompatibleNamespaces := map[string][]schema.GroupVersionResource{}
+	for _, gvk := range incompatibleResources {
+		namespaceOccurence, err := r.occurIn(gvk)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, namespace := range namespaceOccurence {
+			if inNamespaces(namespace, r.Plan.GetSourceNamespaces()) {
+				_, exist := incompatibleNamespaces[namespace]
+				if exist {
+					incompatibleNamespaces[namespace] = append(incompatibleNamespaces[namespace], gvk)
+				} else {
+					incompatibleNamespaces[namespace] = []schema.GroupVersionResource{gvk}
+				}
+			}
+		}
+	}
+
+	return incompatibleNamespaces, nil
+}
+
+func (r *Compare) occurIn(gvr schema.GroupVersionResource) ([]string, error) {
+	namespacesOccurred := []string{}
+	options := metav1.ListOptions{}
+	resourceList, err := r.SrcClient.Resource(gvr).List(options)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, res := range resourceList.Items {
+		if !inNamespaces(res.GetNamespace(), namespacesOccurred) {
+			namespacesOccurred = append(namespacesOccurred, res.GetNamespace())
+		}
+	}
+
+	return namespacesOccurred, nil
+}
+
+func (r *Compare) excludeCRDs(resources []*metav1.APIResourceList) ([]*metav1.APIResourceList, error) {
+	options := metav1.ListOptions{}
+	crdList, err := r.SrcClient.Resource(crdGVR).List(options)
+	if err != nil {
+		return nil, err
+	}
+
+	crdGroups := []string{}
+	groupPath := []string{"spec", "group"}
+	for _, crd := range crdList.Items {
+		group, _, err := unstructured.NestedString(crd.Object, groupPath...)
+		if err != nil {
+			return nil, err
+		}
+		crdGroups = append(crdGroups, group)
+	}
+
+	updatedLists := []*metav1.APIResourceList{}
+	for _, resourceList := range resources {
+		if !isCRDGroup(resourceList.GroupVersion, crdGroups) {
+			updatedLists = append(updatedLists, resourceList)
+		}
+	}
+
+	return updatedLists, nil
+}
+
+func resourceExist(resource metav1.APIResource, resources []metav1.APIResource) bool {
+	for _, resourceItem := range resources {
+		if resource.Name == resourceItem.Name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func compareResources(src []*metav1.APIResourceList, dst []*metav1.APIResourceList) []*metav1.APIResourceList {
+	missingResources := []*metav1.APIResourceList{}
+	for _, srcList := range src {
+		missing := []metav1.APIResource{}
+		for _, resource := range srcList.APIResources {
+			if !resourceExist(resource, fingResourceList(srcList.GroupVersion, dst)) {
+				missing = append(missing, resource)
+			}
+		}
+
+		if len(missing) > 0 {
+			missingList := &metav1.APIResourceList{
+				GroupVersion: srcList.GroupVersion,
+				APIResources: missing,
+			}
+			missingResources = append(missingResources, missingList)
+		}
+	}
+
+	return missingResources
+}
+
+func fingResourceList(groupVersion string, list []*metav1.APIResourceList) []metav1.APIResource {
+	for _, l := range list {
+		if l.GroupVersion == groupVersion {
+			return l.APIResources
+		}
+	}
+
+	return nil
+}
+
+func inNamespaces(item string, namespaces []string) bool {
+	for _, ns := range namespaces {
+		if item == ns {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isCRDGroup(group string, crdGroups []string) bool {
+	for _, crdGroup := range crdGroups {
+		if strings.HasPrefix(group, crdGroup) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
This reverts commit 814bf46d82eba35e670186be410ecf64af971f38 and restores backscaling.

This can be merged once https://github.com/konveyor/mig-operator/pull/303 is updated to include missing permissions and gets merged. Missing permissions are at least the following. I'm a little concerned we'll hit other custom verbs on other resources we hit with velero as well including builds, and velero/migration CRDs, but I don't have a workload to test migrating for builds and my suspicion is the CRDs were unique to velero. 

If we end up seeing the same with builds we'll have to add `build.openshift.io` to the apiGroups here too.

```
diff --git a/deploy/olm-catalog/konveyor-operator/v1.2.0/konveyor-operator.v1.2.0.clusterserviceversion.yaml b/deploy/olm-catalog/konveyor-operator/v1.2.0/konveyor-operator.v1.2.0.clusterserviceversion.yaml
index fe43df7..1d6cdee 100644
--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/konveyor-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/konveyor-operator.v1.2.0.clusterserviceversion.yaml
@@ -589,6 +589,12 @@ spec:
           - update
           - delete
           - deletecollection
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
       - serviceAccountName: velero
         rules:
         - apiGroups:
diff --git a/roles/migrationcontroller/templates/mig_rbac.yml.j2 b/roles/migrationcontroller/templates/mig_rbac.yml.j2
index f429411..d14b3c9 100644
--- a/roles/migrationcontroller/templates/mig_rbac.yml.j2
+++ b/roles/migrationcontroller/templates/mig_rbac.yml.j2
@@ -209,6 +209,12 @@ rules:
   - delete
   - update
   - deletecollection
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
 ---
 apiVersion: v1
 kind: ServiceAccount