### PR TITLE
Bug 1879276: Fix empty controllers listed in plan pods report.

### DIFF
--- a/pkg/controller/discovery/model/table.go
+++ b/pkg/controller/discovery/model/table.go
@@ -99,7 +99,7 @@ SELECT
 {{ end -}}
 FROM {{.Table}}
 WHERE
-{{ if .Pk -}}
+{{ if and .Pk (not .Pk.Empty) -}}
 {{ .Pk.Name }} = {{ .Pk.Param }}
 {{ else -}}
 {{ range $i,$f := .Keys -}}
@@ -752,6 +752,7 @@ func (t Table) getSQL(table string, fields []*Field) (string, error) {
 		TmplData{
 			Table:  table,
 			Keys:   t.KeyFields(fields),
+			Pk:     t.PkField(fields),
 			Fields: fields,
 		})
 	if err != nil {


### PR DESCRIPTION
Fix [1879276](https://bugzilla.redhat.com/show_bug.cgi?id=1879276).
- Get: plans/name/pods report to include the controller pods.
- Get: logs.

In 1.3, the web request handler was changed to query by PK (primary key).  

The SQL template was designed to support Get by either PK or natural keys but lacked an `Empty()` check.  The method for building the `Get` SQL also needed to provide the PK to the template.