### PR TITLE
Bug 1828428 - Return false from GetDisableSSL if the S3 url is empty

### DIFF
--- a/pkg/cloudprovider/aws.go
+++ b/pkg/cloudprovider/aws.go
@@ -276,6 +276,9 @@ func (p *AWSProvider) GetRegion() string {
 // Check the scheme on the configured URL. If a URL is not specified, return
 // false
 func (p *AWSProvider) GetDisableSSL() bool {
+	if p.GetURL() == "" {
+		return false
+	}
 	s3Url, err := url.Parse(p.GetURL())
 	if err != nil {
 		return false

--- a/pkg/cloudprovider/aws_test.go
+++ b/pkg/cloudprovider/aws_test.go
@@ -1,0 +1,26 @@
+package cloudprovider
+
+import (
+	"github.com/onsi/gomega"
+	"testing"
+)
+
+func TestGetDisableSSL(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	p := AWSProvider{S3URL: ""}
+	p.GetDisableSSL()
+	g.Expect(p.GetDisableSSL()).To(gomega.BeFalse())
+
+	p.S3URL = "https://example.com"
+	p.GetDisableSSL()
+	g.Expect(p.GetDisableSSL()).To(gomega.BeFalse())
+
+	p.S3URL = "example.com"
+	p.GetDisableSSL()
+	g.Expect(p.GetDisableSSL()).To(gomega.BeTrue())
+
+	p.S3URL = "http://example.com"
+	p.GetDisableSSL()
+	g.Expect(p.GetDisableSSL()).To(gomega.BeTrue())
+}


### PR DESCRIPTION
`GetDisableSSL()` should return false for empty strings, but since `url.Parse` doesn't throw an error for a empty string the URL falls through to the "no scheme" case and returns true. This patch causes `GetDisableSSL()` to return `false` when `GetURL()` is empty, matching the expected behavior described in the comment.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1828428