### PR TITLE
Bug 1861904: Skip listing GVKs as incompatible if in excluded list

### DIFF
--- a/pkg/controller/migmigration/backup.go
+++ b/pkg/controller/migmigration/backup.go
@@ -8,6 +8,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	liberr "github.com/konveyor/controller/pkg/error"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/settings"
 	"github.com/pkg/errors"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,8 +38,8 @@ func (t *Task) ensureInitialBackup() (*velero.Backup, error) {
 		return nil, liberr.Wrap(err)
 	}
 	newBackup.Labels[InitialBackupLabel] = t.UID()
-	newBackup.Spec.IncludedResources = toStringSlice(includedInitialResources.Difference(toSet(t.PlanResources.MigPlan.Status.ExcludedResources)))
-	newBackup.Spec.ExcludedResources = toStringSlice(excludedInitialResources.Union(toSet(t.PlanResources.MigPlan.Status.ExcludedResources)))
+	newBackup.Spec.IncludedResources = toStringSlice(settings.IncludedInitialResources.Difference(toSet(t.PlanResources.MigPlan.Status.ExcludedResources)))
+	newBackup.Spec.ExcludedResources = toStringSlice(settings.ExcludedInitialResources.Union(toSet(t.PlanResources.MigPlan.Status.ExcludedResources)))
 	delete(newBackup.Annotations, QuiesceAnnotation)
 	err = client.Create(context.TODO(), newBackup)
 	if err != nil {
@@ -95,8 +96,8 @@ func (t *Task) ensureStageBackup() (*velero.Backup, error) {
 		},
 	}
 	newBackup.Labels[StageBackupLabel] = t.UID()
-	newBackup.Spec.IncludedResources = toStringSlice(includedStageResources.Difference(toSet(t.PlanResources.MigPlan.Status.ExcludedResources)))
-	newBackup.Spec.ExcludedResources = toStringSlice(excludedStageResources.Union(toSet(t.PlanResources.MigPlan.Status.ExcludedResources)))
+	newBackup.Spec.IncludedResources = toStringSlice(settings.IncludedStageResources.Difference(toSet(t.PlanResources.MigPlan.Status.ExcludedResources)))
+	newBackup.Spec.ExcludedResources = toStringSlice(settings.ExcludedStageResources.Union(toSet(t.PlanResources.MigPlan.Status.ExcludedResources)))
 	newBackup.Spec.LabelSelector = &labelSelector
 	err = client.Create(context.TODO(), newBackup)
 	if err != nil {

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -23,29 +23,10 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	liberr "github.com/konveyor/controller/pkg/error"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/settings"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-// Backup resources.
-var includedInitialResources = mapset.NewSetFromSlice([]interface{}{})
-var includedStageResources = mapset.NewSetFromSlice([]interface{}{
-	"serviceaccount",
-	"persistentvolumes",
-	"persistentvolumeclaims",
-	"namespaces",
-	"imagestreams",
-	"imagestreamtags",
-	"secrets",
-	"configmaps",
-	"pods",
-})
-
-var excludedInitialResources = mapset.NewSetFromSlice([]interface{}{
-	"persistentvolumes",
-	"persistentvolumeclaims",
-})
-var excludedStageResources = mapset.NewSetFromSlice([]interface{}{})
 
 // Perform the migration.
 func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (time.Duration, error) {
@@ -143,7 +124,7 @@ func (r *ReconcileMigMigration) getAnnotations(migration *migapi.MigMigration) m
 // Get the resources (kinds) to be included in the backup.
 func (r *ReconcileMigMigration) getBackupResources(migration *migapi.MigMigration) mapset.Set {
 	if migration.Spec.Stage {
-		return includedStageResources
+		return settings.IncludedStageResources
 	}
-	return excludedStageResources
+	return settings.ExcludedStageResources
 }

--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -80,6 +80,7 @@ func (r *Compare) Compare() (map[string][]schema.GroupVersionResource, error) {
 	}
 
 	// Remove GVKs from list that are already excluded manually
+	// Where do I get the list of GVKs that has been excluded manually?
 
 	return r.collectIncompatibleMapping(incompatibleGVKs)
 }

--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -79,6 +79,8 @@ func (r *Compare) Compare() (map[string][]schema.GroupVersionResource, error) {
 		return nil, err
 	}
 
+	// Remove GVKs from list that are already excluded manually
+
 	return r.collectIncompatibleMapping(incompatibleGVKs)
 }
 

--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -1,7 +1,6 @@
 package gvk
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 
@@ -87,10 +86,7 @@ func (r *Compare) Compare() (map[string][]schema.GroupVersionResource, error) {
 	}
 
 	// Don't report an incompatibleGVK if user settings will skip resource anyways
-	log.Info(fmt.Sprintf("Pre-filter GVK list: %v", incompatibleGVKs))
 	excludedResources := toStringSlice(settings.ExcludedInitialResources.Union(toSet(r.Plan.Status.ExcludedResources)))
-	log.Info(fmt.Sprintf("Found excludedResources: %v", excludedResources))
-
 	filteredGVKs := []schema.GroupVersionResource{}
 	for _, gvr := range incompatibleGVKs {
 		skip := false
@@ -103,8 +99,6 @@ func (r *Compare) Compare() (map[string][]schema.GroupVersionResource, error) {
 			filteredGVKs = append(filteredGVKs, gvr)
 		}
 	}
-
-	log.Info(fmt.Sprintf("Post-filter GVK list: %v", filteredGVKs))
 
 	return r.collectIncompatibleMapping(filteredGVKs)
 }

--- a/pkg/settings/plan.go
+++ b/pkg/settings/plan.go
@@ -3,6 +3,8 @@ package settings
 import (
 	"os"
 	"strings"
+
+	mapset "github.com/deckarep/golang-set"
 )
 
 // Environment variables.
@@ -12,6 +14,27 @@ const (
 	PvLimit           = "PV_LIMIT"
 	ExcludedResources = "EXCLUDED_RESOURCES"
 )
+
+// Included resource defaults
+var IncludedInitialResources = mapset.NewSetFromSlice([]interface{}{})
+var IncludedStageResources = mapset.NewSetFromSlice([]interface{}{
+	"serviceaccount",
+	"persistentvolumes",
+	"persistentvolumeclaims",
+	"namespaces",
+	"imagestreams",
+	"imagestreamtags",
+	"secrets",
+	"configmaps",
+	"pods",
+})
+
+// Excluded resource defaults
+var ExcludedInitialResources = mapset.NewSetFromSlice([]interface{}{
+	"persistentvolumes",
+	"persistentvolumeclaims",
+})
+var ExcludedStageResources = mapset.NewSetFromSlice([]interface{}{})
 
 // Plan settings.
 //   NsLimit: Maximum number of namespaces on a Plan.


### PR DESCRIPTION
[BZ 1861904](https://bugzilla.redhat.com/show_bug.cgi?id=1861904)

**Summary**

- Moved defaults for included and excluded kinds to `Settings` so that these are accessible to multiple places in the controller as needed

_Snippet from Plan settings_
```
var IncludedInitialResources = mapset.NewSetFromSlice([]interface{}{})
var IncludedStageResources = mapset.NewSetFromSlice([]interface{}{
	"serviceaccount",
	"persistentvolumes",
	"persistentvolumeclaims",
	"namespaces",
	"imagestreams",
	"imagestreamtags",
	"secrets",
	"configmaps",
	"pods",
})

// Excluded resource defaults
var ExcludedInitialResources = mapset.NewSetFromSlice([]interface{}{
	"persistentvolumes",
	"persistentvolumeclaims",
})
var ExcludedStageResources = mapset.NewSetFromSlice([]interface{}{})
```
- Added logic to Incompatible GVK calculation to drop GVKs from list if excluded from migration anyways.