### PR TITLE
Bug 1844638: Add settings switch controlling whether FailedItinerary (auto-rollback) gets used

### DIFF
--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -6,9 +6,13 @@ import (
 	"github.com/go-logr/logr"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/konveyor/mig-controller/pkg/compat"
+	"github.com/konveyor/mig-controller/pkg/settings"
 	"github.com/pkg/errors"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// Application settings.
+var Settings = &settings.Settings
 
 // Requeue
 var FastReQ = time.Duration(time.Millisecond * 100)
@@ -679,7 +683,7 @@ func (t *Task) Run() error {
 // Initialize.
 func (t *Task) init() {
 	t.Requeue = FastReQ
-	if t.failed() {
+	if t.failed() && Settings.Migration.FailureRollback {
 		t.Itinerary = FailedItinerary
 	} else if t.canceled() {
 		t.Itinerary = CancelItinerary

--- a/pkg/settings/migration.go
+++ b/pkg/settings/migration.go
@@ -1,0 +1,19 @@
+package settings
+
+// Environment variables.
+const (
+	FailureRollback = "FAILURE_ROLLBACK"
+)
+
+// Migration settings.
+//   FailureRollback: Should migration failure result in rollback of resources to source cluster?
+type Migration struct {
+	FailureRollback bool
+}
+
+// Load settings.
+func (r *Migration) Load() error {
+	r.FailureRollback = getEnvBool(FailureRollback, false)
+
+	return nil
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -33,6 +33,7 @@ var Settings = _Settings{}
 type _Settings struct {
 	Discovery
 	Plan
+	Migration
 	Roles     map[string]bool
 	ProxyVars map[string]string
 }
@@ -44,6 +45,10 @@ func (r *_Settings) Load() error {
 		return err
 	}
 	err = r.Discovery.Load()
+	if err != nil {
+		return err
+	}
+	err = r.Migration.Load()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Bound to mig-operator PR https://github.com/konveyor/mig-operator/pull/370

**Change summary**
 - Default to **not** running rollback (deletion of migrated resources on destination cluster, re-scaling on src cluster) when migration enters failed state
 - Allow users to turn rollback on via mig-operator switch if needed. 

**Dev Checklist**
- [x] Link to corresponding mig-operator PR
- [x] Attach BZ
- [x] Run manual tests