### PR TITLE
Fix plan/pods endpoint.

### DIFF
--- a/pkg/controller/discovery/web/plan.go
+++ b/pkg/controller/discovery/web/plan.go
@@ -150,6 +150,17 @@ func (h PlanHandler) Pods(ctx *gin.Context) {
 		ctx.Status(status)
 		return
 	}
+	err := h.plan.Get(h.container.Db)
+	if err != nil {
+		if err != sql.ErrNoRows {
+			Log.Trace(err)
+			ctx.Status(http.StatusInternalServerError)
+			return
+		} else {
+			ctx.Status(http.StatusNotFound)
+			return
+		}
+	}
 	content := PlanPods{}
 	content.With(ctx, &h)
 


### PR DESCRIPTION
Getting the referenced MigPlan moved from handler `Prepare()` to individual methods as part of Auth refactoring for non-admin.

The method for the `/plans/<plan>/pods` endpoint got missed.
