### PR TITLE
Add periodic labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+# Add 'update-operator' to any changes within 'config/crds' dir
+update-operator:
+  - config/crds/*

--- a/.github/workflows/periodic-labeler.yml
+++ b/.github/workflows/periodic-labeler.yml
@@ -1,0 +1,14 @@
+---
+name: Pull request labeler
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: paulfantom/periodic-labeler@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LABEL_MAPPINGS_FILE: .github/labeler.yml


### PR DESCRIPTION
### What it does
Auto-labeler runs every 5 minutes and labels all open PRs that contain changes to `config/crds/*` with `update-operator`

### Changes from previous auto-label PRs
This periodic auto-labeler gets a GitHub token with "write" permission that was able to apply labels to PRs coming from forked repos in my tests, unlike the original auto-labeler I attempted to add to this repo.

Due to privilege escalation risk, GitHub actions triggered from forked repos are given a "read-only" GitHub token. Running in a "cron-like" manner as shown here overcomes this limitation. Turns out this action was written by a Red Hatter!

Resolves https://github.com/konveyor/mig-controller/issues/507