### PR TITLE
Bug  1861904:  Reorder MigPlan reconcile so excludedResources are not shown as incompatible

### DIFF
--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -205,15 +205,15 @@ func (r *ReconcileMigPlan) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{Requeue: true}, nil
 	}
 
-	// Validations.
-	err = r.validate(plan)
+	// Set excluded resources on Status.
+	err = r.setExcludedResourceList(plan)
 	if err != nil {
 		log.Trace(err)
 		return reconcile.Result{Requeue: true}, nil
 	}
 
-	// Set excluded resources on Status.
-	err = r.setExcludedResourceList(plan)
+	// Validations.
+	err = r.validate(plan)
 	if err != nil {
 		log.Trace(err)
 		return reconcile.Result{Requeue: true}, nil


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1861904

Tested. Seems that  the correct results appears on the first reconcile now.