### PR TITLE
Update Tiltfile to keep image layers for 24h

### DIFF
--- a/tools/tilt/Tiltfile
+++ b/tools/tilt/Tiltfile
@@ -6,6 +6,8 @@ settings.update(read_json(
     default={},
 ))
 
+docker_prune_settings(max_age_mins=1440)
+
 allow_k8s_contexts(k8s_context())
 img = settings.get('image', os.environ.get('IMG'))
 template = settings.get('migration_controller', os.environ.get('TEMPLATE'))


### PR DESCRIPTION
Speeds up `make tilt` to make integration testing with mig-operator and mig-ui quicker.

Closes #629 