### PR TITLE
Exclude templateinstances from backups

### DIFF
--- a/pkg/controller/migcluster/remote_watch.go
+++ b/pkg/controller/migcluster/remote_watch.go
@@ -63,8 +63,9 @@ func StartRemoteWatch(r *ReconcileMigCluster, config remote.ManagerConfig) error
 
 	sigStopChan := make(chan struct{})
 	log.Info("[rWatch] Starting manager")
-	log.Info("[HF] HotFix #2")
-	log.Info("[HF] Added imagestreamtags to backup exclusion list")
+	log.Info("[HF] HotFix #3")
+	log.Info("[HF] HF#2: Added imagestreamtags to backup exclusion list")
+	log.Info("[HF] HF#3: Added templateinstances to backup exclusion list, prevents templateinstance set username privilege error")
 	go mgr.Start(sigStopChan)
 
 	log.Info("[rWatch] Manager started")

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -148,7 +148,7 @@ func (r *ReconcileMigMigration) getBackupResources(migration *migapi.MigMigratio
 // Get the resources to be excluded from backup
 func (r *ReconcileMigMigration) getExcludedResources(migration *migapi.MigMigration) []string {
 	if Settings.Migration.DisableImageMigration {
-		return []string{"imagestreams", "imagestreamtags"}
+		return []string{"imagestreams", "imagestreamtags", "templateinstances"}
 	}
-	return []string{}
+	return []string{"templateinstances"}
 }


### PR DESCRIPTION
Prevents the migration error:

"spec.requester.username: Forbidden: you do not have permission to set username]."