### PR TITLE
Introducing labels to help identify parent resources 

### DIFF
--- a/pkg/apis/migration/v1alpha1/labels.go
+++ b/pkg/apis/migration/v1alpha1/labels.go
@@ -11,6 +11,7 @@ import (
 const (
 	PartOfLabel = "app.kubernetes.io/part-of" // = Application
 	Application = "openshift-migration"
+	ParentLabel = "migration.openshift.io/parent-name"
 )
 
 // Build label (key, value) used to correlate CRs.

--- a/pkg/apis/migration/v1alpha1/labels.go
+++ b/pkg/apis/migration/v1alpha1/labels.go
@@ -11,7 +11,6 @@ import (
 const (
 	PartOfLabel = "app.kubernetes.io/part-of" // = Application
 	Application = "openshift-migration"
-	ParentLabel = "migration.openshift.io/parent-name"
 )
 
 // Build label (key, value) used to correlate CRs.

--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -54,6 +54,14 @@ const (
 	// for easy search or application rollback.
 	// The value is the Task.UID().
 	MigratedByLabel = "migration.openshift.io/migrated-by" // (migmigration UID)
+	// Identifies associated migmigration
+	// to assist manual debugging
+	// The value is Task.Owner.Name
+	MigMigrationDebugLabel = "migmigration-name"
+	// Identifies associated migplan
+	// to assist manual debugging
+	// The value is Task.Owner.Spec.migPlanRef.Name
+	MigPlanDebugLabel = "migplan-name"
 )
 
 // Set of Service Accounts.

--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -57,11 +57,11 @@ const (
 	// Identifies associated migmigration
 	// to assist manual debugging
 	// The value is Task.Owner.Name
-	MigMigrationDebugLabel = "migmigration-name"
+	MigMigrationDebugLabel = "migration.openshift.io/migmigration-name"
 	// Identifies associated migplan
 	// to assist manual debugging
 	// The value is Task.Owner.Spec.migPlanRef.Name
-	MigPlanDebugLabel = "migplan-name"
+	MigPlanDebugLabel = "migration.openshift.io/migplan-name"
 )
 
 // Set of Service Accounts.

--- a/pkg/controller/migmigration/backup.go
+++ b/pkg/controller/migmigration/backup.go
@@ -38,6 +38,7 @@ func (t *Task) ensureInitialBackup() (*velero.Backup, error) {
 		return nil, liberr.Wrap(err)
 	}
 	newBackup.Labels[InitialBackupLabel] = t.UID()
+	newBackup.Labels[migapi.ParentLabel] = t.Owner.Name
 	newBackup.Spec.IncludedResources = toStringSlice(settings.IncludedInitialResources.Difference(toSet(t.PlanResources.MigPlan.Status.ExcludedResources)))
 	newBackup.Spec.ExcludedResources = toStringSlice(settings.ExcludedInitialResources.Union(toSet(t.PlanResources.MigPlan.Status.ExcludedResources)))
 	delete(newBackup.Annotations, QuiesceAnnotation)
@@ -96,6 +97,7 @@ func (t *Task) ensureStageBackup() (*velero.Backup, error) {
 		},
 	}
 	newBackup.Labels[StageBackupLabel] = t.UID()
+	newBackup.Labels[migapi.ParentLabel] = t.Owner.Name
 	newBackup.Spec.IncludedResources = toStringSlice(settings.IncludedStageResources.Difference(toSet(t.PlanResources.MigPlan.Status.ExcludedResources)))
 	newBackup.Spec.ExcludedResources = toStringSlice(settings.ExcludedStageResources.Union(toSet(t.PlanResources.MigPlan.Status.ExcludedResources)))
 	newBackup.Spec.LabelSelector = &labelSelector

--- a/pkg/controller/migmigration/backup.go
+++ b/pkg/controller/migmigration/backup.go
@@ -38,7 +38,8 @@ func (t *Task) ensureInitialBackup() (*velero.Backup, error) {
 		return nil, liberr.Wrap(err)
 	}
 	newBackup.Labels[InitialBackupLabel] = t.UID()
-	newBackup.Labels[migapi.ParentLabel] = t.Owner.Name
+	newBackup.Labels[MigMigrationDebugLabel] = t.Owner.Name
+	newBackup.Labels[MigPlanDebugLabel] = t.Owner.Spec.MigPlanRef.Name
 	newBackup.Spec.IncludedResources = toStringSlice(settings.IncludedInitialResources.Difference(toSet(t.PlanResources.MigPlan.Status.ExcludedResources)))
 	newBackup.Spec.ExcludedResources = toStringSlice(settings.ExcludedInitialResources.Union(toSet(t.PlanResources.MigPlan.Status.ExcludedResources)))
 	delete(newBackup.Annotations, QuiesceAnnotation)
@@ -97,7 +98,8 @@ func (t *Task) ensureStageBackup() (*velero.Backup, error) {
 		},
 	}
 	newBackup.Labels[StageBackupLabel] = t.UID()
-	newBackup.Labels[migapi.ParentLabel] = t.Owner.Name
+	newBackup.Labels[MigMigrationDebugLabel] = t.Owner.Name
+	newBackup.Labels[MigPlanDebugLabel] = t.Owner.Spec.MigPlanRef.Name
 	newBackup.Spec.IncludedResources = toStringSlice(settings.IncludedStageResources.Difference(toSet(t.PlanResources.MigPlan.Status.ExcludedResources)))
 	newBackup.Spec.ExcludedResources = toStringSlice(settings.ExcludedStageResources.Union(toSet(t.PlanResources.MigPlan.Status.ExcludedResources)))
 	newBackup.Spec.LabelSelector = &labelSelector

--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -328,6 +328,9 @@ func (r *ReconcileMigMigration) setOwnerReference(migration *migapi.MigMigration
 
 // Ensures that the labels required to assist debugging are present on migmigration
 func (r *ReconcileMigMigration) ensureDebugLabels(migration *migapi.MigMigration) error {
+	if migration.Spec.MigPlanRef == nil {
+		return nil
+	}
 	if migration.Labels == nil {
 		migration.Labels = make(map[string]string)
 	} else {

--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -135,6 +135,13 @@ func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{Requeue: true}, nil
 	}
 
+	// Ensure parent labels are present on migmigration
+	err = r.ensureParentLabels(migration)
+	if err != nil {
+		log.Trace(err)
+		return reconcile.Result{Requeue: true}, err
+	}
+
 	// Set values.
 	log.SetValues("migration", migration.Name)
 
@@ -316,5 +323,23 @@ func (r *ReconcileMigMigration) setOwnerReference(migration *migapi.MigMigration
 			UID:        plan.UID,
 		})
 
+	return nil
+}
+
+// Ensures that the labels required to assist debugging are present on migmigration
+func (r *ReconcileMigMigration) ensureParentLabels(migration *migapi.MigMigration) error {
+	if migration.Labels == nil {
+		migration.Labels = make(map[string]string)
+	}
+	if value, exists := migration.Labels[migapi.ParentLabel]; exists {
+		if value == migration.Spec.MigPlanRef.Name {
+			return nil
+		}
+	}
+	migration.Labels[migapi.ParentLabel] = migration.Spec.MigPlanRef.Name
+	err := r.Update(context.TODO(), migration)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
 	return nil
 }

--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -135,8 +135,8 @@ func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{Requeue: true}, nil
 	}
 
-	// Ensure parent labels are present on migmigration
-	err = r.ensureParentLabels(migration)
+	// Ensure debugging labels are present on migmigration
+	err = r.ensureDebugLabels(migration)
 	if err != nil {
 		log.Trace(err)
 		return reconcile.Result{Requeue: true}, err
@@ -327,16 +327,17 @@ func (r *ReconcileMigMigration) setOwnerReference(migration *migapi.MigMigration
 }
 
 // Ensures that the labels required to assist debugging are present on migmigration
-func (r *ReconcileMigMigration) ensureParentLabels(migration *migapi.MigMigration) error {
+func (r *ReconcileMigMigration) ensureDebugLabels(migration *migapi.MigMigration) error {
 	if migration.Labels == nil {
 		migration.Labels = make(map[string]string)
-	}
-	if value, exists := migration.Labels[migapi.ParentLabel]; exists {
-		if value == migration.Spec.MigPlanRef.Name {
-			return nil
+	} else {
+		if value, exists := migration.Labels[MigPlanDebugLabel]; exists {
+			if value == migration.Spec.MigPlanRef.Name {
+				return nil
+			}
 		}
 	}
-	migration.Labels[migapi.ParentLabel] = migration.Spec.MigPlanRef.Name
+	migration.Labels[MigPlanDebugLabel] = migration.Spec.MigPlanRef.Name
 	err := r.Update(context.TODO(), migration)
 	if err != nil {
 		return liberr.Wrap(err)

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -44,7 +44,8 @@ func (t *Task) ensureFinalRestore() (*velero.Restore, error) {
 		return nil, liberr.Wrap(err)
 	}
 	newRestore.Labels[FinalRestoreLabel] = t.UID()
-	newRestore.Labels[migapi.ParentLabel] = t.Owner.Name
+	newRestore.Labels[MigMigrationDebugLabel] = t.Owner.Name
+	newRestore.Labels[MigPlanDebugLabel] = t.Owner.Spec.MigPlanRef.Name
 	err = client.Create(context.TODO(), newRestore)
 	if err != nil {
 		return nil, liberr.Wrap(err)
@@ -87,7 +88,8 @@ func (t *Task) ensureStageRestore() (*velero.Restore, error) {
 		return nil, liberr.Wrap(err)
 	}
 	newRestore.Labels[StageRestoreLabel] = t.UID()
-	newRestore.Labels[migapi.ParentLabel] = t.Owner.Name
+	newRestore.Labels[MigMigrationDebugLabel] = t.Owner.Name
+	newRestore.Labels[MigPlanDebugLabel] = t.Owner.Spec.MigPlanRef.Name
 	stagePodImage, err := t.getStagePodImage(client)
 	if err != nil {
 		return nil, liberr.Wrap(err)

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -44,6 +44,7 @@ func (t *Task) ensureFinalRestore() (*velero.Restore, error) {
 		return nil, liberr.Wrap(err)
 	}
 	newRestore.Labels[FinalRestoreLabel] = t.UID()
+	newRestore.Labels[migapi.ParentLabel] = t.Owner.Name
 	err = client.Create(context.TODO(), newRestore)
 	if err != nil {
 		return nil, liberr.Wrap(err)
@@ -86,13 +87,12 @@ func (t *Task) ensureStageRestore() (*velero.Restore, error) {
 		return nil, liberr.Wrap(err)
 	}
 	newRestore.Labels[StageRestoreLabel] = t.UID()
-
+	newRestore.Labels[migapi.ParentLabel] = t.Owner.Name
 	stagePodImage, err := t.getStagePodImage(client)
 	if err != nil {
 		return nil, liberr.Wrap(err)
 	}
 	newRestore.Annotations[StagePodImageAnnotation] = stagePodImage
-
 	err = client.Create(context.TODO(), newRestore)
 	if err != nil {
 		return nil, liberr.Wrap(err)


### PR DESCRIPTION
Fixes #610 
Fixes #614 

This PR introduces  new labels `migmigration-name` and `migplan-name`. The value of each of the labels is the name of the associated parent resource. 

* MigPlan 

```yml
apiVersion: migration.openshift.io/v1alpha1
kind: MigPlan
metadata:
  name: migplan
  namespace: openshift-migration
  [...]
spec:
  [...]
```

* MigMigration

```yml
apiVersion: migration.openshift.io/v1alpha1
kind: MigMigration
metadata:
  labels:
    migration.openshift.io/migplan-name: migplan
  name: migmigration
  uid: 47c31a36-3ffc-421f-82ea-97f89256ba61
  [...]
spec:
  migPlanRef:
    name: migplan
    namespace: openshift-migration
  [...]
status:
[...]
```
* Backup

```yml
apiVersion: velero.io/v1
kind: Backup
metadata:
  labels:
    migmigration: 47c31a36-3ffc-421f-82ea-97f89256ba61
    migration.openshift.io/migmigration-name: migmigration
    migration.openshift.io/migplan-name: migplan
  [...]
spec:
  [...]
status:
  [...]
```

* Restore

```yml
apiVersion: velero.io/v1
kind: Restore
metadata:
  labels:
    migmigration: 47c31a36-3ffc-421f-82ea-97f89256ba61
    migration.openshift.io/migmigration-name: migmigration
    migration.openshift.io/migplan-name: migplan
    [...]
  [...]
spec:
  [...]
status:
  [...]
```
