### PR TITLE
MIG-323 - Add logging improvements to migmigration_controller

### DIFF
--- a/pkg/apis/migration/v1alpha1/condition.go
+++ b/pkg/apis/migration/v1alpha1/condition.go
@@ -25,12 +25,6 @@ const (
 	False = "False"
 )
 
-// Reasons
-const (
-	ReadyState           = "ReadyState"
-	ReconcileFailedState = "ReconciledFailedState"
-)
-
 // Category
 // Critical - Errors that block Reconcile() and the `Ready` condition.
 // Error - Errors that block the `Ready` condition.
@@ -335,7 +329,6 @@ func (r *Conditions) SetReady(ready bool, message string) {
 		r.SetCondition(Condition{
 			Type:     Ready,
 			Status:   True,
-			Reason:   ReadyState,
 			Category: Required,
 			Message:  message,
 		})
@@ -361,7 +354,6 @@ func (r *Conditions) SetReconcileFailed(err error) {
 	r.SetCondition(Condition{
 		Type:     ReconcileFailed,
 		Status:   True,
-		Reason:   ReconcileFailedState,
 		Category: Critical,
 		Message:  "Reconcile failed: []. See controller logs for details.",
 		Items:    []string{err.Error()},

--- a/pkg/apis/migration/v1alpha1/condition.go
+++ b/pkg/apis/migration/v1alpha1/condition.go
@@ -25,6 +25,12 @@ const (
 	False = "False"
 )
 
+// Reasons
+const (
+	ReadyState           = "ReadyState"
+	ReconcileFailedState = "ReconciledFailedState"
+)
+
 // Category
 // Critical - Errors that block Reconcile() and the `Ready` condition.
 // Error - Errors that block the `Ready` condition.
@@ -329,6 +335,7 @@ func (r *Conditions) SetReady(ready bool, message string) {
 		r.SetCondition(Condition{
 			Type:     Ready,
 			Status:   True,
+			Reason:   ReadyState,
 			Category: Required,
 			Message:  message,
 		})
@@ -354,6 +361,7 @@ func (r *Conditions) SetReconcileFailed(err error) {
 	r.SetCondition(Condition{
 		Type:     ReconcileFailed,
 		Status:   True,
+		Reason:   ReconcileFailedState,
 		Category: Critical,
 		Message:  "Reconcile failed: []. See controller logs for details.",
 		Items:    []string{err.Error()},

--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -273,7 +273,6 @@ func (r *ReconcileMigMigration) postpone(migration *migapi.MigMigration) (time.D
 	migration.Status.SetCondition(migapi.Condition{
 		Type:     Postponed,
 		Status:   True,
-		Reason:   Postponed,
 		Category: Critical,
 		Message:  fmt.Sprintf("Postponed %d seconds to ensure migrations run serially and in order.", requeueAfter/time.Second),
 	})

--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -29,6 +29,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -47,7 +48,7 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileMigMigration{Client: mgr.GetClient(), scheme: mgr.GetScheme()}
+	return &ReconcileMigMigration{Client: mgr.GetClient(), scheme: mgr.GetScheme(), EventRecorder: mgr.GetRecorder("migmigration_controller")}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -116,6 +117,8 @@ var _ reconcile.Reconciler = &ReconcileMigMigration{}
 // ReconcileMigMigration reconciles a MigMigration object
 type ReconcileMigMigration struct {
 	client.Client
+	record.EventRecorder
+
 	scheme *runtime.Scheme
 }
 
@@ -143,10 +146,12 @@ func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.
 	}
 
 	// Set values.
-	log.SetValues("migration", migration.Name)
+	log.SetValues("migration", request)
 
 	// Report reconcile error.
 	defer func() {
+		log.Info("CR", "conditions", migration.Status.Conditions)
+		migration.Status.Conditions.RecordEvents(migration, r.EventRecorder)
 		if err == nil || errors.IsConflict(err) {
 			return
 		}
@@ -207,7 +212,7 @@ func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.
 	migration.Status.SetReady(
 		migration.Status.Phase != Completed &&
 			!migration.Status.HasBlockerCondition(),
-		ReadyMessage)
+		"The migration is ready.")
 
 	// End staging conditions.
 	migration.Status.EndStagingConditions()
@@ -268,8 +273,9 @@ func (r *ReconcileMigMigration) postpone(migration *migapi.MigMigration) (time.D
 	migration.Status.SetCondition(migapi.Condition{
 		Type:     Postponed,
 		Status:   True,
+		Reason:   Postponed,
 		Category: Critical,
-		Message:  fmt.Sprintf(PostponedMessage, requeueAfter/time.Second),
+		Message:  fmt.Sprintf("Postponed %d seconds to ensure migrations run serially and in order.", requeueAfter/time.Second),
 	})
 
 	return requeueAfter, nil

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -85,7 +85,7 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (time.Du
 				Status:   True,
 				Reason:   task.Phase,
 				Category: Advisory,
-				Message:  SucceededMessage,
+				Message:  "The migration has completed successfully.",
 				Durable:  true,
 			})
 		}
@@ -93,7 +93,7 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (time.Du
 	}
 
 	phase, n, total := task.Itinerary.progressReport(task.Phase)
-	message := fmt.Sprintf(RunningMessage, n, total)
+	message := fmt.Sprintf("Step: %d/%d", n, total)
 	migration.Status.SetCondition(migapi.Condition{
 		Type:     Running,
 		Status:   True,

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -175,23 +175,25 @@ func (t Task) hasRestoreCompleted(restore *velero.Restore) (bool, []string) {
 // Set warning conditions on migmigration if there were restic errors
 func (t *Task) setResticConditions(restore *velero.Restore) {
 	if len(restore.Status.PodVolumeRestoreErrors) > 0 {
-		message := fmt.Sprintf(ResticErrorsMessage, len(restore.Status.PodVolumeRestoreErrors), restore.Name)
 		t.Owner.Status.SetCondition(migapi.Condition{
 			Type:     ResticErrors,
 			Status:   True,
+			Reason:   ErrorsDetected,
 			Category: migapi.Warn,
-			Message:  message,
-			Durable:  true,
+			Message: fmt.Sprintf("There were errors found in %d Restic volume restores. See restore `%s` for details",
+				len(restore.Status.PodVolumeRestoreErrors), restore.Name),
+			Durable: true,
 		})
 	}
 	if len(restore.Status.PodVolumeRestoreVerifyErrors) > 0 {
-		message := fmt.Sprintf(ResticVerifyErrorsMessage, len(restore.Status.PodVolumeRestoreVerifyErrors), restore.Name)
 		t.Owner.Status.SetCondition(migapi.Condition{
 			Type:     ResticVerifyErrors,
 			Status:   True,
+			Reason:   ErrorsDetected,
 			Category: migapi.Warn,
-			Message:  message,
-			Durable:  true,
+			Message: fmt.Sprintf("There were verify errors found in %d Restic volume restores. See restore `%s` for details",
+				len(restore.Status.PodVolumeRestoreVerifyErrors), restore.Name),
+			Durable: true,
 		})
 	}
 }

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -178,7 +178,6 @@ func (t *Task) setResticConditions(restore *velero.Restore) {
 		t.Owner.Status.SetCondition(migapi.Condition{
 			Type:     ResticErrors,
 			Status:   True,
-			Reason:   ErrorsDetected,
 			Category: migapi.Warn,
 			Message: fmt.Sprintf("There were errors found in %d Restic volume restores. See restore `%s` for details",
 				len(restore.Status.PodVolumeRestoreErrors), restore.Name),
@@ -189,7 +188,6 @@ func (t *Task) setResticConditions(restore *velero.Restore) {
 		t.Owner.Status.SetCondition(migapi.Condition{
 			Type:     ResticVerifyErrors,
 			Status:   True,
-			Reason:   ErrorsDetected,
 			Category: migapi.Warn,
 			Message: fmt.Sprintf("There were verify errors found in %d Restic volume restores. See restore `%s` for details",
 				len(restore.Status.PodVolumeRestoreVerifyErrors), restore.Name),

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -851,7 +851,6 @@ func (t *Task) init() error {
 		t.Owner.Status.SetCondition(migapi.Condition{
 			Type:     StageNoOp,
 			Status:   True,
-			Reason:   StageNoOp,
 			Category: migapi.Warn,
 			Message:  "Stage migration was run without any PVs or ImageStreams in source cluster. No Velero operations were initiated.",
 			Durable:  true,

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -747,7 +747,7 @@ func (t *Task) Run() error {
 			Status:   True,
 			Reason:   Cancel,
 			Category: Advisory,
-			Message:  CancelInProgressMessage,
+			Message:  "The migration is being canceled.",
 			Durable:  true,
 		})
 		if err = t.next(); err != nil {
@@ -798,7 +798,7 @@ func (t *Task) Run() error {
 			Status:   True,
 			Reason:   Cancel,
 			Category: Advisory,
-			Message:  CanceledMessage,
+			Message:  "The migration has been canceled.",
 			Durable:  true,
 		})
 		if err = t.next(); err != nil {
@@ -851,8 +851,9 @@ func (t *Task) init() error {
 		t.Owner.Status.SetCondition(migapi.Condition{
 			Type:     StageNoOp,
 			Status:   True,
+			Reason:   StageNoOp,
 			Category: migapi.Warn,
-			Message:  StageNoOpMessage,
+			Message:  "Stage migration was run without any PVs or ImageStreams in source cluster. No Velero operations were initiated.",
 			Durable:  true,
 		})
 	}
@@ -1003,7 +1004,7 @@ func (t *Task) fail(nextPhase string, reasons []string) {
 		Status:   True,
 		Reason:   t.Phase,
 		Category: Advisory,
-		Message:  FailedMessage,
+		Message:  "The migration has failed.  See: Errors.",
 		Durable:  true,
 	})
 	t.Phase = nextPhase

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -44,9 +44,7 @@ const (
 	NotFound            = "NotFound"
 	NotReady            = "NotReady"
 	Cancel              = "Cancel"
-	ClosedState         = "ClosedState"
 	ErrorsDetected      = "ErrorsDetected"
-	FinalMigrationState = "FinalMigrationState"
 	UnhealthyState      = "UnhealthyState"
 	HealthyState        = "HealthyState"
 )
@@ -132,7 +130,6 @@ func (r ReconcileMigMigration) validatePlan(migration *migapi.MigMigration) (*mi
 		migration.Status.SetCondition(migapi.Condition{
 			Type:     PlanClosed,
 			Status:   True,
-			Reason:   ClosedState,
 			Category: Critical,
 			Message: fmt.Sprintf("The associated migration plan is closed, subject: %s.",
 				path.Join(migration.Spec.MigPlanRef.Namespace, migration.Spec.MigPlanRef.Name)),
@@ -182,7 +179,6 @@ func (r ReconcileMigMigration) validateFinalMigration(plan *migapi.MigPlan, migr
 		migration.Status.SetCondition(migapi.Condition{
 			Type:     HasFinalMigration,
 			Status:   True,
-			Reason:   FinalMigrationState,
 			Category: Critical,
 			Message: fmt.Sprintf("The associated MigPlan already has a final migration, subject: %s.",
 				path.Join(migration.Spec.MigPlanRef.Namespace, migration.Spec.MigPlanRef.Name)),

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -42,11 +42,8 @@ const (
 const (
 	NotSet              = "NotSet"
 	NotFound            = "NotFound"
-	NotReady            = "NotReady"
 	Cancel              = "Cancel"
 	ErrorsDetected      = "ErrorsDetected"
-	UnhealthyState      = "UnhealthyState"
-	HealthyState        = "HealthyState"
 )
 
 // Statuses
@@ -118,7 +115,6 @@ func (r ReconcileMigMigration) validatePlan(migration *migapi.MigMigration) (*mi
 		migration.Status.SetCondition(migapi.Condition{
 			Type:     PlanNotReady,
 			Status:   True,
-			Reason:   NotReady,
 			Category: Critical,
 			Message: fmt.Sprintf("The referenced `migPlanRef` does not have a `Ready` condition, subject: %s.",
 				path.Join(migration.Spec.MigPlanRef.Namespace, migration.Spec.MigPlanRef.Name)),
@@ -201,7 +197,6 @@ func (r ReconcileMigMigration) validateRegistriesRunning(migration *migapi.MigMi
 			migration.Status.SetCondition(migapi.Condition{
 				Type:     RegistriesUnhealthy,
 				Status:   True,
-				Reason:   UnhealthyState,
 				Category: migapi.Critical,
 				Message:  message,
 				Durable:  true,
@@ -218,7 +213,6 @@ func setMigRegistryHealthyCondition(migration *migapi.MigMigration) {
 	migration.Status.SetCondition(migapi.Condition{
 		Type:     RegistriesHealthy,
 		Status:   True,
-		Reason:   HealthyState,
 		Category: migapi.Required,
 		Message:  "The migration registries are healthy.",
 		Durable:  true,

--- a/pkg/controller/migmigration/verify.go
+++ b/pkg/controller/migmigration/verify.go
@@ -104,7 +104,8 @@ func (t *Task) reportHealthCondition() {
 			Status:   True,
 			Category: migapi.Warn,
 			Reason:   ErrorsDetected,
-			Message:  fmt.Sprintf(UnhealthyNamespacesMessage, destination),
+			Message: fmt.Sprintf("'%s' cluster has unhealthy namespaces. See status.namespaces for details.",
+				destination),
 		})
 	}
 }


### PR DESCRIPTION
This adds logging improvements and kube events for status conditions to the Migmigration_controller, follows the pattern applied in #698 for Migstorage_controller.

Essentially, this PR does the following:
- Adds the eventRecorder for status conditions
- Adds end of reconcile logging for status conditions
- Moves all const messages for migmigration controller directly into where conditions are set, some messages may be reframed
- Adds additional context/subject if needed to the condition messages
- Adds missing `Reason` field for the Conditions