### PR TITLE
fixes bug 1845090: compare namespaces when checking prior stage pods

### DIFF
--- a/pkg/controller/migmigration/stage.go
+++ b/pkg/controller/migmigration/stage.go
@@ -74,6 +74,9 @@ func BuildStagePods(labels map[string]string,
 }
 
 func (p StagePod) volumesContained(pod StagePod) bool {
+	if p.Namespace != pod.Namespace {
+		return false
+	}
 	for _, volume := range p.Spec.Volumes {
 		found := false
 		for _, targetVolume := range pod.Spec.Volumes {


### PR DESCRIPTION
The stage pod code iterates over all migrated namespaces, but when
comparing whether the current pod is already in the list of stage pods
take namespace into account.