### PR TITLE
Add non-admin support in discovery controller.

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/konveyor/mig-controller/pkg/imagescheme"
 	"github.com/konveyor/mig-controller/pkg/webhook"
 	appsv1 "github.com/openshift/api/apps/v1"
+	project "github.com/openshift/api/project/v1"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -79,6 +80,10 @@ func main() {
 	}
 	if err := appsv1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "unable to add OpenShift apps APIs to scheme")
+		os.Exit(1)
+	}
+	if err := project.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "unable to add OpenShift project APIs to scheme")
 		os.Exit(1)
 	}
 	if err := clusterregv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {

--- a/pkg/controller/discovery/auth/rbac.go
+++ b/pkg/controller/discovery/auth/rbac.go
@@ -1,0 +1,342 @@
+package auth
+
+import (
+	"context"
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/logging"
+	project "github.com/openshift/api/project/v1"
+	auth "k8s.io/api/authentication/v1beta1"
+	"k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
+	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//
+// Shared logger.
+var Log *logging.Logger
+
+//
+// k8s Resources.
+const (
+	ALL       = "*"
+	Namespace = "namespaces"
+	PV        = "persistentvolumes"
+	PVC       = "persistentvolumeclaims"
+	Service   = "services"
+	Pod       = "pods"
+	PodLog    = "pods/log"
+)
+
+//
+// Verbs
+const (
+	ANY    = "*"
+	LIST   = "list"
+	GET    = "get"
+	CREATE = "create"
+	DELETE = "delete"
+	PATCH  = "patch"
+	UPDATE = "update"
+)
+
+//
+// SAR request.
+type Review = v1.ResourceAttributes
+
+//
+// RBAC authorization provider.
+type Provider interface {
+	// Authenticate the token.
+	Authenticate() (bool, error)
+	// Get whether the token was authenticated.
+	Authenticated() bool
+	// Determine of actions specified are authorized
+	// for the token.
+	Allow(*Review) (bool, error)
+	// Determine if the all of the actions
+	// specified in the matrix are authorized for
+	// the token.
+	AllowMatrix(*Matrix) (bool, error)
+	// Get the user name.
+	User() string
+}
+
+//
+// Review Matrix.
+type Matrix struct {
+	// API group.
+	Group string
+	// Namespace
+	Namespace string
+	// Resource name.
+	Name string
+	// Resources.
+	Resources []string
+	// Verbs.
+	Verbs []string
+}
+
+//
+// Provides RBAC authorization.
+type RBAC struct {
+	client.Client
+	// Cluster
+	Cluster *migapi.MigCluster
+	// The subject bearer token.
+	Token string
+	// Token review status.
+	tokenStatus auth.TokenReviewStatus
+	// Token authenticated.
+	authenticated *bool
+	// Project-based authorization.
+	pbac *PBAC
+}
+
+//
+// Allow/deny the subject review request.
+// Special (optimized) steps for namespaces:
+//   1. Populate `allowedProject`.
+//   2. Match namespace in `allowedProject`.
+//   3. Match `*` in `allowedProject`.
+//   4. SAR
+// The SAR for each namespace is last resort. For large
+// clusters this will be very slow.
+func (r *RBAC) Allow(request *Review) (bool, error) {
+	authenticated, err := r.Authenticate()
+	if err != nil {
+		Log.Trace(err)
+		return false, err
+	}
+	if !authenticated {
+		return false, nil
+	}
+	if r.pbac == nil {
+		r.pbac = &PBAC{
+			Cluster: r.Cluster,
+			Token:   r.Token,
+		}
+	}
+	switch request.Resource {
+	case Namespace:
+		switch request.Verb {
+		case LIST, GET:
+			if r.pbac.Supported() {
+				allowed := r.pbac.Allow(request.Name)
+				return allowed, nil
+			}
+		}
+		fallthrough
+	default:
+		return r.sar(request)
+	}
+}
+
+//
+// Allow all the combinations in the matrix.
+// See: Allow() for details.
+func (r *RBAC) AllowMatrix(m *Matrix) (bool, error) {
+	mAllowed := false
+	request := &Review{
+		Group:     m.Group,
+		Namespace: m.Namespace,
+		Name:      m.Name,
+	}
+	for _, resource := range m.Resources {
+		for _, verb := range m.Verbs {
+			mAllowed = true
+			request.Resource = resource
+			request.Verb = verb
+			allowed, err := r.Allow(request)
+			if err != nil {
+				Log.Trace(err)
+				return false, err
+			}
+			if !allowed {
+				return false, nil
+			}
+		}
+	}
+
+	return mAllowed, nil
+}
+
+//
+// Get whether authenticated
+func (r *RBAC) Authenticated() bool {
+	return r != nil && *r.authenticated
+}
+
+//
+// Get the user name for the token.
+func (r *RBAC) User() string {
+	if r.Authenticated() {
+		return r.tokenStatus.User.Username
+	}
+
+	return ""
+}
+
+//
+// Get the user ID for the token.
+func (r *RBAC) UID() string {
+	if r.Authenticated() {
+		return r.tokenStatus.User.UID
+	}
+
+	return ""
+}
+
+//
+// Get the user's groups.
+func (r *RBAC) Groups() []string {
+	if r.Authenticated() {
+		return r.tokenStatus.User.Groups
+	}
+
+	return []string{}
+}
+
+//
+// Get the extra fields for the token.
+func (r *RBAC) Extra() map[string]v1.ExtraValue {
+	extra := map[string]v1.ExtraValue{}
+	if r.Authenticated() {
+		for k, v := range r.tokenStatus.User.Extra {
+			extra[k] = append(
+				v1.ExtraValue{},
+				v...)
+		}
+	}
+
+	return extra
+}
+
+//
+// Do subject access review.
+func (r *RBAC) sar(request *Review) (bool, error) {
+	sar := v1.SubjectAccessReview{
+		Spec: v1.SubjectAccessReviewSpec{
+			ResourceAttributes: request,
+			Groups:             r.Groups(),
+			User:               r.User(),
+			UID:                r.UID(),
+			Extra:              r.Extra(),
+		},
+	}
+	err := r.Client.Create(context.TODO(), &sar)
+	if err != nil {
+		Log.Trace(err)
+		return false, err
+	}
+
+	return sar.Status.Allowed, nil
+}
+
+//
+// Authenticate the token.
+// Build the `subjectClient`.
+func (r *RBAC) Authenticate() (bool, error) {
+	if r.authenticated != nil {
+		return *r.authenticated, nil
+	}
+	r.authenticated = pointer.BoolPtr(false)
+	tr := &auth.TokenReview{
+		Spec: auth.TokenReviewSpec{
+			Token: r.Token,
+		},
+	}
+	err := r.Client.Create(context.TODO(), tr)
+	if err != nil {
+		Log.Trace(err)
+		return false, err
+	}
+	if !tr.Status.Authenticated {
+		return false, err
+	}
+	r.tokenStatus = tr.Status
+	r.authenticated = pointer.BoolPtr(true)
+
+	return true, nil
+}
+
+//
+// Provides project-based authorization.
+type PBAC struct {
+	// Token
+	Token string
+	// Cluster
+	Cluster *migapi.MigCluster
+	// Project API supported by the cluster.
+	supported bool
+	// List of projects.
+	projects map[string]bool
+}
+
+//
+// Project API is supported by the cluster.
+func (p *PBAC) Supported() bool {
+	p.Load()
+	return p.supported
+}
+
+//
+// The token is allowed access to the specified namespace.
+func (p *PBAC) Allow(ns string) bool {
+	p.Load()
+	_, found := p.projects[ns]
+	return found
+}
+
+//
+// Load projects (as needed).
+func (p *PBAC) Load() {
+	if p.projects != nil {
+		return
+	}
+	p.projects = map[string]bool{}
+	tokenClient, err := p.client()
+	if err != nil {
+		return
+	}
+	list := &project.ProjectList{}
+	err = tokenClient.List(context.TODO(), nil, list)
+	if err != nil {
+		return
+	}
+	p.supported = true
+	for _, project := range list.Items {
+		p.projects[project.Name] = true
+	}
+}
+
+//
+// Build a client for the token.
+func (p *PBAC) client() (client.Client, error) {
+	var err error
+	restCfg, err := p.Cluster.BuildRestConfigWithToken(p.Token)
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	newClient, err := client.New(
+		restCfg,
+		client.Options{
+			Scheme: scheme.Scheme,
+		})
+	if err != nil {
+		if stErr, cast := err.(*errors.StatusError); cast {
+			switch stErr.Status().Code {
+			case http.StatusUnauthorized,
+				http.StatusForbidden:
+				return nil, err
+			}
+		}
+		Log.Trace(err)
+		return nil, err
+	}
+
+	return newClient, nil
+}

--- a/pkg/controller/discovery/container/ns.go
+++ b/pkg/controller/discovery/container/ns.go
@@ -46,10 +46,8 @@ func (r *Namespace) Reconcile() error {
 	r.hasReconciled = true
 	Log.Info(
 		"Namespace (collection) reconciled.",
-		"ns",
-		r.ds.Cluster.Namespace,
-		"name",
-		r.ds.Cluster.Name,
+		"cluster",
+		r.ds.Name(),
 		"duration",
 		time.Since(mark))
 

--- a/pkg/controller/discovery/container/plan.go
+++ b/pkg/controller/discovery/container/plan.go
@@ -1,0 +1,146 @@
+package container
+
+import (
+	"context"
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	"time"
+)
+
+//
+// A collection of k8s Plan resources.
+type Plan struct {
+	// Base
+	BaseCollection
+}
+
+func (r *Plan) AddWatch(dsController controller.Controller) error {
+	err := dsController.Watch(
+		&source.Kind{
+			Type: &migapi.MigPlan{},
+		},
+		&handler.EnqueueRequestForObject{},
+		r)
+	if err != nil {
+		Log.Trace(err)
+		return err
+	}
+
+	return nil
+}
+
+func (r *Plan) Reconcile() error {
+	mark := time.Now()
+	sr := SimpleReconciler{
+		Db: r.ds.Container.Db,
+	}
+	err := sr.Reconcile(r)
+	if err != nil {
+		Log.Trace(err)
+		return err
+	}
+	r.hasReconciled = true
+	Log.Info(
+		"Plan reconciled.",
+		"cluster",
+		r.ds.Name(),
+		"duration",
+		time.Since(mark))
+
+	return nil
+}
+
+func (r *Plan) GetDiscovered() ([]model.Model, error) {
+	models := []model.Model{}
+	onCluster := migapi.MigPlanList{}
+	err := r.ds.Client.List(context.TODO(), nil, &onCluster)
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	for _, discovered := range onCluster.Items {
+		plan := &model.Plan{}
+		plan.With(&discovered)
+		models = append(models, plan)
+	}
+
+	return models, nil
+}
+
+func (r *Plan) GetStored() ([]model.Model, error) {
+	models := []model.Model{}
+	list, err := model.Plan{}.List(r.ds.Container.Db, model.ListOptions{})
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	for _, plan := range list {
+		models = append(models, plan)
+	}
+
+	return models, nil
+}
+
+//
+// Predicate methods.
+//
+
+func (r *Plan) Create(e event.CreateEvent) bool {
+	Log.Reset()
+	object, cast := e.Object.(*migapi.MigPlan)
+	if !cast {
+		return false
+	}
+	plan := &model.Plan{}
+	plan.With(object)
+	r.ds.Create(plan)
+
+	return false
+}
+
+func (r *Plan) Update(e event.UpdateEvent) bool {
+	Log.Reset()
+	o, cast := e.ObjectOld.(*migapi.MigPlan)
+	if !cast {
+		return false
+	}
+	n, cast := e.ObjectNew.(*migapi.MigPlan)
+	if !cast {
+		return false
+	}
+	changed := !reflect.DeepEqual(
+		o.Spec.SrcMigClusterRef,
+		n.Spec.SrcMigClusterRef) ||
+		!reflect.DeepEqual(
+			o.Spec.DestMigClusterRef,
+			n.Spec.DestMigClusterRef)
+	if changed {
+		plan := &model.Plan{}
+		plan.With(n)
+		r.ds.Update(plan)
+	}
+
+	return false
+}
+
+func (r *Plan) Delete(e event.DeleteEvent) bool {
+	Log.Reset()
+	object, cast := e.Object.(*migapi.MigPlan)
+	if !cast {
+		return false
+	}
+	plan := &model.Plan{}
+	plan.With(object)
+	r.ds.Delete(plan)
+
+	return false
+}
+
+func (r *Plan) Generic(e event.GenericEvent) bool {
+	return false
+}

--- a/pkg/controller/discovery/container/pod.go
+++ b/pkg/controller/discovery/container/pod.go
@@ -44,10 +44,8 @@ func (r *Pod) Reconcile() error {
 	r.hasReconciled = true
 	Log.Info(
 		"Pod (collection) reconciled.",
-		"ns",
-		r.ds.Cluster.Namespace,
-		"name",
-		r.ds.Cluster.Name,
+		"cluster",
+		r.ds.Name(),
 		"duration",
 		time.Since(mark))
 

--- a/pkg/controller/discovery/container/pv.go
+++ b/pkg/controller/discovery/container/pv.go
@@ -45,10 +45,8 @@ func (r *PV) Reconcile() error {
 	r.hasReconciled = true
 	Log.Info(
 		"PV (collection) reconciled.",
-		"ns",
-		r.ds.Cluster.Namespace,
-		"name",
-		r.ds.Cluster.Name,
+		"cluster",
+		r.ds.Name(),
 		"duration",
 		time.Since(mark))
 

--- a/pkg/controller/discovery/container/pvc.go
+++ b/pkg/controller/discovery/container/pvc.go
@@ -45,10 +45,8 @@ func (r *PVC) Reconcile() error {
 	r.hasReconciled = true
 	Log.Info(
 		"PVC (collection) reconciled.",
-		"ns",
-		r.ds.Cluster.Namespace,
-		"name",
-		r.ds.Cluster.Name,
+		"cluster",
+		r.ds.Name(),
 		"duration",
 		time.Since(mark))
 

--- a/pkg/controller/discovery/controller.go
+++ b/pkg/controller/discovery/controller.go
@@ -19,6 +19,7 @@ package discovery
 import (
 	"context"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/controller/discovery/auth"
 	"github.com/konveyor/mig-controller/pkg/controller/discovery/container"
 	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
 	"github.com/konveyor/mig-controller/pkg/controller/discovery/web"
@@ -49,6 +50,7 @@ func init() {
 	model.Log = &log
 	container.Log = &log
 	web.Log = &log
+	auth.Log = &log
 }
 
 func Add(mgr manager.Manager) error {
@@ -64,6 +66,8 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	if err != nil {
 		panic(err)
 	}
+	restCfg.Burst = 1000
+	restCfg.QPS = 100
 	nClient, err := client.New(
 		restCfg,
 		client.Options{
@@ -83,8 +87,6 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 		web:       web,
 	}
 
-	web.Start()
-
 	return &reconciler
 }
 
@@ -98,6 +100,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		log.Trace(err)
 		return err
 	}
+	//
+	// Add watches.
 	err = c.Watch(
 		&source.Kind{
 			Type: &migapi.MigCluster{},
@@ -108,18 +112,22 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		log.Trace(err)
 		return err
 	}
-	err = c.Watch(
-		&source.Kind{
-			Type: &migapi.MigPlan{},
+	//
+	// Add the `host` cluster.
+	cluster := &migapi.MigCluster{
+		Spec: migapi.MigClusterSpec{
+			IsHostCluster: true,
 		},
-		&handler.EnqueueRequestForObject{},
-		&PlanPredicate{
-			Container: r.(*ReconcileDiscovery).container,
-		})
-	if err != nil {
-		log.Trace(err)
-		return err
 	}
+	err = r.(*ReconcileDiscovery).container.Add(
+		cluster,
+		container.Collections{
+			&container.Namespace{},
+			&container.Plan{},
+		})
+	//
+	// Start Web
+	r.(*ReconcileDiscovery).web.Start()
 
 	return nil
 }
@@ -154,7 +162,15 @@ func (r *ReconcileDiscovery) Reconcile(request reconcile.Request) (reconcile.Res
 	if !r.IsValid(cluster) {
 		return reconcile.Result{}, nil
 	}
-	err = r.container.Add(cluster)
+	err = r.container.Add(
+		cluster,
+		container.Collections{
+			&container.Namespace{},
+			&container.Service{},
+			&container.PVC{},
+			&container.Pod{},
+			&container.PV{},
+		})
 	if err != nil {
 		log.Trace(err)
 		return reQueue, nil
@@ -220,75 +236,5 @@ func (r *ClusterPredicate) Delete(e event.DeleteEvent) bool {
 }
 
 func (r *ClusterPredicate) Generic(e event.GenericEvent) bool {
-	return false
-}
-
-//
-// Plan predicate
-type PlanPredicate struct {
-	Container *container.Container
-}
-
-func (r PlanPredicate) Create(e event.CreateEvent) bool {
-	log.Reset()
-	object, cast := e.Object.(*migapi.MigPlan)
-	if !cast {
-		return false
-	}
-	plan := model.Plan{}
-	plan.With(object)
-	err := plan.Insert(r.Container.Db)
-	if err != nil {
-		log.Trace(err)
-	}
-
-	return false
-}
-
-func (r PlanPredicate) Update(e event.UpdateEvent) bool {
-	log.Reset()
-	o, cast := e.ObjectOld.(*migapi.MigPlan)
-	if !cast {
-		return false
-	}
-	n, cast := e.ObjectNew.(*migapi.MigPlan)
-	if !cast {
-		return false
-	}
-	changed := !reflect.DeepEqual(
-		o.Spec.SrcMigClusterRef,
-		n.Spec.SrcMigClusterRef) ||
-		!reflect.DeepEqual(
-			o.Spec.DestMigClusterRef,
-			n.Spec.DestMigClusterRef)
-	if changed {
-		plan := model.Plan{}
-		plan.With(n)
-		err := plan.Update(r.Container.Db)
-		if err != nil {
-			log.Trace(err)
-		}
-	}
-
-	return false
-}
-
-func (r *PlanPredicate) Delete(e event.DeleteEvent) bool {
-	log.Reset()
-	object, cast := e.Object.(*migapi.MigPlan)
-	if !cast {
-		return false
-	}
-	plan := model.Plan{}
-	plan.With(object)
-	err := plan.Delete(r.Container.Db)
-	if err != nil {
-		log.Trace(err)
-	}
-
-	return false
-}
-
-func (r *PlanPredicate) Generic(e event.GenericEvent) bool {
 	return false
 }

--- a/pkg/controller/discovery/model/table.go
+++ b/pkg/controller/discovery/model/table.go
@@ -793,6 +793,19 @@ func (t Table) listSQL(table string, fields []*Field, options ListOptions) (stri
 //
 // Scan the fetch row into the model.
 // The model fields are updated.
+func (t Table) Scan(row Row, model interface{}) error {
+	fields, err := t.Fields(model)
+	if err != nil {
+		Log.Trace(err)
+		return err
+	}
+
+	return t.scan(row, fields)
+}
+
+//
+// Scan the fetch row into the model.
+// The model fields are updated.
 func (t Table) scan(row Row, fields []*Field) error {
 	list := []interface{}{}
 	for _, f := range fields {

--- a/pkg/controller/discovery/web/ns.go
+++ b/pkg/controller/discovery/web/ns.go
@@ -2,9 +2,12 @@ package web
 
 import (
 	"github.com/gin-gonic/gin"
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/controller/discovery/auth"
 	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
 	"k8s.io/api/core/v1"
 	"net/http"
+	"strings"
 )
 
 const (
@@ -16,15 +19,64 @@ const (
 // Namespaces (route) handler.
 type NsHandler struct {
 	// Base
-	ClusterScoped
+	BaseHandler
 }
 
 //
 // Add routes.
 func (h NsHandler) AddRoutes(r *gin.Engine) {
+	r.GET(strings.Split(Root, "/")[1], h.ListRoot)
+	r.GET(strings.Split(Root, "/")[1]+"/", h.ListRoot)
 	r.GET(NamespacesRoot, h.List)
 	r.GET(NamespacesRoot+"/", h.List)
 	r.GET(NamespaceRoot, h.Get)
+}
+
+//
+// List root namespaces.
+func (h NsHandler) ListRoot(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	db := h.container.Db
+	collection := model.Namespace{
+		Base: model.Base{
+			Cluster: h.cluster.PK,
+		},
+	}
+	list, err := collection.List(
+		db,
+		model.ListOptions{
+			Sort: []int{5},
+		})
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	list, err = h.hasBasic(list)
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	count := int64(len(list))
+	content := NamespaceList{
+		Items: []Namespace{},
+		Count: count,
+	}
+	h.page.Slice(list)
+	for _, m := range list {
+		content.Items = append(
+			content.Items,
+			Namespace{
+				Name: m.Name,
+			})
+	}
+
+	ctx.JSON(http.StatusOK, content)
 }
 
 //
@@ -41,16 +93,9 @@ func (h NsHandler) List(ctx *gin.Context) {
 			Cluster: h.cluster.PK,
 		},
 	}
-	count, err := collection.Count(db, model.ListOptions{})
-	if err != nil {
-		Log.Trace(err)
-		ctx.Status(http.StatusInternalServerError)
-		return
-	}
 	list, err := collection.List(
 		db,
 		model.ListOptions{
-			Page: &h.page,
 			Sort: []int{5},
 		})
 	if err != nil {
@@ -58,9 +103,18 @@ func (h NsHandler) List(ctx *gin.Context) {
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
+	list, err = h.hasRead(list)
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	count := int64(len(list))
 	content := NamespaceList{
+		Items: []Namespace{},
 		Count: count,
 	}
+	h.page.Slice(list)
 	for _, m := range list {
 		podCount, err := model.Pod{
 			Base: model.Base{
@@ -117,29 +171,111 @@ func (h NsHandler) List(ctx *gin.Context) {
 //
 // Get a specific namespace on a cluster.
 func (h NsHandler) Get(ctx *gin.Context) {
-	status := h.Prepare(ctx)
-	if status != http.StatusOK {
-		ctx.Status(status)
-		return
+	ctx.Status(http.StatusMethodNotAllowed)
+}
+
+//
+// Token has MIG-admin.
+func (h *NsHandler) hasAdmin() (bool, error) {
+	return h.rbac.Allow(&auth.Review{
+		Group:     migapi.SchemeGroupVersion.Group,
+		Namespace: auth.ALL,
+		Resource:  auth.ALL,
+		Verb:      auth.ALL,
+	})
+}
+
+//
+// Filter the list of namespaces by READ access.
+// Returns only those namespaces that the token has READ access.
+// Uses `hasAdmin()` as an optimization.  The check is fast and
+// efficient and may elliminate a large number of SAR.
+func (h *NsHandler) hasRead(models []*model.Namespace) ([]*model.Namespace, error) {
+	hasAdmin, err := h.hasAdmin()
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	if hasAdmin {
+		return models, nil
+	}
+	list := []*model.Namespace{}
+	for _, ns := range models {
+		allowed, err := h.rbac.Allow(&auth.Review{
+			Resource:  auth.Namespace,
+			Verb:      auth.GET,
+			Namespace: ns.Name,
+			Name:      ns.Name,
+		})
+		if err != nil {
+			Log.Trace(err)
+			return nil, err
+		}
+		if allowed {
+			list = append(list, ns)
+		}
 	}
 
-	ctx.JSON(http.StatusOK, h.cluster.Namespace)
+	return list, nil
+}
+
+//
+// Filter the list of namespaces by having MIG basic access.
+// Returns only those namespaces that the token has MIG basic access.
+// Uses `hasRead()` as an optimization. The check is fast and will
+// likely narrow down the list quickly which reduces the number
+// of SAR required.
+func (h *NsHandler) hasBasic(models []*model.Namespace) ([]*model.Namespace, error) {
+	hasAdmin, err := h.hasAdmin()
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	if hasAdmin {
+		return models, nil
+	}
+	models, err = h.hasRead(models)
+	if err != nil {
+		return nil, err
+	}
+	list := []*model.Namespace{}
+	for _, ns := range models {
+		allowed, err := h.rbac.AllowMatrix(&auth.Matrix{
+			Group: migapi.SchemeGroupVersion.Group,
+			Resources: []string{
+				"migplans",
+				"migstorages",
+				"migmigrations",
+				"migtokens",
+			},
+			Namespace: ns.Name,
+			Verbs: []string{
+				auth.ALL,
+			}})
+		if err != nil {
+			Log.Trace(err)
+			return nil, err
+		}
+		if allowed {
+			list = append(list, ns)
+		}
+	}
+
+	return list, err
 }
 
 // Namespace REST resource
 type Namespace struct {
-	// Cluster k8s namespace.
-	Namespace string `json:"namespace,omitempty"`
-	// Cluster k8s name.
+	// Namespace name.
 	Name string `json:"name"`
 	// Raw k8s object.
 	Object *v1.Namespace `json:"object,omitempty"`
 	// Number of services.
-	ServiceCount int64 `json:"serviceCount"`
+	ServiceCount int64 `json:"serviceCount,omitempty"`
 	// Number of pods.
-	PodCount int64 `json:"podCount"`
+	PodCount int64 `json:"podCount,omitempty"`
 	// Number of PVCs.
-	PvcCount int64 `json:"pvcCount"`
+	PvcCount int64 `json:"pvcCount,omitempty"`
 }
 
 //

--- a/pkg/controller/discovery/web/plan.go
+++ b/pkg/controller/discovery/web/plan.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"github.com/gin-gonic/gin"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/controller/discovery/auth"
 	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
-	auth "k8s.io/api/authorization/v1"
 	"k8s.io/api/core/v1"
 	"net/http"
 	"strings"
@@ -38,10 +38,12 @@ func (h PlanHandler) AddRoutes(r *gin.Engine) {
 
 //
 // Prepare to fulfil the request.
-// Fetch the referenced plan.
-// Perform SAR authorization.
 func (h *PlanHandler) Prepare(ctx *gin.Context) int {
 	status := h.BaseHandler.Prepare(ctx)
+	if status != http.StatusOK {
+		return status
+	}
+	status = h.allow(ctx)
 	if status != http.StatusOK {
 		return status
 	}
@@ -51,37 +53,27 @@ func (h *PlanHandler) Prepare(ctx *gin.Context) int {
 			Name:      ctx.Param("plan"),
 		},
 	}
-	err := h.plan.Get(h.container.Db)
-	if err != nil {
-		if err != sql.ErrNoRows {
-			Log.Trace(err)
-			return http.StatusInternalServerError
-		} else {
-			return http.StatusNotFound
-		}
-	}
-	status = h.allow(h.getSAR())
-	if status != http.StatusOK {
-		return status
-	}
 
 	return http.StatusOK
 }
 
-// Build the appropriate SAR object.
-// The subject is the MigPlan.
-func (h *PlanHandler) getSAR() auth.SelfSubjectAccessReview {
-	return auth.SelfSubjectAccessReview{
-		Spec: auth.SelfSubjectAccessReviewSpec{
-			ResourceAttributes: &auth.ResourceAttributes{
-				Group:     "apps",
-				Resource:  "MigPlan",
-				Namespace: h.plan.Namespace,
-				Name:      h.plan.Name,
-				Verb:      "get",
-			},
-		},
+//
+// RBAC authorization.
+func (h *PlanHandler) allow(ctx *gin.Context) int {
+	allowed, err := h.rbac.Allow(&auth.Review{
+		Namespace: h.cluster.Namespace,
+		Resource:  "migplan",
+		Verb:      auth.GET,
+	})
+	if err != nil {
+		Log.Trace(err)
+		return http.StatusInternalServerError
 	}
+	if !allowed {
+		return http.StatusForbidden
+	}
+
+	return http.StatusOK
 }
 
 //
@@ -107,6 +99,7 @@ func (h PlanHandler) List(ctx *gin.Context) {
 		return
 	}
 	content := PlanList{
+		Items: []Plan{},
 		Count: count,
 	}
 	for _, m := range list {

--- a/pkg/controller/discovery/web/pvc.go
+++ b/pkg/controller/discovery/web/pvc.go
@@ -3,6 +3,7 @@ package web
 import (
 	"database/sql"
 	"github.com/gin-gonic/gin"
+	"github.com/konveyor/mig-controller/pkg/controller/discovery/auth"
 	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
 	"k8s.io/api/core/v1"
 	"net/http"
@@ -17,7 +18,7 @@ const (
 // PVC (route) handler.
 type PvcHandler struct {
 	// Base
-	ClusterScoped
+	BaseHandler
 }
 
 //
@@ -26,6 +27,41 @@ func (h PvcHandler) AddRoutes(r *gin.Engine) {
 	r.GET(PvcsRoot, h.List)
 	r.GET(PvcsRoot+"/", h.List)
 	r.GET(PvcRoot, h.Get)
+}
+
+//
+// Prepare the handler to fulfil the request.
+// Perform RBAC authorization.
+func (h *PvcHandler) Prepare(ctx *gin.Context) int {
+	status := h.BaseHandler.Prepare(ctx)
+	if status != http.StatusOK {
+		return status
+	}
+	status = h.allow(ctx)
+	if status != http.StatusOK {
+		return status
+	}
+
+	return http.StatusOK
+}
+
+//
+// RBAC authorization.
+func (h *PvcHandler) allow(ctx *gin.Context) int {
+	allowed, err := h.rbac.Allow(&auth.Review{
+		Namespace: ctx.Param("ns2"),
+		Resource:  auth.PVC,
+		Verb:      auth.GET,
+	})
+	if err != nil {
+		Log.Trace(err)
+		return http.StatusInternalServerError
+	}
+	if !allowed {
+		return http.StatusForbidden
+	}
+
+	return http.StatusOK
 }
 
 //
@@ -39,7 +75,8 @@ func (h PvcHandler) List(ctx *gin.Context) {
 	db := h.container.Db
 	collection := model.PVC{
 		Base: model.Base{
-			Cluster: h.cluster.PK,
+			Cluster:   h.cluster.PK,
+			Namespace: ctx.Param("ns2"),
 		},
 	}
 	count, err := collection.Count(db, model.ListOptions{})
@@ -58,6 +95,7 @@ func (h PvcHandler) List(ctx *gin.Context) {
 		return
 	}
 	content := PvcList{
+		Items: []PVC{},
 		Count: count,
 	}
 	for _, pvc := range list {

--- a/pkg/controller/discovery/web/service.go
+++ b/pkg/controller/discovery/web/service.go
@@ -3,6 +3,7 @@ package web
 import (
 	"database/sql"
 	"github.com/gin-gonic/gin"
+	"github.com/konveyor/mig-controller/pkg/controller/discovery/auth"
 	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
 	"k8s.io/api/core/v1"
 	"net/http"
@@ -17,7 +18,7 @@ const (
 // Service (route) handler.
 type ServiceHandler struct {
 	// Base
-	ClusterScoped
+	BaseHandler
 }
 
 //
@@ -26,6 +27,41 @@ func (h ServiceHandler) AddRoutes(r *gin.Engine) {
 	r.GET(ServicesRoot, h.List)
 	r.GET(ServicesRoot+"/", h.List)
 	r.GET(ServiceRoot, h.Get)
+}
+
+//
+// Prepare the handler to fulfil the request.
+// Perform RBAC authorization.
+func (h *ServiceHandler) Prepare(ctx *gin.Context) int {
+	status := h.BaseHandler.Prepare(ctx)
+	if status != http.StatusOK {
+		return status
+	}
+	status = h.allow(ctx)
+	if status != http.StatusOK {
+		return status
+	}
+
+	return http.StatusOK
+}
+
+//
+// RBAC authorization.
+func (h *ServiceHandler) allow(ctx *gin.Context) int {
+	allowed, err := h.rbac.Allow(&auth.Review{
+		Namespace: ctx.Param("ns2"),
+		Resource:  auth.Service,
+		Verb:      auth.GET,
+	})
+	if err != nil {
+		Log.Trace(err)
+		return http.StatusInternalServerError
+	}
+	if !allowed {
+		return http.StatusForbidden
+	}
+
+	return http.StatusOK
 }
 
 //
@@ -39,7 +75,8 @@ func (h ServiceHandler) List(ctx *gin.Context) {
 	db := h.container.Db
 	collection := model.Service{
 		Base: model.Base{
-			Cluster: h.cluster.PK,
+			Cluster:   h.cluster.PK,
+			Namespace: ctx.Param("ns2"),
 		},
 	}
 	count, err := collection.Count(db, model.ListOptions{})
@@ -58,6 +95,7 @@ func (h ServiceHandler) List(ctx *gin.Context) {
 		return
 	}
 	content := ServiceList{
+		Items: []Service{},
 		Count: count,
 	}
 	for _, service := range list {

--- a/pkg/controller/discovery/web/user.go
+++ b/pkg/controller/discovery/web/user.go
@@ -1,0 +1,68 @@
+package web
+
+import (
+	"github.com/gin-gonic/gin"
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/controller/discovery/auth"
+	"net/http"
+)
+
+// User route roots.
+const (
+	UserRoot = Root + "/auth"
+)
+
+//
+// Cluster (route) handler.
+type UserHandler struct {
+	// Base
+	BaseHandler
+}
+
+//
+// Add routes.
+func (h UserHandler) AddRoutes(r *gin.Engine) {
+	r.GET(UserRoot, h.Get)
+}
+
+//
+// List users.
+func (h UserHandler) List(ctx *gin.Context) {
+	ctx.Status(http.StatusMethodNotAllowed)
+}
+
+//
+// Get a cluster user.
+func (h UserHandler) Get(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	allowed, err := h.rbac.Allow(
+		&auth.Review{
+			Group:     migapi.SchemeGroupVersion.Group,
+			Namespace: ctx.Param("ns1"),
+			Resource:  auth.ALL,
+			Verb:      auth.ALL,
+		})
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	content := User{
+		Authenticated: h.rbac.Authenticated(),
+		HasAdmin:      allowed,
+	}
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Cluster authorization
+type User struct {
+	Authenticated bool `json:"Authenticated"`
+	// User has admin.
+	HasAdmin bool `json:"hasAdmin"`
+}

--- a/pkg/controller/discovery/web/wellknown.go
+++ b/pkg/controller/discovery/web/wellknown.go
@@ -1,0 +1,92 @@
+package web
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"github.com/gin-gonic/gin"
+	"io/ioutil"
+	"k8s.io/client-go/rest"
+	"net/http"
+)
+
+// Route roots.
+const (
+	WellKnownRoot = ClusterRoot + WellKnown
+	WellKnown     = "/.well-known/oauth-authorization-server"
+)
+
+//
+// Cluster (route) handler.
+type WellKnownHandler struct {
+	BaseHandler
+}
+
+//
+// Add routes.
+func (h WellKnownHandler) AddRoutes(r *gin.Engine) {
+	r.GET(WellKnownRoot, h.Get)
+}
+
+//
+// Get the well-know oauth information.
+func (h WellKnownHandler) Get(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	cluster := h.cluster.DecodeObject()
+	restCfg, err := cluster.BuildRestConfig(h.container.Client)
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	url := restCfg.Host + WellKnown
+	client, err := h.client(restCfg)
+	r, err := client.Get(url)
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	if r.StatusCode != http.StatusOK {
+		ctx.Status(r.StatusCode)
+		return
+	}
+	defer r.Body.Close()
+	content := map[string]interface{}{}
+	body, err := ioutil.ReadAll(r.Body)
+	err = json.Unmarshal(body, &content)
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Build the http client.
+func (h *WellKnownHandler) client(restCfg *rest.Config) (*http.Client, error) {
+	pool := x509.NewCertPool()
+	if restCfg.TLSClientConfig.CAData != nil {
+		pool.AppendCertsFromPEM(restCfg.TLSClientConfig.CAData)
+	}
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: restCfg.TLSClientConfig.Insecure,
+			RootCAs:            pool,
+		},
+	}
+	client := &http.Client{Transport: tr}
+	return client, nil
+}
+
+//
+// List.
+func (h WellKnownHandler) List(ctx *gin.Context) {
+	ctx.Status(http.StatusMethodNotAllowed)
+}


### PR DESCRIPTION
Add support for non-admin.
Changes:
- Change authorization model to perform SAR for specific resource being requested.
- Add _/wellknown_ endpoint needed by the UI to renew tokens.
- Add _/auth_ endpoint needed by the UI to determine if token (user) has (MIG) admin on a specific namespace.
- Included a fix done in earlier versions of non-admin.  Mainly, that it inventories MigPlan like any other resource.  This fixes the problem of not detecting a plan has been deleted while the controller is down.