### PR TITLE
Refine getRegistryPods query to fetch only the associated registry pods

### DIFF
--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -359,18 +359,18 @@ func (r *MigPlan) UpdateRegistryDeployment(storage *MigStorage, deployment *apps
 	deployment.Spec = appsv1.DeploymentSpec{
 		Replicas: pointer.Int32Ptr(1),
 		Selector: metav1.SetAsLabelSelector(map[string]string{
-			"app":        name,
-			"deployment": name,
-			"migplan":    string(r.UID),
+			"app":                  name,
+			"deployment":           name,
+			"migplan":              string(r.UID),
 			MigrationRegistryLabel: string(r.UID),
 		}),
 		Template: kapi.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				CreationTimestamp: metav1.Time{},
 				Labels: map[string]string{
-					"app":        name,
-					"deployment": name,
-					"migplan":    string(r.UID),
+					"app":                  name,
+					"deployment":           name,
+					"migplan":              string(r.UID),
 					MigrationRegistryLabel: string(r.UID),
 				},
 			},

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -362,6 +362,7 @@ func (r *MigPlan) UpdateRegistryDeployment(storage *MigStorage, deployment *apps
 			"app":        name,
 			"deployment": name,
 			"migplan":    string(r.UID),
+			MigrationRegistryLabel: string(r.UID),
 		}),
 		Template: kapi.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
@@ -370,6 +371,7 @@ func (r *MigPlan) UpdateRegistryDeployment(storage *MigStorage, deployment *apps
 					"app":        name,
 					"deployment": name,
 					"migplan":    string(r.UID),
+					MigrationRegistryLabel: string(r.UID),
 				},
 			},
 			Spec: kapi.PodSpec{

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -48,7 +48,7 @@ const (
 	ClosedIndexField = "closed"
 )
 
-// MigPlanHook hold a referene to a MigHook along with the desired phase to run it in
+// MigPlanHook hold a reference to a MigHook along with the desired phase to run it in
 type MigPlanHook struct {
 	Reference          *kapi.ObjectReference `json:"reference"`
 	Phase              string                `json:"phase"`
@@ -231,15 +231,15 @@ func (r *MigPlan) ListMigrations(client k8sclient.Client) ([]*MigMigration, erro
 // Registry
 //
 
-// Registry label for controller-created migration registry resources
+// Registry labels for controller-created migration registry resources
 const (
-	MigrationRegistryLabel = "migration-registry"
+	MigrationRegistryLabel = "migration.openshift.io/migration-registry"
 )
 
 // Build a credentials Secret as desired for the source cluster.
 func (r *MigPlan) BuildRegistrySecret(client k8sclient.Client, storage *MigStorage) (*kapi.Secret, error) {
 	labels := r.GetCorrelationLabels()
-	labels[MigrationRegistryLabel] = string(r.UID)
+	labels[MigrationRegistryLabel] = True
 	secret := &kapi.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:       labels,
@@ -271,7 +271,7 @@ func (r *MigPlan) UpdateRegistrySecret(client k8sclient.Client, storage *MigStor
 func (r *MigPlan) GetRegistrySecret(client k8sclient.Client) (*kapi.Secret, error) {
 	list := kapi.SecretList{}
 	labels := r.GetCorrelationLabels()
-	labels[MigrationRegistryLabel] = string(r.UID)
+	labels[MigrationRegistryLabel] = True
 	err := client.List(
 		context.TODO(),
 		k8sclient.MatchingLabels(labels),
@@ -295,7 +295,7 @@ func (r *MigPlan) EqualsRegistrySecret(a, b *kapi.Secret) bool {
 // Build a Registry Deployment.
 func (r *MigPlan) BuildRegistryDeployment(storage *MigStorage, proxySecret *kapi.Secret, name, dirName, registryImage string) *appsv1.Deployment {
 	labels := r.GetCorrelationLabels()
-	labels[MigrationRegistryLabel] = string(r.UID)
+	labels[MigrationRegistryLabel] = True
 	labels["app"] = name
 	labels["migplan"] = string(r.UID)
 	deployment := &appsv1.Deployment{
@@ -362,7 +362,7 @@ func (r *MigPlan) UpdateRegistryDeployment(storage *MigStorage, deployment *apps
 			"app":                  name,
 			"deployment":           name,
 			"migplan":              string(r.UID),
-			MigrationRegistryLabel: string(r.UID),
+			MigrationRegistryLabel: True,
 		}),
 		Template: kapi.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
@@ -371,7 +371,7 @@ func (r *MigPlan) UpdateRegistryDeployment(storage *MigStorage, deployment *apps
 					"app":                  name,
 					"deployment":           name,
 					"migplan":              string(r.UID),
-					MigrationRegistryLabel: string(r.UID),
+					MigrationRegistryLabel: True,
 				},
 			},
 			Spec: kapi.PodSpec{
@@ -436,7 +436,7 @@ func (r *MigPlan) UpdateRegistryDeployment(storage *MigStorage, deployment *apps
 func (r *MigPlan) GetRegistryDeployment(client k8sclient.Client) (*appsv1.Deployment, error) {
 	list := appsv1.DeploymentList{}
 	labels := r.GetCorrelationLabels()
-	labels[MigrationRegistryLabel] = string(r.UID)
+	labels[MigrationRegistryLabel] = True
 	err := client.List(
 		context.TODO(),
 		k8sclient.MatchingLabels(labels),
@@ -479,7 +479,7 @@ func (r *MigPlan) EqualsRegistryDeployment(a, b *appsv1.Deployment) bool {
 // Build a Registry Service as desired for the specified cluster.
 func (r *MigPlan) BuildRegistryService(name string) *kapi.Service {
 	labels := r.GetCorrelationLabels()
-	labels[MigrationRegistryLabel] = string(r.UID)
+	labels[MigrationRegistryLabel] = True
 	labels["app"] = name
 	service := &kapi.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -515,7 +515,7 @@ func (r *MigPlan) UpdateRegistryService(service *kapi.Service, name string) {
 func (r *MigPlan) GetRegistryService(client k8sclient.Client) (*kapi.Service, error) {
 	list := kapi.ServiceList{}
 	labels := r.GetCorrelationLabels()
-	labels[MigrationRegistryLabel] = string(r.UID)
+	labels[MigrationRegistryLabel] = True
 	err := client.List(
 		context.TODO(),
 		k8sclient.MatchingLabels(labels),

--- a/pkg/controller/migmigration/registry.go
+++ b/pkg/controller/migmigration/registry.go
@@ -21,11 +21,6 @@ const (
 	MigRegistryDirAnnotationKey string = "openshift.io/migration-registry-dir"
 )
 
-// Registry label for controller-created migration registry resources
-const (
-	MigrationRegistryLabel = "migration-registry"
-)
-
 // Returns the right backup/restore annotations including registry-specific ones
 func (t *Task) getAnnotations(client k8sclient.Client) (map[string]string, error) {
 	annotations := t.Annotations

--- a/pkg/controller/migmigration/registry.go
+++ b/pkg/controller/migmigration/registry.go
@@ -21,6 +21,11 @@ const (
 	MigRegistryDirAnnotationKey string = "openshift.io/migration-registry-dir"
 )
 
+// Registry label for controller-created migration registry resources
+const (
+	MigrationRegistryLabel = "migration-registry"
+)
+
 // Returns the right backup/restore annotations including registry-specific ones
 func (t *Task) getAnnotations(client k8sclient.Client) (map[string]string, error) {
 	annotations := t.Annotations

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -316,7 +316,8 @@ func getRegistryPods(plan *migapi.MigPlan, registryClient compat.Client) (corev1
 	registryPodList := corev1.PodList{}
 	err := registryClient.List(context.TODO(), &k8sclient.ListOptions{
 		LabelSelector: k8sLabels.SelectorFromSet(map[string]string{
-			MigrationRegistryLabel: string(plan.UID),
+			migapi.MigrationRegistryLabel: True,
+			"migplan":                     string(plan.UID),
 		}),
 	}, &registryPodList)
 

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -316,7 +316,7 @@ func getRegistryPods(plan *migapi.MigPlan, registryClient compat.Client) (corev1
 	registryPodList := corev1.PodList{}
 	err := registryClient.List(context.TODO(), &k8sclient.ListOptions{
 		LabelSelector: k8sLabels.SelectorFromSet(map[string]string{
-			"migration-registry": string(plan.UID),
+			MigrationRegistryLabel: string(plan.UID),
 		}),
 	}, &registryPodList)
 

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -316,7 +316,7 @@ func getRegistryPods(plan *migapi.MigPlan, registryClient compat.Client) (corev1
 	registryPodList := corev1.PodList{}
 	err := registryClient.List(context.TODO(), &k8sclient.ListOptions{
 		LabelSelector: k8sLabels.SelectorFromSet(map[string]string{
-			"migplan": string(plan.UID),
+			"migration-registry": string(plan.UID),
 		}),
 	}, &registryPodList)
 


### PR DESCRIPTION
This PR does the following (fixes https://github.com/konveyor/mig-controller/issues/740):
- Updates the registry deployment such that the `migration-registry` label gets cascaded to registry pods.
- Updates the `getRegistryPods` function to fetch the pods based on the `migration-registry` label and not on the `migplan` label.