### PR TITLE
bug 1845157: Don't quiesce ReplicaSets with owner refs

### DIFF
--- a/pkg/controller/migmigration/quiesce.go
+++ b/pkg/controller/migmigration/quiesce.go
@@ -339,6 +339,10 @@ func (t *Task) quiesceReplicaSets(client k8sclient.Client) error {
 			return err
 		}
 		for _, set := range list.Items {
+			if len(set.OwnerReferences) > 0 {
+				t.Log.Info("Quiesce skipping ReplicaSet, has OwnerReferences", "name", set.Name)
+				continue
+			}
 			if set.Annotations == nil {
 				set.Annotations = make(map[string]string)
 			}
@@ -371,6 +375,10 @@ func (t *Task) unQuiesceReplicaSets(client k8sclient.Client) error {
 			return err
 		}
 		for _, set := range list.Items {
+			if len(set.OwnerReferences) > 0 {
+				t.Log.Info("Unquiesce skipping ReplicaSet, has OwnerReferences", "name", set.Name)
+				continue
+			}
 			if set.Annotations == nil {
 				continue
 			}


### PR DESCRIPTION
ReplicaSets can exist standalone or as part of a Deployment.
Standalone ReplicaSets should be quiesced, but Deployment
ReplicaSets should not -- the Deployment quiesce will handle it
and without skipping it, we run into a race condition with
two things modifying the ReplicaSet at once.