### PR TITLE
MIG-323 - Add logging improvements to miganalytic_controller 

### DIFF
--- a/pkg/controller/miganalytic/miganalytics_controller.go
+++ b/pkg/controller/miganalytic/miganalytics_controller.go
@@ -67,7 +67,7 @@ func Add(mgr manager.Manager) error {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager) reconcile.Reconciler { // TODO check if its miganalytic of miganalytics
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileMigAnalytic{Client: mgr.GetClient(), scheme: mgr.GetScheme(), EventRecorder: mgr.GetRecorder("miganalytic_controller")}
 }
 

--- a/pkg/controller/miganalytic/miganalytics_controller.go
+++ b/pkg/controller/miganalytic/miganalytics_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
@@ -66,8 +67,8 @@ func Add(mgr manager.Manager) error {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileMigAnalytic{Client: mgr.GetClient(), scheme: mgr.GetScheme()}
+func newReconciler(mgr manager.Manager) reconcile.Reconciler { // TODO check if its miganalytic of miganalytics
+	return &ReconcileMigAnalytic{Client: mgr.GetClient(), scheme: mgr.GetScheme(), EventRecorder: mgr.GetRecorder("miganalytic_controller")}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -97,12 +98,15 @@ var _ reconcile.Reconciler = &ReconcileMigAnalytic{}
 // ReconcileMigAnalytic reconciles a MigAnalytic object
 type ReconcileMigAnalytic struct {
 	client.Client
+	record.EventRecorder
+
 	scheme *runtime.Scheme
 }
 
 func (r *ReconcileMigAnalytic) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	var err error
 	log.Reset()
+	log.SetValues("analytic", request)
 
 	// Fetch the MigAnalytic instance
 	analytic := &migapi.MigAnalytic{}
@@ -118,6 +122,8 @@ func (r *ReconcileMigAnalytic) Reconcile(request reconcile.Request) (reconcile.R
 
 	// Report reconcile error.
 	defer func() {
+		log.Info("CR", "conditions", analytic.Status.Conditions)
+		analytic.Status.Conditions.RecordEvents(analytic, r.EventRecorder)
 		if err == nil || errors.IsConflict(err) {
 			return
 		}
@@ -160,7 +166,7 @@ func (r *ReconcileMigAnalytic) Reconcile(request reconcile.Request) (reconcile.R
 	// Ready
 	analytic.Status.SetReady(
 		!analytic.Status.HasBlockerCondition(),
-		ReadyMessage)
+		"The analytic is ready.")
 
 	// End staging conditions.
 	analytic.Status.EndStagingConditions()

--- a/pkg/controller/miganalytic/validation.go
+++ b/pkg/controller/miganalytic/validation.go
@@ -38,13 +38,6 @@ const (
 	False = migapi.False
 )
 
-// Messages
-const (
-	ReadyMessage          = "The analytic is ready."
-	InvalidPlanRefMessage = "The referenced plan does not exist."
-	PostponedMessage      = "Waiting %d seconds for referenced MigPlan to become ready."
-)
-
 // Validate the analytic resource.
 func (r ReconcileMigAnalytic) validate(analytic *migapi.MigAnalytic) error {
 	err := r.validatePlan(analytic)
@@ -71,7 +64,7 @@ func (r ReconcileMigAnalytic) validatePlan(analytic *migapi.MigAnalytic) error {
 			Status:   True,
 			Reason:   NotFound,
 			Category: Critical,
-			Message:  InvalidPlanRefMessage,
+			Message:  fmt.Sprintf("The referenced plan does not exist."),
 		})
 		return nil
 	} else if err != nil {
@@ -85,7 +78,7 @@ func (r ReconcileMigAnalytic) validatePlan(analytic *migapi.MigAnalytic) error {
 			Status:   True,
 			Reason:   TestFailed,
 			Category: Critical,
-			Message:  fmt.Sprintf(PostponedMessage, RequeueInterval),
+			Message:  fmt.Sprintf("Waiting %d seconds for referenced MigPlan to become ready.", RequeueInterval),
 		})
 		return nil
 	} else if err != nil {


### PR DESCRIPTION
This adds logging improvements and kube events for status conditions to the miganalytic_controller, follows the pattern applied in #698 for miganalytic_controller.

Essentially, this PR does the following:
- Adds the eventRecorder for status conditions
- Adds end of reconcile logging for status conditions
- Moves all const messages for miganalytic controller directly into where conditions are set, some messages may be reframed
- Adds additional context/subject if needed to the condition messages
- Adds missing `Reason` field for the Conditions