### PR TITLE
Bug 1824395: Warn for no-op stage migrations

### DIFF
--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -682,6 +682,15 @@ func (t *Task) init() {
 	if t.Owner.Status.Itenerary != t.Itinerary.Name {
 		t.Phase = t.Itinerary.Steps[0].phase
 	}
+	if t.stage() && !t.hasPVs() {
+		t.Owner.Status.SetCondition(migapi.Condition{
+			Type:     StageNoOp,
+			Status:   True,
+			Category: migapi.Warn,
+			Message:  StageNoOpMessage,
+			Durable:  true,
+		})
+	}
 }
 
 // Advance the task to the next phase.

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -18,6 +18,7 @@ const (
 	Failed              = "Failed"
 	ResticErrors        = "ResticErrors"
 	ResticVerifyErrors  = "ResticVerifyErrors"
+	StageNoOp           = "StageNoOp"
 )
 
 // Categories
@@ -56,6 +57,7 @@ const (
 	UnhealthyNamespacesMessage = "'%s' cluster has unhealthy namespaces. See status.namespaces for details."
 	ResticErrorsMessage        = "There were errors found in %d Restic volume restores. See restore `%s` for details"
 	ResticVerifyErrorsMessage  = "There were verify errors found in %d Restic volume restores. See restore `%s` for details"
+	StageNoOpMessage           = "Stage migration was run without any PVs. No Velero operations were initiated."
 )
 
 // Validate the plan resource.


### PR DESCRIPTION
If a stage migration with no PVs is run, add a warning
condition to the migmigration.

Example migmigration warning:
  - category: Warn
    durable: true
    lastTransitionTime: 2020-04-22T13:56:22Z
    message: Stage migration was run without any PVs. No Velero operations were initiated.
    status: "True"
    type: StageNoOp