### PR TITLE
Add CABundle help text when X509 error detected

### DIFF
--- a/pkg/controller/migcluster/validation.go
+++ b/pkg/controller/migcluster/validation.go
@@ -48,7 +48,7 @@ const (
 const (
 	ReadyMessage                = "The cluster is ready."
 	MissingURLMessage           = "The `url` is required when `isHostCluster` is false."
-	CaBundleMessage             = "The `caBundle` may be required when `insecure` is false."
+	CaBundleMessage             = "The `caBundle` is required for self-signed APIserver certificates"
 	InvalidSaSecretRefMessage   = "The `serviceAccountSecretRef` must reference a `secret`."
 	InvalidSaTokenMessage       = "The `saToken` not found in `serviceAccountSecretRef` secret."
 	TestConnectFailedMessage    = "Test connect failed. %s: %s"
@@ -204,7 +204,8 @@ func (r ReconcileMigCluster) testConnection(cluster *migapi.MigCluster) error {
 	err := cluster.TestConnection(r.Client, timeout)
 	if err != nil {
 		helpText := ""
-		if strings.Contains(err.Error(), "x509") {
+		if strings.Contains(err.Error(), "x509") &&
+			len(cluster.Spec.CABundle) == 0 && !cluster.Spec.Insecure {
 			helpText = CaBundleMessage
 		}
 		message := fmt.Sprintf(TestConnectFailedMessage, helpText, err)

--- a/pkg/controller/migcluster/validation.go
+++ b/pkg/controller/migcluster/validation.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"regexp"
 	"time"
 
 	auth "k8s.io/api/authorization/v1"
@@ -22,7 +21,6 @@ const (
 	TestConnectFailed    = "TestConnectFailed"
 	SaTokenNotPrivileged = "SaTokenNotPrivileged"
 	MissingCaBundle      = "MissingCaBundle"
-	MalformedCaBundle    = "MalformedCaBundle"
 )
 
 // Categories
@@ -51,7 +49,6 @@ const (
 	ReadyMessage                = "The cluster is ready."
 	MissingURLMessage           = "The `url` is required when `isHostCluster` is false."
 	MissingCaBundleMessage      = "The `caBundle` is required when `insecure` is false."
-	MalformedCaBundleMessage    = "The `caBundle` must be base64 encoded."
 	InvalidSaSecretRefMessage   = "The `serviceAccountSecretRef` must reference a `secret`."
 	InvalidSaTokenMessage       = "The `saToken` not found in `serviceAccountSecretRef` secret."
 	TestConnectFailedMessage    = "Test connect failed: %s"
@@ -284,6 +281,10 @@ func (r *ReconcileMigCluster) validateSaTokenPrivileges(cluster *migapi.MigClust
 }
 
 func (r ReconcileMigCluster) validateCaBundle(cluster *migapi.MigCluster) error {
+	if cluster.Spec.IsHostCluster == true {
+		return nil
+	}
+
 	// Validate caBundle is provided if running in secure mode
 	if cluster.Spec.Insecure == false && len(cluster.Spec.CABundle) == 0 {
 		cluster.Status.SetCondition(migapi.Condition{
@@ -293,23 +294,6 @@ func (r ReconcileMigCluster) validateCaBundle(cluster *migapi.MigCluster) error 
 			Category: Critical,
 			Message:  MissingCaBundleMessage,
 		})
-	}
-
-	// Validate caBundle is a base64 encoded string
-	if cluster.Spec.Insecure == false && len(cluster.Spec.CABundle) > 0 {
-		isBase64, _ := regexp.MatchString(
-			"^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$",
-			string(cluster.Spec.CABundle),
-		)
-		if !isBase64 {
-			cluster.Status.SetCondition(migapi.Condition{
-				Type:     MalformedCaBundle,
-				Status:   True,
-				Reason:   Malformed,
-				Category: Critical,
-				Message:  MalformedCaBundleMessage,
-			})
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
This PR provides the user with a hint of why the remote cluster connection is failing if `insecure: false` and caBundle is not yet provided, and we detect `x509` in the error output.

Resolves #682 

```
  status:
    conditions:
    - category: Critical
      lastTransitionTime: "2020-09-23T20:11:10Z"
      message: 'Test connect failed. The `caBundle` is required for self-signed certificates.: 
        Get "https://master1.myapiserver.com:443/api?timeout=5s":
        x509: certificate is valid for kubernetes, kubernetes.default, kubernetes.default.svc,
        openshift, openshift.default, openshift.default.svc, openshift.default.svc.cluster.local...
      reason: ConnectFailed
      status: "True"
      type: TestConnectFailed
```