### PR TITLE
Add round trip time metric to compat client

### DIFF
--- a/pkg/compat/client.go
+++ b/pkg/compat/client.go
@@ -190,10 +190,10 @@ func (c client) Get(ctx context.Context, key k8sclient.ObjectKey, in runtime.Obj
 	if err != nil {
 		return err
 	}
-	elapsed := float64(time.Since(start).Milliseconds())
+	elapsed := float64(time.Since(start) / nanoToMilli)
 
 	RequestRTTMetrics.Get(c, in, elapsed)
-	RequestCountMetrics.Get(c, in, One)
+	RequestCountMetrics.Get(c, in, one)
 
 	return c.upConvert(ctx, obj, in)
 }
@@ -212,9 +212,9 @@ func (c client) List(ctx context.Context, opt *k8sclient.ListOptions, in runtime
 	if err != nil {
 		return err
 	}
-	elapsed := float64(time.Since(start).Milliseconds())
+	elapsed := float64(time.Since(start) / nanoToMilli)
 
-	RequestCountMetrics.List(c, in, One)
+	RequestCountMetrics.List(c, in, one)
 	RequestRTTMetrics.List(c, in, elapsed)
 
 	return c.upConvert(ctx, obj, in)
@@ -229,13 +229,13 @@ func (c client) Create(ctx context.Context, in runtime.Object) error {
 	}
 
 	start := time.Now()
-	res := c.Client.Create(ctx, obj)
-	elapsed := float64(time.Since(start).Milliseconds())
+	err = c.Client.Create(ctx, obj)
+	elapsed := float64(time.Since(start) / nanoToMilli)
 
-	RequestCountMetrics.Create(c, in, One)
+	RequestCountMetrics.Create(c, in, one)
 	RequestRTTMetrics.Create(c, in, elapsed)
 
-	return res
+	return err
 }
 
 // Delete the specified resource.
@@ -247,13 +247,13 @@ func (c client) Delete(ctx context.Context, in runtime.Object, opt ...k8sclient.
 	}
 
 	start := time.Now()
-	res := c.Client.Delete(ctx, obj, opt...)
-	elapsed := float64(time.Since(start).Milliseconds())
+	err = c.Client.Delete(ctx, obj, opt...)
+	elapsed := float64(time.Since(start) / nanoToMilli)
 
-	RequestCountMetrics.Delete(c, in, One)
+	RequestCountMetrics.Delete(c, in, one)
 	RequestRTTMetrics.Delete(c, in, elapsed)
 
-	return res
+	return err
 }
 
 // Update the specified resource.
@@ -265,11 +265,11 @@ func (c client) Update(ctx context.Context, in runtime.Object) error {
 	}
 
 	start := time.Now()
-	res := c.Client.Update(ctx, obj)
-	elapsed := float64(time.Since(start).Milliseconds())
+	err = c.Client.Update(ctx, obj)
+	elapsed := float64(time.Since(start) / nanoToMilli)
 
-	RequestCountMetrics.Update(c, in, One)
+	RequestCountMetrics.Update(c, in, one)
 	RequestRTTMetrics.Update(c, in, elapsed)
 
-	return res
+	return err
 }

--- a/pkg/compat/client.go
+++ b/pkg/compat/client.go
@@ -191,9 +191,7 @@ func (c client) Get(ctx context.Context, key k8sclient.ObjectKey, in runtime.Obj
 		return err
 	}
 	elapsed := float64(time.Since(start) / nanoToMilli)
-
-	RequestRTTMetrics.Get(c, in, elapsed)
-	RequestCountMetrics.Get(c, in, one)
+	Metrics.Get(c, in, elapsed)
 
 	return c.upConvert(ctx, obj, in)
 }
@@ -213,9 +211,7 @@ func (c client) List(ctx context.Context, opt *k8sclient.ListOptions, in runtime
 		return err
 	}
 	elapsed := float64(time.Since(start) / nanoToMilli)
-
-	RequestCountMetrics.List(c, in, one)
-	RequestRTTMetrics.List(c, in, elapsed)
+	Metrics.List(c, in, elapsed)
 
 	return c.upConvert(ctx, obj, in)
 }
@@ -231,9 +227,7 @@ func (c client) Create(ctx context.Context, in runtime.Object) error {
 	start := time.Now()
 	err = c.Client.Create(ctx, obj)
 	elapsed := float64(time.Since(start) / nanoToMilli)
-
-	RequestCountMetrics.Create(c, in, one)
-	RequestRTTMetrics.Create(c, in, elapsed)
+	Metrics.Create(c, in, elapsed)
 
 	return err
 }
@@ -249,9 +243,7 @@ func (c client) Delete(ctx context.Context, in runtime.Object, opt ...k8sclient.
 	start := time.Now()
 	err = c.Client.Delete(ctx, obj, opt...)
 	elapsed := float64(time.Since(start) / nanoToMilli)
-
-	RequestCountMetrics.Delete(c, in, one)
-	RequestRTTMetrics.Delete(c, in, elapsed)
+	Metrics.Delete(c, in, elapsed)
 
 	return err
 }
@@ -267,9 +259,7 @@ func (c client) Update(ctx context.Context, in runtime.Object) error {
 	start := time.Now()
 	err = c.Client.Update(ctx, obj)
 	elapsed := float64(time.Since(start) / nanoToMilli)
-
-	RequestCountMetrics.Update(c, in, one)
-	RequestRTTMetrics.Update(c, in, elapsed)
+	Metrics.Update(c, in, elapsed)
 
 	return err
 }

--- a/pkg/compat/metrics.go
+++ b/pkg/compat/metrics.go
@@ -77,32 +77,32 @@ type Reporter struct {
 
 //
 // Report `get` API call.
-func (m *Reporter) Get(client Client, object api.Object, count float64) {
-	m.report(client, Get, object, count)
+func (m *Reporter) Get(client Client, object api.Object, increment float64) {
+	m.report(client, Get, object, increment)
 }
 
 //
 // Report `list` API call.
-func (m *Reporter) List(client Client, object api.Object, count float64) {
-	m.report(client, List, object, count)
+func (m *Reporter) List(client Client, object api.Object, increment float64) {
+	m.report(client, List, object, increment)
 }
 
 //
 // Report `create` API call.
-func (m *Reporter) Create(client Client, object api.Object, count float64) {
-	m.report(client, Create, object, count)
+func (m *Reporter) Create(client Client, object api.Object, increment float64) {
+	m.report(client, Create, object, increment)
 }
 
 //
 // Report `update` API call.
-func (m *Reporter) Update(client Client, object api.Object, count float64) {
-	m.report(client, Update, object, count)
+func (m *Reporter) Update(client Client, object api.Object, increment float64) {
+	m.report(client, Update, object, increment)
 }
 
 //
 // Report `delete` API call.
-func (m *Reporter) Delete(client Client, object api.Object, count float64) {
-	m.report(client, Delete, object, count)
+func (m *Reporter) Delete(client Client, object api.Object, increment float64) {
+	m.report(client, Delete, object, increment)
 }
 
 //
@@ -137,7 +137,7 @@ func (m *Reporter) context() (component, function string) {
 
 //
 // Report the API call.
-func (m *Reporter) report(client Client, method string, object api.Object, count float64) {
+func (m *Reporter) report(client Client, method string, object api.Object, increment float64) {
 	component, function := m.context()
 	m.counter.With(
 		prometheus.Labels{
@@ -146,5 +146,5 @@ func (m *Reporter) report(client Client, method string, object api.Object, count
 			Function:  function,
 			Kind:      ref.ToKind(object),
 			Method:    method,
-		}).Add(float64(count))
+		}).Add(increment)
 }

--- a/pkg/compat/metrics.go
+++ b/pkg/compat/metrics.go
@@ -23,7 +23,13 @@ const (
 	Function  = "function"
 	Kind      = "kind"
 	Method    = "method"
-	One       = 1.0
+)
+
+//
+// Numeric metrics consts
+const (
+	one         = 1
+	nanoToMilli = 1e6
 )
 
 //
@@ -140,5 +146,5 @@ func (m *Reporter) report(client Client, method string, object api.Object, count
 			Function:  function,
 			Kind:      ref.ToKind(object),
 			Method:    method,
-		}).Add(count)
+		}).Add(float64(count))
 }


### PR DESCRIPTION
**Summary**

- Renames `mtc_client` to `mtc_client_count`
- Introduces `mtc_client_rtt`

Provides cumulative milliseconds spent waiting for each type of request to return from APIserver.

Closes #606 