### PR TITLE
Registering pprof http handler

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 
 	"github.com/konveyor/mig-controller/pkg/apis"


### PR DESCRIPTION
 

This PR imports pprof to register its default memory profile http handler as a side-effect.

The memory profile will be automatically available at `localhost:2112/debug/pprof/heap` endpoint