### PR TITLE
Bug 1867597: Add support for pulling stage pod + registry images from "migration-cluster-config" configmap

### DIFF
--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -138,7 +138,7 @@ func (m *MigCluster) GetRegistryImage(c k8sclient.Client) (string, error) {
 	}
 	registryImage, ok := clusterConfig.Data[RegistryImageKey]
 	if !ok {
-		return "", liberr.Wrap(errors.New("configmap key not found"))
+		return "", liberr.Wrap(errors.Errorf("configmap key not found: %v", RegistryImageKey))
 	}
 	return registryImage, nil
 }

--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -50,6 +50,7 @@ const (
 const (
 	ClusterConfigMapName = "migration-cluster-config"
 	RegistryImageKey     = "REGISTRY_IMAGE"
+	StagePodImageKey     = "STAGE_IMAGE"
 )
 
 // MigClusterSpec defines the desired state of MigCluster

--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	liberr "github.com/konveyor/controller/pkg/error"
 	pvdr "github.com/konveyor/mig-controller/pkg/cloudprovider"
 	"github.com/konveyor/mig-controller/pkg/compat"
 	"github.com/pkg/errors"
@@ -30,10 +31,12 @@ import (
 	imgapi "github.com/openshift/api/image/v1"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	kapi "k8s.io/api/core/v1"
 	storageapi "k8s.io/api/storage/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -41,6 +44,12 @@ import (
 // SA secret keys.
 const (
 	SaToken = "saToken"
+)
+
+// migration-cluster-config configmap
+const (
+	ClusterConfigMapName = "migration-cluster-config"
+	RegistryImageKey     = "REGISTRY_IMAGE"
 )
 
 // MigClusterSpec defines the desired state of MigCluster
@@ -117,6 +126,21 @@ func (m *MigCluster) GetClient(c k8sclient.Client) (compat.Client, error) {
 	}
 
 	return client, nil
+}
+
+// GetRegistryImage gets a MigCluster specific registry image from ConfigMap
+func (m *MigCluster) GetRegistryImage(c k8sclient.Client) (string, error) {
+	clusterConfig := &corev1.ConfigMap{}
+	clusterConfigRef := types.NamespacedName{Name: ClusterConfigMapName, Namespace: VeleroNamespace}
+	err := c.Get(context.TODO(), clusterConfigRef, clusterConfig)
+	if err != nil {
+		return "", liberr.Wrap(err)
+	}
+	registryImage, ok := clusterConfig.Data[RegistryImageKey]
+	if !ok {
+		return "", liberr.Wrap(errors.New("configmap key not found"))
+	}
+	return registryImage, nil
 }
 
 // Test the connection settings by building a client.

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -224,9 +224,7 @@ func (r *MigPlan) ListMigrations(client k8sclient.Client) ([]*MigMigration, erro
 
 // Registry label for controller-created migration registry resources
 const (
-	MigrationRegistryLabel        = "migration-registry"
-	MigrationRegistryDefaultImage = "registry:2"
-	MigrationRegistryImageEnvVar  = "MIGRATION_REGISTRY_IMAGE"
+	MigrationRegistryLabel = "migration-registry"
 )
 
 // Build a credentials Secret as desired for the source cluster.

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -229,15 +229,6 @@ const (
 	MigrationRegistryImageEnvVar  = "MIGRATION_REGISTRY_IMAGE"
 )
 
-// Return the image reference for the migration registry (defaults to "registry:2")
-// func migRegistryImageRef() string {
-// 	envImage := os.Getenv(MigrationRegistryImageEnvVar)
-// 	if envImage == "" {
-// 		return MigrationRegistryDefaultImage
-// 	}
-// 	return envImage
-// }
-
 // Build a credentials Secret as desired for the source cluster.
 func (r *MigPlan) BuildRegistrySecret(client k8sclient.Client, storage *MigStorage) (*kapi.Secret, error) {
 	labels := r.GetCorrelationLabels()

--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -22,7 +22,7 @@ const (
 	SuspendAnnotation        = "migration.openshift.io/preQuiesceSuspend"
 	ReplicasAnnotation       = "migration.openshift.io/preQuiesceReplicas"
 	NodeSelectorAnnotation   = "migration.openshift.io/preQuiesceNodeSelector"
-	StageRestorePodImage     = "migration.openshift.io/stage-pod-image"
+	StagePodImageAnnotation  = "migration.openshift.io/stage-pod-image"
 )
 
 // Restic Annotations

--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -22,6 +22,7 @@ const (
 	SuspendAnnotation        = "migration.openshift.io/preQuiesceSuspend"
 	ReplicasAnnotation       = "migration.openshift.io/preQuiesceReplicas"
 	NodeSelectorAnnotation   = "migration.openshift.io/preQuiesceNodeSelector"
+	StageRestorePodImage     = "migration.openshift.io/stage-pod-image"
 )
 
 // Restic Annotations

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -87,7 +87,7 @@ func (t *Task) ensureStageRestore() (*velero.Restore, error) {
 	}
 	newRestore.Labels[StageRestoreLabel] = t.UID()
 
-	stagePodImage, err := t.getDestStagePodImage()
+	stagePodImage, err := t.getStagePodImage(client)
 	if err != nil {
 		return nil, liberr.Wrap(err)
 	}

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -86,6 +86,13 @@ func (t *Task) ensureStageRestore() (*velero.Restore, error) {
 		return nil, liberr.Wrap(err)
 	}
 	newRestore.Labels[StageRestoreLabel] = t.UID()
+
+	stagePodImage, err := t.getDestStagePodImage()
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+	newRestore.Annotations[StageRestorePodImage] = stagePodImage
+
 	err = client.Create(context.TODO(), newRestore)
 	if err != nil {
 		return nil, liberr.Wrap(err)

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -91,7 +91,7 @@ func (t *Task) ensureStageRestore() (*velero.Restore, error) {
 	if err != nil {
 		return nil, liberr.Wrap(err)
 	}
-	newRestore.Annotations[StageRestorePodImage] = stagePodImage
+	newRestore.Annotations[StagePodImageAnnotation] = stagePodImage
 
 	err = client.Create(context.TODO(), newRestore)
 	if err != nil {

--- a/pkg/controller/migmigration/stage.go
+++ b/pkg/controller/migmigration/stage.go
@@ -37,11 +37,6 @@ const (
 	defaultCPU    = "100m"
 )
 
-// migration-cluster-config configmap key
-const (
-	StagePodImageKey = "STAGE_IMAGE"
-)
-
 // Stage pod start report.
 type PodStartReport struct {
 	// failed detected.
@@ -175,9 +170,9 @@ func (t *Task) getStagePodImage(client k8sclient.Client) (string, error) {
 	if err != nil {
 		return "", liberr.Wrap(err)
 	}
-	stagePodImage, ok := clusterConfig.Data[StagePodImageKey]
+	stagePodImage, ok := clusterConfig.Data[migapi.StagePodImageKey]
 	if !ok {
-		return "", liberr.Wrap(errors.Errorf("configmap key not found: %v", StagePodImageKey))
+		return "", liberr.Wrap(errors.Errorf("configmap key not found: %v", migapi.StagePodImageKey))
 	}
 	return stagePodImage, nil
 }

--- a/pkg/controller/migmigration/stage.go
+++ b/pkg/controller/migmigration/stage.go
@@ -194,7 +194,7 @@ func (t *Task) getStagePodImage(client k8sclient.Client) (string, error) {
 	}
 	stagePodImage, ok := clusterConfig.Data[StagePodImageKey]
 	if !ok {
-		return "", liberr.Wrap(errors.New("configmap key not found"))
+		return "", liberr.Wrap(errors.Errorf("configmap key not found: %v", StagePodImageKey))
 	}
 	return stagePodImage, nil
 }

--- a/pkg/controller/migmigration/stage.go
+++ b/pkg/controller/migmigration/stage.go
@@ -37,10 +37,9 @@ const (
 	defaultCPU    = "100m"
 )
 
-// migration-cluster-config configmap
+// migration-cluster-config configmap key
 const (
-	ClusterConfigMapName = "migration-cluster-config"
-	StagePodImageKey     = "STAGE_IMAGE"
+	StagePodImageKey = "STAGE_IMAGE"
 )
 
 // Stage pod start report.
@@ -187,7 +186,7 @@ func (t *Task) getDestStagePodImage() (string, error) {
 
 func (t *Task) getStagePodImage(client k8sclient.Client) (string, error) {
 	clusterConfig := &corev1.ConfigMap{}
-	clusterConfigRef := types.NamespacedName{Name: ClusterConfigMapName, Namespace: migapi.VeleroNamespace}
+	clusterConfigRef := types.NamespacedName{Name: migapi.ClusterConfigMapName, Namespace: migapi.VeleroNamespace}
 	err := client.Get(context.TODO(), clusterConfigRef, clusterConfig)
 	if err != nil {
 		return "", liberr.Wrap(err)

--- a/pkg/controller/migmigration/stage.go
+++ b/pkg/controller/migmigration/stage.go
@@ -228,6 +228,11 @@ func (t *Task) ensureStagePodsFromOrphanedPVCs() error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
+	stagePodImage, err := t.getSrcStagePodImage()
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+
 	for _, ns := range t.sourceNamespaces() {
 		list := &corev1.PersistentVolumeClaimList{}
 		err = client.List(context.TODO(), k8sclient.InNamespace(ns), list)
@@ -253,7 +258,7 @@ func (t *Task) ensureStagePodsFromOrphanedPVCs() error {
 			if pvcMounted(existingStagePods, claimKey) {
 				continue
 			}
-			stagePods.merge(*buildStagePod(pvc, t.stagePodLabels(), resourceLimitMapping))
+			stagePods.merge(*buildStagePod(pvc, t.stagePodLabels(), stagePodImage, resourceLimitMapping))
 		}
 	}
 

--- a/pkg/controller/migmigration/stage.go
+++ b/pkg/controller/migmigration/stage.go
@@ -37,6 +37,12 @@ const (
 	defaultCPU    = "100m"
 )
 
+// migration-cluster-config configmap
+const (
+	ClusterConfigMapName = "migration-cluster-config"
+	StagePodImageKey     = "STAGE_IMAGE"
+)
+
 // Stage pod start report.
 type PodStartReport struct {
 	// failed detected.
@@ -182,14 +188,14 @@ func (t *Task) getDestStagePodImage() (string, error) {
 
 func (t *Task) getStagePodImage(client k8sclient.Client) (string, error) {
 	clusterConfig := &corev1.ConfigMap{}
-	clusterConfigRef := types.NamespacedName{Name: "migration-cluster-config", Namespace: "openshift-migration"}
+	clusterConfigRef := types.NamespacedName{Name: ClusterConfigMapName, Namespace: migapi.VeleroNamespace}
 	err := client.Get(context.TODO(), clusterConfigRef, clusterConfig)
 	if err != nil {
 		return "", liberr.Wrap(err)
 	}
-	stagePodImage, ok := clusterConfig.Data["STAGE_IMAGE"]
+	stagePodImage, ok := clusterConfig.Data[StagePodImageKey]
 	if !ok {
-		return "", liberr.Wrap(errors.New("STAGE_IMAGE configmap key not found"))
+		return "", liberr.Wrap(errors.New("configmap key not found"))
 	}
 	return stagePodImage, nil
 }

--- a/pkg/controller/migmigration/stage.go
+++ b/pkg/controller/migmigration/stage.go
@@ -161,27 +161,11 @@ func (t *Task) listStagePods(client k8sclient.Client) (StagePodList, error) {
 	if err != nil {
 		return nil, liberr.Wrap(err)
 	}
-	stagePodImage, err := t.getSrcStagePodImage()
+	stagePodImage, err := t.getStagePodImage(client)
 	if err != nil {
 		return nil, liberr.Wrap(err)
 	}
 	return BuildStagePods(t.stagePodLabels(), t.getPVCs(), &podList.Items, stagePodImage, resourceLimitMapping), nil
-}
-
-func (t *Task) getSrcStagePodImage() (string, error) {
-	client, err := t.getSourceClient()
-	if err != nil {
-		return "", liberr.Wrap(err)
-	}
-	return t.getStagePodImage(client)
-}
-
-func (t *Task) getDestStagePodImage() (string, error) {
-	client, err := t.getDestinationClient()
-	if err != nil {
-		return "", liberr.Wrap(err)
-	}
-	return t.getStagePodImage(client)
 }
 
 func (t *Task) getStagePodImage(client k8sclient.Client) (string, error) {
@@ -232,7 +216,7 @@ func (t *Task) ensureStagePodsFromOrphanedPVCs() error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-	stagePodImage, err := t.getSrcStagePodImage()
+	stagePodImage, err := t.getStagePodImage(client)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
@@ -302,7 +286,7 @@ func (t *Task) ensureStagePodsFromTemplates() error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-	stagePodImage, err := t.getSrcStagePodImage()
+	stagePodImage, err := t.getStagePodImage(client)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
@@ -391,7 +375,7 @@ func (t *Task) ensureStagePodsFromRunning() error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-	stagePodImage, err := t.getSrcStagePodImage()
+	stagePodImage, err := t.getStagePodImage(client)
 	if err != nil {
 		return liberr.Wrap(err)
 	}

--- a/pkg/controller/migplan/registry.go
+++ b/pkg/controller/migplan/registry.go
@@ -39,6 +39,12 @@ func (r ReconcileMigPlan) ensureMigRegistries(plan *migapi.MigPlan) error {
 			return liberr.Wrap(err)
 		}
 
+		// Get cluster specific registry image
+		registryImage, err := cluster.GetRegistryImage(client)
+		if err != nil {
+			return liberr.Wrap(err)
+		}
+
 		// Migration Registry Secret
 		secret, err := r.ensureRegistrySecret(client, plan, storage)
 		if err != nil {
@@ -46,13 +52,13 @@ func (r ReconcileMigPlan) ensureMigRegistries(plan *migapi.MigPlan) error {
 		}
 
 		// Migration Registry ImageStream
-		err = r.ensureRegistryImageStream(client, plan, secret)
+		err = r.ensureRegistryImageStream(client, plan, secret, registryImage)
 		if err != nil {
 			return liberr.Wrap(err)
 		}
 
 		// Migration Registry DeploymentConfig
-		err = r.ensureRegistryDC(client, plan, storage, secret)
+		err = r.ensureRegistryDC(client, plan, storage, secret, registryImage)
 		if err != nil {
 			return liberr.Wrap(err)
 		}
@@ -110,8 +116,8 @@ func (r ReconcileMigPlan) ensureRegistrySecret(client k8sclient.Client, plan *mi
 }
 
 // Ensure the imagestream for the migration registry on the specified cluster has been created
-func (r ReconcileMigPlan) ensureRegistryImageStream(client k8sclient.Client, plan *migapi.MigPlan, secret *kapi.Secret) error {
-	newImageStream, err := plan.BuildRegistryImageStream(secret.GetName())
+func (r ReconcileMigPlan) ensureRegistryImageStream(client k8sclient.Client, plan *migapi.MigPlan, secret *kapi.Secret, registryImage string) error {
+	newImageStream, err := plan.BuildRegistryImageStream(secret.GetName(), registryImage)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
@@ -129,7 +135,7 @@ func (r ReconcileMigPlan) ensureRegistryImageStream(client k8sclient.Client, pla
 	if plan.EqualsRegistryImageStream(newImageStream, foundImageStream) {
 		return nil
 	}
-	plan.UpdateRegistryImageStream(foundImageStream)
+	plan.UpdateRegistryImageStream(foundImageStream, registryImage)
 	err = client.Update(context.TODO(), foundImageStream)
 	if err != nil {
 		return liberr.Wrap(err)
@@ -139,7 +145,9 @@ func (r ReconcileMigPlan) ensureRegistryImageStream(client k8sclient.Client, pla
 }
 
 // Ensure the deploymentconfig for the migration registry on the specified cluster has been created
-func (r ReconcileMigPlan) ensureRegistryDC(client k8sclient.Client, plan *migapi.MigPlan, storage *migapi.MigStorage, secret *kapi.Secret) error {
+func (r ReconcileMigPlan) ensureRegistryDC(client k8sclient.Client, plan *migapi.MigPlan,
+	storage *migapi.MigStorage, secret *kapi.Secret, registryImage string) error {
+
 	name := secret.GetName()
 	dirName := storage.GetName() + "-registry-" + string(storage.UID)
 
@@ -150,7 +158,7 @@ func (r ReconcileMigPlan) ensureRegistryDC(client k8sclient.Client, plan *migapi
 	}
 
 	//Construct Registry DC
-	newDC, err := plan.BuildRegistryDC(storage, proxySecret, name, dirName)
+	newDC, err := plan.BuildRegistryDC(storage, proxySecret, name, dirName, registryImage)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
@@ -168,7 +176,7 @@ func (r ReconcileMigPlan) ensureRegistryDC(client k8sclient.Client, plan *migapi
 	if plan.EqualsRegistryDC(newDC, foundDC) {
 		return nil
 	}
-	plan.UpdateRegistryDC(storage, foundDC, proxySecret, name, dirName)
+	plan.UpdateRegistryDC(storage, foundDC, proxySecret, name, dirName, registryImage)
 	err = client.Update(context.TODO(), foundDC)
 	if err != nil {
 		return liberr.Wrap(err)


### PR DESCRIPTION
**Merge in sync with**
 - mig-operator PR [400](https://github.com/konveyor/mig-operator/pull/400)
 - openshift-migration-plugin PR [69](https://github.com/konveyor/openshift-migration-plugin/pull/69)

**Summary**
 - Adds ability to customize `STAGE_IMAGE` with configmap value
 - Adds ability to customize `REGISTRY_IMAGE` with configmap value
 - Annotates Stage Restore with `migration.openshift.io/stage-pod-image=<STAGE_IMAGE>`

![image](https://user-images.githubusercontent.com/7576968/90181515-92660a00-dd7e-11ea-9ce3-83988f90ebe4.png)
