### PR TITLE
Fix NFS PVC validation for move action only

### DIFF
--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -1206,7 +1206,8 @@ func (r *NfsValidation) validate() error {
 	server := map[string]bool{}
 	for i := range r.Plan.Spec.PersistentVolumes.List {
 		pv := &r.Plan.Spec.PersistentVolumes.List[i]
-		if pv.NFS == nil {
+		// Skip non-NFS PVs and PVs which data should be copied
+		if pv.NFS == nil || pv.Selection.Action == "copy" {
 			continue
 		}
 		if passed, found := server[pv.NFS.Server]; found {


### PR DESCRIPTION
NFS accessibility validation is not needed when PVC data should be copied to the destination (and not moved).

Updated PVC validation not to be executed on copy action.

Fixes https://github.com/konveyor/mig-controller/issues/558