### PR TITLE
Bug 1846521: Add fallback to parse gitVersion when version.Major/Minor not available

### DIFF
--- a/pkg/compat/client.go
+++ b/pkg/compat/client.go
@@ -59,15 +59,30 @@ func NewClient(restCfg *rest.Config) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	// Attempt parsing version.Major/Minor first, fall back to parsing gitVersion
 	major, err1 := strconv.Atoi(version.Major)
 	minor, err2 := strconv.Atoi(strings.Trim(version.Minor, "+"))
+
 	if err1 != nil || err2 != nil {
-		major, minor, err = parseGitVersion(version.GitVersion)
+		// gitVersion format ("v1.11.0+d4cacc0")
+		r, _ := regexp.Compile(`v[0-9]+\.[0-9]+`)
+		valid := r.MatchString(version.GitVersion)
+		if !valid {
+			return nil, errors.New("gitVersion does not match expected format")
+		}
+		majorMinorArr := strings.Split(strings.Split(version.GitVersion, "v")[1], ".")
+
+		major, err = strconv.Atoi(majorMinorArr[0])
+		if err != nil {
+			return nil, err
+		}
+		minor, err = strconv.Atoi(majorMinorArr[1])
 		if err != nil {
 			return nil, err
 		}
 	}
+
 	nClient := &client{
 		Config:             restCfg,
 		Client:             rClient,
@@ -221,32 +236,4 @@ func (c client) Update(ctx context.Context, in runtime.Object) error {
 		return err
 	}
 	return c.Client.Update(ctx, obj)
-}
-
-//
-// Parses gitVersion ("v1.11.0+d4cacc0"), returns major, minor, err
-func parseGitVersion(gitVersion string) (int, int, error) {
-	r, _ := regexp.Compile(`v[0-9]+\.[0-9]+`)
-	valid := r.MatchString(gitVersion)
-	if !valid {
-		return 0, 0, errors.New("gitVersion does not match expected format")
-	}
-	versionArr := strings.Split(gitVersion, "v")
-	if len(versionArr) < 2 {
-		return 0, 0, errors.New("gitVersion missing leading 'v'")
-	}
-	majorMinorArr := strings.Split(versionArr[1], ".")
-	if len(majorMinorArr) < 2 {
-		return 0, 0, errors.New("gitVersion major + minor parse failed")
-	}
-
-	major, err := strconv.Atoi(majorMinorArr[0])
-	if err != nil {
-		return 0, 0, err
-	}
-	minor, err := strconv.Atoi(majorMinorArr[1])
-	if err != nil {
-		return 0, 0, err
-	}
-	return major, minor, nil
 }

--- a/pkg/compat/client.go
+++ b/pkg/compat/client.go
@@ -66,7 +66,7 @@ func NewClient(restCfg *rest.Config) (Client, error) {
 
 	if err1 != nil || err2 != nil {
 		// gitVersion format ("v1.11.0+d4cacc0")
-		r, _ := regexp.Compile(`v[0-9]+\.[0-9]+`)
+		r, _ := regexp.Compile(`v[0-9]+\.[0-9]+\.`)
 		valid := r.MatchString(version.GitVersion)
 		if !valid {
 			return nil, errors.New("gitVersion does not match expected format")


### PR DESCRIPTION
We have found cases where an OCP cluster does not provide the `major` and `minor` fields in the response from the `version` endpoint. Example below.

```
Response Body: {
  "major": "",
  "minor": "",
  "gitVersion": "v1.9.1+a0ce1bc657",
  "gitCommit": "a0ce1bc",
  "gitTreeState": "clean",
  "buildDate": "2018-04-26T16:48:23Z",
  "goVersion": "go1.9.4",
  "compiler": "gc",
  "platform": "linux/amd64"
}
```

These missing fields are breaking our `compat` client, which relies on knowing the cluster version.

In these cases, we can parse the `gitVersion` field as a fallback. We will still use the major/minor fields by default.

---

**Tracking Links**
https://bugzilla.redhat.com/show_bug.cgi?id=1846521
https://issues.redhat.com/browse/MIG-261

Related plugin PR: https://github.com/konveyor/openshift-migration-plugin/pull/65