### PR TITLE
Bug 1879424: Remove destination stage pod check

### DIFF
--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -44,7 +44,6 @@ const (
 	EnsureStagePodsFromOrphanedPVCs = "EnsureStagePodsFromOrphanedPVCs"
 	StagePodsCreated                = "StagePodsCreated"
 	SourceStagePodsFailed           = "SourceStagePodsFailed"
-	DestinationStagePodsFailed      = "DestinationStagePodsFailed"
 	RestartRestic                   = "RestartRestic"
 	ResticRestarted                 = "ResticRestarted"
 	QuiesceApplications             = "QuiesceApplications"
@@ -552,16 +551,6 @@ func (t *Task) Run() error {
 		if restore == nil {
 			return errors.New("Restore not found")
 		}
-		report, err := t.ensureDestinationStagePodsStarted()
-		if err != nil {
-			return liberr.Wrap(err)
-		}
-		if report.failed {
-			t.fail(DestinationStagePodsFailed, report.reasons)
-			t.Requeue = NoReQ
-			break
-		}
-		t.Log.Info("all destination stage pods are ready")
 		completed, reasons := t.hasRestoreCompleted(restore)
 		if completed {
 			t.setResticConditions(restore)


### PR DESCRIPTION
The check for destination stage pods will not work because destination cluster stage pods are created during the restore process.

The current sequence is:
1. Create StageRestore
2. Immediately evaluate if Stage Pods are present on destination cluster

This is flawed because a restore will take a variable amount of time to generate the Stage Pods on the destination cluster. _Destination stage pods are created by Velero, not mig-controller directly._ We have no guarantee that Stage Pods will be present and bound to PVCs on the destination immediately after the StageRestore is submitted to Velero. 

Additionally, if we check for PVC binding issues constantly, we are guaranteed to trigger failure when we shouldn't necessarily do so, because all Pods will go through a period where they have not yet bound to their respective PVCs.

On my cluster this fails every migration involving PVCs.
