### PR TITLE
Common storage backend for all migplans sharing a migstorage

### DIFF
--- a/pkg/controller/migplan/registry.go
+++ b/pkg/controller/migplan/registry.go
@@ -151,7 +151,7 @@ func (r ReconcileMigPlan) ensureRegistryImageStream(client k8sclient.Client, pla
 // Ensure the deploymentconfig for the migration registry on the specified cluster has been created
 func (r ReconcileMigPlan) ensureRegistryDC(client k8sclient.Client, plan *migapi.MigPlan, storage *migapi.MigStorage, secret *kapi.Secret) error {
 	name := secret.GetName()
-	dirName := plan.GetName() + "-registry-" + string(plan.UID)
+	dirName := storage.GetName() + "-registry-" + string(storage.UID)
 
 	// Get Proxy Env Vars for DC
 	proxySecret, err := plan.GetRegistryProxySecret(client)


### PR DESCRIPTION
This is intended enable performance gain of same image layers
referenced across multiple migplans

Perf/scale tracking issue: https://github.com/konveyor/mig-controller/issues/597