### PR TITLE
compat.NewClient returns Client interface, refactor

### DIFF
--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -18,12 +18,13 @@ package v1alpha1
 
 import (
 	"context"
+	"time"
+
 	pvdr "github.com/konveyor/mig-controller/pkg/cloudprovider"
 	"github.com/konveyor/mig-controller/pkg/compat"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"time"
 
 	ocapi "github.com/openshift/api/apps/v1"
 	imgapi "github.com/openshift/api/image/v1"
@@ -104,7 +105,7 @@ func (m *MigCluster) GetServiceAccountSecret(client k8sclient.Client) (*kapi.Sec
 }
 
 // GetClient get a local or remote client using a MigCluster and an existing client
-func (m *MigCluster) GetClient(c k8sclient.Client) (k8sclient.Client, error) {
+func (m *MigCluster) GetClient(c k8sclient.Client) (compat.Client, error) {
 	restConfig, err := m.BuildRestConfig(c)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/gvk"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
@@ -490,7 +491,7 @@ func (t *Task) deleteNamespaceLabels(client k8sclient.Client, namespaceList []st
 // deleteLabels will delete all migration.openshift.io/migrated-by labels
 // from the application upon successful completion
 func (t *Task) deleteLabels() error {
-	client, GVRs, err := t.getResourcesForDelete()
+	client, GVRs, err := gvk.GetGVRsForCluster(t.PlanResources.DestMigCluster, t.Client)
 	if err != nil {
 		log.Trace(err)
 		return err

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-logr/logr"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/compat"
 	"github.com/pkg/errors"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -815,12 +816,12 @@ func (t *Task) keepAnnotations() bool {
 }
 
 // Get a client for the source cluster.
-func (t *Task) getSourceClient() (k8sclient.Client, error) {
+func (t *Task) getSourceClient() (compat.Client, error) {
 	return t.PlanResources.SrcMigCluster.GetClient(t.Client)
 }
 
 // Get a client for the destination cluster.
-func (t *Task) getDestinationClient() (k8sclient.Client, error) {
+func (t *Task) getDestinationClient() (compat.Client, error) {
 	return t.PlanResources.DestMigCluster.GetClient(t.Client)
 }
 

--- a/pkg/controller/migplan/gvk.go
+++ b/pkg/controller/migplan/gvk.go
@@ -2,7 +2,6 @@ package migplan
 
 import (
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
-	"github.com/konveyor/mig-controller/pkg/compat"
 	"github.com/konveyor/mig-controller/pkg/gvk"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -44,19 +43,17 @@ func (r ReconcileMigPlan) newGVKCompare(plan *migapi.MigPlan) (*gvk.Compare, err
 		return nil, err
 	}
 
-	src, err := srcCluster.GetClient(r)
+	srcClient, err := srcCluster.GetClient(r)
 	if err != nil {
 		log.Trace(err)
 		return nil, err
 	}
-	srcClient := src.(compat.Client)
-	dst, err := dstCluster.GetClient(r)
+	dstClient, err := dstCluster.GetClient(r)
 	if err != nil {
 		log.Trace(err)
 		return nil, err
 	}
-	dstClient := dst.(compat.Client)
-	dynamicClient, err := dynamic.NewForConfig(srcClient.Config)
+	dynamicClient, err := dynamic.NewForConfig(srcClient.RestConfig())
 	if err != nil {
 		log.Trace(err)
 		return nil, err


### PR DESCRIPTION
This pr avoid such mappings from `compat.NewClient`, as they are causing issues the current controller setup, as they are not evaluated during static compile.

Closes #506 

```golang
        dst, err := dstCluster.GetClient(r)
        if err != nil {
                log.Trace(err)
                return nil, err
        }
        dstClient := dst.(*compat.Client)
```