### PR TITLE
Remove most remote watches

### DIFF
--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -171,7 +171,7 @@ func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.
 	}
 
 	// Re-queue (after) in seconds.
-	requeueAfter := time.Duration(0) // not re-queued.
+	requeueAfter := time.Duration(PollReQ)
 
 	// Begin staging conditions.
 	migration.Status.BeginStagingConditions()

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -242,6 +242,7 @@ type Task struct {
 //   3. Set the Requeue (as appropriate).
 //   4. Return.
 func (t *Task) Run() error {
+	t.Requeue = FastReQ
 	t.Log.Info("[RUN]", "stage", t.stage(), "phase", t.Phase)
 
 	err := t.init()
@@ -256,6 +257,7 @@ func (t *Task) Run() error {
 			return liberr.Wrap(err)
 		}
 	case Prepare:
+		t.Requeue = PollReQ
 		err := t.ensureStagePodsDeleted()
 		if err != nil {
 			return liberr.Wrap(err)
@@ -298,14 +300,13 @@ func (t *Task) Run() error {
 				return liberr.Wrap(err)
 			}
 		} else {
-			t.Requeue = NoReQ
+			t.Requeue = PollReQ
 		}
 	case EnsureInitialBackup:
 		_, err := t.ensureInitialBackup()
 		if err != nil {
 			return liberr.Wrap(err)
 		}
-		t.Requeue = NoReQ
 		if err = t.next(); err != nil {
 			return liberr.Wrap(err)
 		}
@@ -342,7 +343,7 @@ func (t *Task) Run() error {
 		if err != nil {
 			return liberr.Wrap(err)
 		}
-		t.Requeue = NoReQ
+		t.Requeue = PollReQ
 		if err = t.next(); err != nil {
 			return liberr.Wrap(err)
 		}
@@ -351,7 +352,7 @@ func (t *Task) Run() error {
 		if err != nil {
 			return liberr.Wrap(err)
 		}
-		t.Requeue = NoReQ
+		t.Requeue = PollReQ
 		if err = t.next(); err != nil {
 			return liberr.Wrap(err)
 		}
@@ -360,7 +361,7 @@ func (t *Task) Run() error {
 		if err != nil {
 			return liberr.Wrap(err)
 		}
-		t.Requeue = NoReQ
+		t.Requeue = PollReQ
 		if err = t.next(); err != nil {
 			return liberr.Wrap(err)
 		}
@@ -378,7 +379,7 @@ func (t *Task) Run() error {
 				return liberr.Wrap(err)
 			}
 		} else {
-			t.Requeue = NoReQ
+			t.Requeue = PollReQ
 		}
 	case RestartRestic:
 		err := t.restartResticPods()
@@ -434,7 +435,7 @@ func (t *Task) Run() error {
 		if err != nil {
 			return liberr.Wrap(err)
 		}
-		t.Requeue = NoReQ
+		t.Requeue = PollReQ
 		if err = t.next(); err != nil {
 			return liberr.Wrap(err)
 		}
@@ -488,7 +489,7 @@ func (t *Task) Run() error {
 				return liberr.Wrap(err)
 			}
 		} else {
-			t.Requeue = NoReQ
+			t.Requeue = PollReQ
 		}
 	case PreRestoreHooks:
 		status, err := t.runHooks(migapi.PreRestoreHookPhase)
@@ -501,7 +502,7 @@ func (t *Task) Run() error {
 				return liberr.Wrap(err)
 			}
 		} else {
-			t.Requeue = NoReQ
+			t.Requeue = PollReQ
 		}
 	case EnsureStageRestore:
 		_, err := t.ensureStageRestore()
@@ -531,7 +532,7 @@ func (t *Task) Run() error {
 				}
 			}
 		} else {
-			t.Requeue = NoReQ
+			t.Requeue = PollReQ
 		}
 	case EnsureStagePodsDeleted:
 		err := t.ensureStagePodsDeleted()
@@ -580,7 +581,7 @@ func (t *Task) Run() error {
 				return liberr.Wrap(err)
 			}
 		} else {
-			t.Requeue = NoReQ
+			t.Requeue = PollReQ
 		}
 	case EnsureFinalRestore:
 		backup, err := t.getInitialBackup()
@@ -594,7 +595,7 @@ func (t *Task) Run() error {
 		if err != nil {
 			return liberr.Wrap(err)
 		}
-		t.Requeue = NoReQ
+		t.Requeue = PollReQ
 		if err = t.next(); err != nil {
 			return liberr.Wrap(err)
 		}
@@ -616,7 +617,7 @@ func (t *Task) Run() error {
 				}
 			}
 		} else {
-			t.Requeue = NoReQ
+			t.Requeue = PollReQ
 		}
 	case PostRestoreHooks:
 		status, err := t.runHooks(migapi.PostRestoreHookPhase)
@@ -629,7 +630,7 @@ func (t *Task) Run() error {
 				return liberr.Wrap(err)
 			}
 		} else {
-			t.Requeue = NoReQ
+			t.Requeue = PollReQ
 		}
 	case Verification:
 		completed, err := t.VerificationCompleted()

--- a/pkg/controller/migstorage/migstorage_controller.go
+++ b/pkg/controller/migstorage/migstorage_controller.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/konveyor/controller/pkg/logging"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
-	migref "github.com/konveyor/mig-controller/pkg/reference"
-	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,19 +58,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		&source.Kind{Type: &migapi.MigStorage{}},
 		&handler.EnqueueRequestForObject{},
 		&StoragePredicate{})
-	if err != nil {
-		return err
-	}
-
-	// Watch for changes to Secrets referenced by MigStorage.
-	err = c.Watch(
-		&source.Kind{Type: &kapi.Secret{}},
-		&handler.EnqueueRequestsFromMapFunc{
-			ToRequests: handler.ToRequestsFunc(
-				func(a handler.MapObject) []reconcile.Request {
-					return migref.GetRequests(a, migapi.MigStorage{})
-				}),
-		})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/remotewatcher/remotewatcher_controller.go
+++ b/pkg/controller/remotewatcher/remotewatcher_controller.go
@@ -16,9 +16,6 @@ package remotewatcher
 import (
 	"github.com/konveyor/controller/pkg/logging"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
-	batchv1 "k8s.io/api/batch/v1"
-	kapi "k8s.io/api/core/v1"
-	storageapi "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -96,79 +93,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		},
 		&handler.EnqueueRequestForObject{},
 		&VSLPredicate{})
-	if err != nil {
-		return err
-	}
-
-	// Secret
-	err = c.Watch(
-		&source.Kind{
-			Type: &kapi.Secret{},
-		},
-		&handler.EnqueueRequestForObject{},
-		&SecretPredicate{})
-	if err != nil {
-		return err
-	}
-
-	// Pod
-	err = c.Watch(
-		&source.Kind{
-			Type: &kapi.Pod{},
-		},
-		&handler.EnqueueRequestForObject{},
-		&PodPredicate{})
-	if err != nil {
-		return err
-	}
-
-	// PV
-	err = c.Watch(
-		&source.Kind{
-			Type: &kapi.PersistentVolume{},
-		},
-		&handler.EnqueueRequestForObject{})
-	if err != nil {
-		return err
-	}
-
-	// PVC
-	err = c.Watch(
-		&source.Kind{
-			Type: &kapi.PersistentVolumeClaim{},
-		},
-		&handler.EnqueueRequestForObject{})
-	if err != nil {
-		return err
-	}
-
-	// Namespaces
-	err = c.Watch(
-		&source.Kind{
-			Type: &kapi.Namespace{},
-		},
-		&handler.EnqueueRequestForObject{})
-	if err != nil {
-		return err
-	}
-
-	// StorageClass
-	err = c.Watch(
-		&source.Kind{
-			Type: &storageapi.StorageClass{},
-		},
-		&handler.EnqueueRequestForObject{})
-	if err != nil {
-		return err
-	}
-
-	// Job
-	err = c.Watch(
-		&source.Kind{
-			Type: &batchv1.Job{},
-		},
-		&handler.EnqueueRequestForObject{},
-		&JobPredicate{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR explores the impact of removing watches and remote watches on k8s core kinds. The goal is to reduce memory footprint and spurious reconciles. I will use this PR to dump info on memory and API server request deltas due to this change.

**I suspect this PR will:**
 - Greatly reduce cache memory consumption, since we will no longer be caching all k8s core kinds on remote watch clusters
 - Reduce spurious reconciles.

I am running tests to evaluate if the above are true.