### PR TITLE
Filter velero pod list on currently-running (non-terminating) pods

### DIFF
--- a/pkg/controller/migmigration/pod.go
+++ b/pkg/controller/migmigration/pod.go
@@ -150,23 +150,7 @@ func (t *Task) findVeleroPods(cluster *migapi.MigCluster) ([]corev1.Pod, error) 
 	if err != nil {
 		return nil, liberr.Wrap(err)
 	}
-	list := &corev1.PodList{}
-	selector := labels.SelectorFromSet(
-		map[string]string{
-			"component": "velero",
-		})
-	err = client.List(
-		context.TODO(),
-		&k8sclient.ListOptions{
-			Namespace:     migapi.VeleroNamespace,
-			LabelSelector: selector,
-		},
-		list)
-	if err != nil {
-		return nil, liberr.Wrap(err)
-	}
-
-	return list.Items, nil
+	return pods.FindVeleroPods(client)
 }
 
 // Ensure the velero cloud-credentials secret content has been

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -1224,18 +1224,12 @@ func (r *NfsValidation) validate() error {
 
 // Find a pod suitable for command execution.
 func (r *NfsValidation) findPod() error {
-	list := kapi.PodList{}
-	options := k8sclient.MatchingLabels(map[string]string{"component": "velero"})
-	options.Namespace = migapi.VeleroNamespace
-	err := r.client.List(
-		context.TODO(),
-		options,
-		&list)
+	podList, err := pods.FindVeleroPods(r.client)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-	for i := range list.Items {
-		r.pod = &list.Items[i]
+	for _, pod := range podList {
+		r.pod = &pod
 		command := pods.PodCommand{
 			Args:    []string{"/usr/bin/nc", "-h"},
 			RestCfg: r.restCfg,

--- a/pkg/pods/velero.go
+++ b/pkg/pods/velero.go
@@ -1,0 +1,43 @@
+package pods
+
+import (
+	"context"
+
+	liberr "github.com/konveyor/controller/pkg/error"
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Find all velero pods for the specified client.
+func FindVeleroPods(client k8sclient.Client) ([]corev1.Pod, error) {
+	var podList []corev1.Pod
+	list := &corev1.PodList{}
+	labelSelector := labels.SelectorFromSet(
+		map[string]string{
+			"component": "velero",
+		})
+	fieldSelector := fields.SelectorFromSet(
+		map[string]string{
+			"status.phase": "Running",
+		})
+	err := client.List(
+		context.TODO(),
+		&k8sclient.ListOptions{
+			Namespace:     migapi.VeleroNamespace,
+			LabelSelector: labelSelector,
+			FieldSelector: fieldSelector,
+		},
+		list)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+	for _, pod := range list.Items {
+		if pod.DeletionTimestamp == nil {
+			podList = append(podList, pod)
+		}
+	}
+	return podList, nil
+}


### PR DESCRIPTION
We need to filter out non-running pods since this pod list is used to exec into, and if the pod isn't running, the exec will always fail. I hit this in my dev environment where I had a node in a bad state, so the velero pod on that node was stuck in terminating, but the replacement velero pod was up and running witthout errors. Migrations should have succeeded, but were failing because of the exec-into-dead-pod failures.