### PR TITLE
MIG-119-Rearrange workflow to enable update in condition in middle of a reconcile

### DIFF
--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -183,6 +183,9 @@ func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{Requeue: true}, nil
 	}
 
+	// End staging conditions.
+	migration.Status.EndStagingConditions()
+
 	// Ensure that migrations run serially ordered by when created
 	// and grouped with stage migrations followed by final migrations.
 	// Reconcile of a migration not in the desired order will be postponed.
@@ -208,9 +211,6 @@ func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.
 		migration.Status.Phase != Completed &&
 			!migration.Status.HasBlockerCondition(),
 		ReadyMessage)
-
-	// End staging conditions.
-	migration.Status.EndStagingConditions()
 
 	// Apply changes.
 	migration.MarkReconciled()


### PR DESCRIPTION
Rearrangement of flow makes sure that Conditions for `migmigration` CR do not get updated while the conditions are in the staging phase. We end the staging of conditions before migration begins.

QE test results after the change:
```
EXECUTION RESULT: OK (smoke/ocp-33393-bz1845569.yml)
EXECUTION RESULT: OK (smoke/ocp-26160-max-pvs.yml)
EXECUTION RESULT: OK (smoke/ocp-25212-initcont.yml)
EXECUTION RESULT: OK (smoke/ocp-32834-pvc-terminating.yml)
EXECUTION RESULT: FAILURE (smoke/ocp-34867-imagestreamsstage.yml)
EXECUTION RESULT: FAILURE (smoke/ocp-24769-cakephp.yml)
EXECUTION RESULT: OK (smoke/ocp-25022-cronjob-quiesced.yml)
EXECUTION RESULT: OK (smoke/ocp-32189-cronjob-with-pvc.yml)
EXECUTION RESULT: OK (smoke/ocp-25021-cronjob.yml)
EXECUTION RESULT: OK (smoke/ocp-24706-basicvolmig.yml)
EXECUTION RESULT: OK (smoke/ocp-28967-migplan-naming.yml)
EXECUTION RESULT: OK (smoke/ocp-33379-maxns-equalquota.yml)
EXECUTION RESULT: OK (smoke/ocp-33378-max-pvs-equalquota.yml)
EXECUTION RESULT: OK (smoke/ocp-29918-hooks.yml)
EXECUTION RESULT: OK (smoke/ocp-33423-hooksnosa.yml)
EXECUTION RESULT: OK (smoke/ocp-26032-maxns.yml)
EXECUTION RESULT: OK (smoke/ocp-32077-empty-pvc.yml)
EXECUTION RESULT: OK (smoke/ocp-30240-datavalidation.yml)
EXECUTION RESULT: OK (smoke/ocp-24872-mssql.yml)
EXECUTION RESULT: OK (smoke/ocp-25986-maxpods.yml)
EXECUTION RESULT: OK (smoke/ocp-33375-maxpods-equalquota.yml)
EXECUTION RESULT: OK (smoke/ocp-29947-customhooks.yml)
EXECUTION RESULT: OK (smoke/ocp-29946-hooksfailure.yml)
EXECUTION RESULT: OK (smoke/ocp-31358-restartrestic-newer-than-310.yml)
EXECUTION RESULT: OK (smoke/ocp-31339-pvc-not-connected.yml)
EXECUTION RESULT: OK (smoke/ocp-24787-redis.yml)
EXECUTION RESULT: FAILURE (smoke/ocp-28021-istags.yml)
EXECUTION RESULT: OK (smoke/ocp-25090-jobs.yml)
EXECUTION RESULT: OK (smoke/ocp-25000-sets.yml)
EXECUTION RESULT: OK (smoke/ocp-27335-velero-version.yml)
EXECUTION RESULT: OK (smoke/ocp-34821-increase-data.yml)
EXECUTION RESULT: OK (smoke/ocp-24995-role.yml)
EXECUTION RESULT: OK (smoke/ocp-29871-resquota.yml)
EXECUTION RESULT: OK (smoke/ocp-24997-configmap.yml)
EXECUTION RESULT: OK (smoke/ocp-24659-mysql.yml)
EXECUTION RESULT: OK (smoke/ocp-24730-django.yml)
EXECUTION RESULT: OK (smoke/ocp-24871-datagrid.yml)
EXECUTION RESULT: OK (smoke/ocp-34824-decrease-data.yml)
EXECUTION RESULT: OK (smoke/ocp-24686-project.yml)
EXECUTION RESULT: OK (smoke/ocp-31309-quotanoattach.yml)
EXECUTION RESULT: OK (smoke/ocp-29073-internalis.yml)
EXECUTION RESULT: OK (smoke/ocp-24797-mongodb.yml)
EXECUTION RESULT: OK (smoke/ocp-34703-crd.yml)
```
The following test cases failed due to a known bug
```
EXECUTION RESULT: FAILURE (smoke/ocp-34867-imagestreamsstage.yml)
EXECUTION RESULT: FAILURE (smoke/ocp-24769-cakephp.yml)
EXECUTION RESULT: FAILURE (smoke/ocp-28021-istags.yml)
```