### PR TITLE
Only refresh MigPlan from StartRefresh phase, skip MigCluster/MigStorage refresh.

### DIFF
--- a/pkg/controller/migmigration/verify.go
+++ b/pkg/controller/migmigration/verify.go
@@ -109,7 +109,7 @@ func (t *Task) reportHealthCondition() {
 	}
 }
 
-// Start a refresh on MigPlan and attached resources
+// Start a refresh on MigPlan
 func (t *Task) startRefresh() (bool, error) {
 	started := false
 
@@ -126,55 +126,13 @@ func (t *Task) startRefresh() (bool, error) {
 		return started, liberr.Wrap(err)
 	}
 
-	storage, err := plan.GetStorage(t.Client)
-	if err != nil {
-		return started, liberr.Wrap(err)
-	}
-	storage.Spec.Refresh = true
-	err = t.Client.Update(context.TODO(), storage)
-	if err != nil {
-		if errors.IsConflict(err) {
-			return started, nil
-		}
-		return started, liberr.Wrap(err)
-	}
-
-	srcCluster, err := plan.GetSourceCluster(t.Client)
-	if err != nil {
-		return started, liberr.Wrap(err)
-	}
-	srcCluster.Spec.Refresh = true
-	err = t.Client.Update(context.TODO(), srcCluster)
-	if err != nil {
-		if errors.IsConflict(err) {
-			return started, nil
-		}
-		return started, liberr.Wrap(err)
-	}
-
-	destCluster, err := plan.GetDestinationCluster(t.Client)
-	if err != nil {
-		return started, liberr.Wrap(err)
-	}
-	destCluster.Spec.Refresh = true
-	err = t.Client.Update(context.TODO(), destCluster)
-	if err != nil {
-		if errors.IsConflict(err) {
-			return started, nil
-		}
-		return started, liberr.Wrap(err)
-	}
-
 	started = true
 	return started, nil
 }
 
 // Verify plan finished with refresh before migrating
 func (t *Task) waitForRefresh() bool {
-	if t.PlanResources.MigPlan.Spec.Refresh == true ||
-		t.PlanResources.MigStorage.Spec.Refresh == true ||
-		t.PlanResources.SrcMigCluster.Spec.Refresh == true ||
-		t.PlanResources.DestMigCluster.Spec.Refresh == true {
+	if t.PlanResources.MigPlan.Spec.Refresh == true {
 		return false
 	}
 	return true


### PR DESCRIPTION
MigStorage and MigClusters use watch ProviderSources to continuously monitor health, so I don't think we need to manually poke them for a refresh at migration start time.

https://github.com/konveyor/mig-controller/blob/master/pkg/controller/migstorage/migstorage_controller.go#L68-L76
https://github.com/konveyor/mig-controller/blob/master/pkg/controller/migcluster/migcluster_controller.go#L69-L77

_The problem with performing a refresh on these two at migration start:_ updating  MigCluster/MigStorage will trigger reconciles of _all_ other MigPlans using these resources meaning that the MigPlan reconciler will be tied up for potentially a long time if the user has many several idle MigPlans.

I noticed this problem when running migrations in my stress test env with 50 MigPlans. It doesn't block the migration, but the MigPlan reconciler does get tied up for a while after.