### PR TITLE
Add StorageClasses to discovery service

### DIFF
--- a/pkg/controller/discovery/container/storageclass.go
+++ b/pkg/controller/discovery/container/storageclass.go
@@ -1,0 +1,157 @@
+package container
+
+import (
+	"context"
+	"time"
+
+	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
+	v1 "k8s.io/api/storage/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// A collection of k8s StorageClass resources.
+type StorageClass struct {
+	// Base
+	BaseCollection
+}
+
+func (r *StorageClass) AddWatch(dsController controller.Controller) error {
+	err := dsController.Watch(
+		&source.Kind{
+			Type: &v1.StorageClass{},
+		},
+		&handler.EnqueueRequestForObject{},
+		r)
+	if err != nil {
+		Log.Trace(err)
+		return err
+	}
+
+	return nil
+}
+
+func (r *StorageClass) Reconcile() error {
+	mark := time.Now()
+	sr := SimpleReconciler{
+		Db: r.ds.Container.Db,
+	}
+	err := sr.Reconcile(r)
+	if err != nil {
+		Log.Trace(err)
+		return err
+	}
+	r.hasReconciled = true
+	Log.Info(
+		"StorageClass (collection) reconciled.",
+		"ns",
+		r.ds.Cluster.Namespace,
+		"name",
+		r.ds.Cluster.Name,
+		"duration",
+		time.Since(mark))
+
+	return nil
+}
+
+func (r *StorageClass) GetDiscovered() ([]model.Model, error) {
+	models := []model.Model{}
+	onCluster := v1.StorageClassList{}
+	err := r.ds.Client.List(context.TODO(), nil, &onCluster)
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	for _, discovered := range onCluster.Items {
+		StorageClass := &model.StorageClass{
+			Base: model.Base{
+				Cluster: r.ds.Cluster.PK,
+			},
+		}
+		StorageClass.With(&discovered)
+		models = append(models, StorageClass)
+	}
+
+	return models, nil
+}
+
+func (r *StorageClass) GetStored() ([]model.Model, error) {
+	models := []model.Model{}
+	list, err := model.StorageClass{
+		Base: model.Base{
+			Cluster: r.ds.Cluster.PK,
+		},
+	}.List(
+		r.ds.Container.Db,
+		model.ListOptions{})
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	for _, StorageClass := range list {
+		models = append(models, StorageClass)
+	}
+
+	return models, nil
+}
+
+//
+// Predicate methods.
+//
+
+func (r *StorageClass) Create(e event.CreateEvent) bool {
+	Log.Reset()
+	object, cast := e.Object.(*v1.StorageClass)
+	if !cast {
+		return false
+	}
+	StorageClass := model.StorageClass{
+		Base: model.Base{
+			Cluster: r.ds.Cluster.PK,
+		},
+	}
+	StorageClass.With(object)
+	r.ds.Create(&StorageClass)
+
+	return false
+}
+
+func (r *StorageClass) Update(e event.UpdateEvent) bool {
+	Log.Reset()
+	object, cast := e.ObjectNew.(*v1.StorageClass)
+	if !cast {
+		return false
+	}
+	StorageClass := model.StorageClass{
+		Base: model.Base{
+			Cluster: r.ds.Cluster.PK,
+		},
+	}
+	StorageClass.With(object)
+	r.ds.Update(&StorageClass)
+
+	return false
+}
+
+func (r *StorageClass) Delete(e event.DeleteEvent) bool {
+	Log.Reset()
+	object, cast := e.Object.(*v1.StorageClass)
+	if !cast {
+		return false
+	}
+	StorageClass := model.StorageClass{
+		Base: model.Base{
+			Cluster: r.ds.Cluster.PK,
+		},
+	}
+	StorageClass.With(object)
+	r.ds.Delete(&StorageClass)
+
+	return false
+}
+
+func (r *StorageClass) Generic(e event.GenericEvent) bool {
+	return false
+}

--- a/pkg/controller/discovery/controller.go
+++ b/pkg/controller/discovery/controller.go
@@ -18,6 +18,9 @@ package discovery
 
 import (
 	"context"
+	"reflect"
+	"time"
+
 	"github.com/konveyor/controller/pkg/logging"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/konveyor/mig-controller/pkg/controller/discovery/container"
@@ -27,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -36,7 +38,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"time"
 )
 
 var log logging.Logger
@@ -163,7 +164,9 @@ func (r *ReconcileDiscovery) Reconcile(request reconcile.Request) (reconcile.Res
 		&container.Service{},
 		&container.PVC{},
 		&container.Pod{},
-		&container.PV{})
+		&container.PV{},
+		&container.StorageClass{},
+	)
 	if err != nil {
 		log.Trace(err)
 		return reQueue, nil

--- a/pkg/controller/discovery/model/model.go
+++ b/pkg/controller/discovery/model/model.go
@@ -4,13 +4,14 @@ import (
 	"crypto/sha1"
 	"database/sql"
 	"fmt"
-	"github.com/konveyor/controller/pkg/logging"
-	"github.com/konveyor/mig-controller/pkg/settings"
-	_ "github.com/mattn/go-sqlite3"
 	pathlib "path"
 	"reflect"
 	"strconv"
 	"sync"
+
+	"github.com/konveyor/controller/pkg/logging"
+	"github.com/konveyor/mig-controller/pkg/settings"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 // Shared logger.
@@ -58,6 +59,7 @@ func Create() (*sql.DB, error) {
 		&Pod{},
 		&PV{},
 		&PVC{},
+		&StorageClass{},
 	}
 	for _, m := range models {
 		ddl, err := Table{}.DDL(m)

--- a/pkg/controller/discovery/model/storageclass.go
+++ b/pkg/controller/discovery/model/storageclass.go
@@ -1,0 +1,87 @@
+package model
+
+import (
+	"encoding/json"
+
+	v1 "k8s.io/api/storage/v1"
+)
+
+//
+// StorageClass model.
+type StorageClass struct {
+	Base
+}
+
+//
+// Update the model `with` a k8s StorageClass.
+func (m *StorageClass) With(object *v1.StorageClass) {
+	m.UID = string(object.UID)
+	m.Version = object.ResourceVersion
+	m.Namespace = object.Namespace
+	m.Name = object.Name
+	m.EncodeObject(object)
+}
+
+//
+// Encode the object.
+func (m *StorageClass) EncodeObject(StorageClass *v1.StorageClass) {
+	object, _ := json.Marshal(StorageClass)
+	m.Object = string(object)
+}
+
+//
+// Encode the object.
+func (m *StorageClass) DecodeObject() *v1.StorageClass {
+	StorageClass := &v1.StorageClass{}
+	json.Unmarshal([]byte(m.Object), StorageClass)
+	return StorageClass
+}
+
+//
+// Count in the DB.
+func (m StorageClass) Count(db DB, options ListOptions) (int64, error) {
+	return Table{db}.Count(&m, options)
+}
+
+//
+// Fetch the from in the DB.
+func (m StorageClass) List(db DB, options ListOptions) ([]*StorageClass, error) {
+	list := []*StorageClass{}
+	listed, err := Table{db}.List(&m, options)
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	for _, intPtr := range listed {
+		list = append(list, intPtr.(*StorageClass))
+	}
+
+	return list, nil
+}
+
+//
+// Fetch the model from the DB.
+func (m *StorageClass) Get(db DB) error {
+	return Table{db}.Get(m)
+}
+
+//
+// Insert the model into the DB.
+func (m *StorageClass) Insert(db DB) error {
+	m.SetPk()
+	return Table{db}.Insert(m)
+}
+
+//
+// Update the model in the DB.
+func (m *StorageClass) Update(db DB) error {
+	m.SetPk()
+	return Table{db}.Update(m)
+}
+
+//
+// Delete the model in the DB.
+func (m *StorageClass) Delete(db DB) error {
+	m.SetPk()
+	return Table{db}.Delete(m)
+}

--- a/pkg/controller/discovery/web/storageclass.go
+++ b/pkg/controller/discovery/web/storageclass.go
@@ -1,0 +1,148 @@
+package web
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
+	v1 "k8s.io/api/storage/v1"
+)
+
+const (
+	StorageClassParam = "storageclass"
+	StorageClasssRoot = ClusterRoot + "/storageclasses"
+	StorageClassRoot  = StorageClasssRoot + "/:" + StorageClassParam
+)
+
+//
+// StorageClass (route) handler.
+type StorageClassHandler struct {
+	// Base
+	ClusterScoped
+}
+
+//
+// Add routes.
+func (h StorageClassHandler) AddRoutes(r *gin.Engine) {
+	r.GET(StorageClasssRoot, h.List)
+	r.GET(StorageClasssRoot+"/", h.List)
+	r.GET(StorageClassRoot, h.Get)
+}
+
+//
+// List all of the StorageClasss on a cluster.
+func (h StorageClassHandler) List(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	db := h.container.Db
+	collection := model.StorageClass{
+		Base: model.Base{
+			Cluster: h.cluster.PK,
+		},
+	}
+	count, err := collection.Count(db, model.ListOptions{})
+	if err != nil {
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	list, err := collection.List(
+		db,
+		model.ListOptions{
+			Page: &h.page,
+		})
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	content := StorageClassList{
+		Count: count,
+	}
+	for _, m := range list {
+		r := StorageClass{}
+		r.With(m)
+		r.SelfLink = h.Link(&h.cluster, m)
+		content.Items = append(content.Items, r)
+	}
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Get a specific StorageClass on a cluster.
+func (h StorageClassHandler) Get(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	m := model.StorageClass{
+		Base: model.Base{
+			Cluster: h.cluster.PK,
+			Name:    ctx.Param(StorageClassParam),
+		},
+	}
+	err := m.Get(h.container.Db)
+	if err != nil {
+		if err != sql.ErrNoRows {
+			Log.Trace(err)
+			ctx.Status(http.StatusInternalServerError)
+			return
+		} else {
+			ctx.Status(http.StatusNotFound)
+			return
+		}
+	}
+	r := StorageClass{}
+	r.With(&m)
+	r.SelfLink = h.Link(&h.cluster, &m)
+	content := r
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Build self link.
+func (h StorageClassHandler) Link(c *model.Cluster, m *model.StorageClass) string {
+	return h.BaseHandler.Link(
+		StorageClassRoot,
+		Params{
+			NsParam:           c.Namespace,
+			ClusterParam:      c.Name,
+			Ns2Param:          m.Namespace,
+			StorageClassParam: m.Name,
+		})
+}
+
+// StorageClass REST resource
+type StorageClass struct {
+	// The k8s namespace.
+	Namespace string `json:"namespace,omitempty"`
+	// The k8s name.
+	Name string `json:"name"`
+	// Self URI.
+	SelfLink string `json:"selfLink"`
+	// Raw k8s object.
+	Object *v1.StorageClass `json:"object,omitempty"`
+}
+
+//
+// Build the resource.
+func (r *StorageClass) With(m *model.StorageClass) {
+	r.Namespace = m.Namespace
+	r.Name = m.Name
+	r.Object = m.DecodeObject()
+}
+
+//
+// StorageClass collection REST resource.
+type StorageClassList struct {
+	// Total number in the collection.
+	Count int64 `json:"count"`
+	// List of resources.
+	Items []StorageClass `json:"resources"`
+}

--- a/pkg/controller/discovery/web/web.go
+++ b/pkg/controller/discovery/web/web.go
@@ -1,6 +1,13 @@
 package web
 
 import (
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/controller/pkg/logging"
@@ -10,14 +17,8 @@ import (
 	auth "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
-	"net/http"
-	"regexp"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"sort"
-	"strconv"
-	"strings"
-	"time"
 )
 
 // Application settings.
@@ -178,6 +179,13 @@ func (w *WebServer) addRoutes(r *gin.Engine) {
 			},
 		},
 		PvRestoreHandler{
+			ClusterScoped: ClusterScoped{
+				BaseHandler: BaseHandler{
+					container: w.Container,
+				},
+			},
+		},
+		StorageClassHandler{
 			ClusterScoped: ClusterScoped{
 				BaseHandler: BaseHandler{
 					container: w.Container,


### PR DESCRIPTION
This is related to #651 . The UI changes needed to read StorageClass data from the discovery service instead of from Mig resources are large enough that I won't be able to complete them this sprint. 

This is just a copy-paste of the discovery service files for another cluster-scoped resource (`PVs`) with var names changed. @jortel I can tell you that this builds and seems to work correctly when mig-controller is started, but I haven't been able to validate that it's working beyond that. Not entirely sure how to do so.