### PR TITLE
Implement HasMigrate

### DIFF
--- a/pkg/controller/migmigration/migmigration_controller_test.go
+++ b/pkg/controller/migmigration/migmigration_controller_test.go
@@ -86,7 +86,7 @@ func TestReconcile(t *testing.T) {
 // but for not they are expected to be the identical.
 func Test_Itineraries(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	start := 5 // Start with AnnotateResources
+	start := 6 // Start with AnnotateResources
 	stage := StageItinerary[start : len(StageItinerary)-1]
 
 	begin := 0


### PR DESCRIPTION
This does two things:

1) Adds a `CanI(namespace, resource, verb)` convenience function on the Identity.
2) Implements the permissions checks in HasMigrate

@dymurray and I had an initial chat about what the list of resources we need to check against might be. For now this does a SAR check on each of those resources for all (`*`) verbs to avoid making a half dozen SAR checks per resource.

Nested for loops inherently give me the creeps but I don't see a better way to approach this at the moment.