### PR TITLE
Bug 1879455: Fix swapped pod/pvc count in namespace listing.

### DIFF
--- a/pkg/controller/discovery/web/ns.go
+++ b/pkg/controller/discovery/web/ns.go
@@ -103,7 +103,7 @@ func (h NsHandler) List(ctx *gin.Context) {
 			return
 		}
 		r := Namespace{}
-		r.With(m, srvCount, pvcCount, podCount)
+		r.With(m, srvCount, podCount, pvcCount)
 		r.SelfLink = h.Link(m)
 		content.Items = append(content.Items, r)
 	}


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1879455

Fix swapped pod/pvc count in namespace listing. 