### PR TITLE
MIG-323 - add logging improvements and kube events for status conditions to migstorage_controller

### DIFF
--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -205,12 +205,12 @@ func (r *MigStorage) GetVolumeSnapshotProvider() pvdr.Provider {
 	return provider
 }
 
-// Get the backup credentials secret.
+// Get the backup credentials secret. If the secret is not found it returns nil
 func (r *MigStorage) GetBackupStorageCredSecret(client k8sclient.Client) (*kapi.Secret, error) {
 	return r.Spec.BackupStorageConfig.GetCredSecret(client)
 }
 
-// Get the backup credentials secret.
+// Get the backup credentials secret. If the secret is not found it returns nil
 func (r *MigStorage) GetVolumeSnapshotCredSecret(client k8sclient.Client) (*kapi.Secret, error) {
 	if r.Spec.VolumeSnapshotProvider != "" {
 		return r.Spec.VolumeSnapshotConfig.GetCredSecret(client)


### PR DESCRIPTION
This adds logging improvement to migstorage_controller.

The idea is to set a standard between condition messages and
log messages. Since conditions are on an object it has the object
metadata attached to it. The log entry needs the namespace and
the name of the object for which the condition is added.

With this, a developer will be able 
1. to pinpoint the line at which error condition occurred 
2. will be able to get more context on what the code was
    trying to do when the error occurred.