### PR TITLE
Enhance Makefile to allow for easier running of local controller + discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,15 +19,33 @@ manager: generate fmt vet
 # Run against the configured Kubernetes cluster in ~/.kube/config after login as mig controller SA
 run: generate fmt vet
 	./hack/controller-sa-login.sh
-	KUBECONFIG=$(KUBECONFIG)-${KUBECONFIG_POSTFIX} go run -tags "${BUILDTAGS}" ./cmd/manager/main.go
+	KUBECONFIG=$(KUBECONFIG)-${KUBECONFIG_POSTFIX} ./hack/start-local-controller.sh
 
+# Same as `make run`, but skips generate, fmt, vet. Useful for quick iteration.
+run-fast:
+	./hack/controller-sa-login.sh
+	KUBECONFIG=$(KUBECONFIG)-${KUBECONFIG_POSTFIX} ./hack/start-local-controller.sh
 
 # Run against the configured Kubernetes cluster in ~/.kube/config, skip login to mig-controller SA
 run-skip-sa-login: generate fmt vet
-	go run -tags "${BUILDTAGS}" ./cmd/manager/main.go
+	./hack/start-local-controller.sh
 
 tilt:
 	 IMG=${IMG} TEMPLATE=${TEMPLATE} tilt up --hud=false --no-browser --file tools/tilt/Tiltfile
+
+# Patch MigrationController CR to use local mig-controller + discovery service
+use-local-controller:
+	oc patch migrationcontroller migration-controller --type=json \
+	--patch '[{ "op": "add", "path": "/spec/discovery_api_url_override", "value": "http://localhost:8080" }]'
+	oc patch migrationcontroller migration-controller --type=json \
+	--patch '[{ "op": "replace", "path": "/spec/migration_controller", "value": false }]'
+
+# Patch MigrationController CR to use on-cluster mig-controller + discovery service
+use-oncluster-controller:
+	oc patch migrationcontroller migration-controller --type=json \
+	--patch '[{ "op": "remove", "path": "/spec/discovery_api_url_override" }]'
+	oc patch migrationcontroller migration-controller --type=json \
+	--patch '[{ "op": "replace", "path": "/spec/migration_controller", "value": true }]'
 
 # Install CRDs into a cluster
 install: manifests

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ tilt:
 # Patch MigrationController CR to use local mig-controller + discovery service
 use-local-controller:
 	oc patch migrationcontroller migration-controller --type=json \
-	--patch '[{ "op": "add", "path": "/spec/discovery_api_url_override", "value": "http://localhost:8080" }]'
+	--patch '[{ "op": "add", "path": "/spec/discovery_api_url", "value": "http://localhost:8080" }]'
 	oc patch migrationcontroller migration-controller --type=json \
 	--patch '[{ "op": "replace", "path": "/spec/migration_controller", "value": false }]'
 
@@ -45,7 +45,7 @@ use-oncluster-controller:
 	oc patch migrationcontroller migration-controller --type=json \
 	--patch '[{ "op": "replace", "path": "/spec/migration_controller", "value": true }]'
 	oc patch migrationcontroller migration-controller --type=json \
-	--patch '[{ "op": "remove", "path": "/spec/discovery_api_url_override" }]'
+	--patch '[{ "op": "remove", "path": "/spec/discovery_api_url" }]'
 
 # Install CRDs into a cluster
 install: manifests

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,9 @@ use-local-controller:
 # Patch MigrationController CR to use on-cluster mig-controller + discovery service
 use-oncluster-controller:
 	oc patch migrationcontroller migration-controller --type=json \
-	--patch '[{ "op": "remove", "path": "/spec/discovery_api_url_override" }]'
-	oc patch migrationcontroller migration-controller --type=json \
 	--patch '[{ "op": "replace", "path": "/spec/migration_controller", "value": true }]'
+	oc patch migrationcontroller migration-controller --type=json \
+	--patch '[{ "op": "remove", "path": "/spec/discovery_api_url_override" }]'
 
 # Install CRDs into a cluster
 install: manifests

--- a/hack/controller-sa-login.sh
+++ b/hack/controller-sa-login.sh
@@ -16,7 +16,6 @@ MIG_UI_ROUTE_PATH=$MIG_KUBECONFIG-ui-route
 # Interrogate mig-ui route to set CORS_ALLOWED_ORIGINS 
 MIG_UI_ROUTE_HOST=$(oc get route migration -n openshift-migration migration -o=jsonpath='{.items[0].spec.host}')
 if [ $? -eq 0 ]; then
-    echo "Found mig-ui route domain."
     echo "${MIG_UI_ROUTE_HOST}" > ${MIG_UI_ROUTE_PATH}
 else
     echo "Missing mig-ui route domain. Continuing without setting CORS_ALLOWED_ORIGINS."

--- a/hack/controller-sa-login.sh
+++ b/hack/controller-sa-login.sh
@@ -7,8 +7,22 @@ then
       exit 1
 fi
 
-# Create copy of original KUBECONFIG that will be logged in with mig-controller SA token
+# Set path for new KUBECONFIG
 MIG_KUBECONFIG=$KUBECONFIG-$KUBECONFIG_POSTFIX
+
+# Drop a copy of mig-ui hostname on disk
+MIG_UI_ROUTE_PATH=$MIG_KUBECONFIG-ui-route
+
+# Interrogate mig-ui route to set CORS_ALLOWED_ORIGINS 
+MIG_UI_ROUTE_HOST=$(oc get route migration -n openshift-migration migration -o=jsonpath='{.items[0].spec.host}')
+if [ $? -eq 0 ]; then
+    echo "Found mig-ui route domain."
+    echo "${MIG_UI_ROUTE_HOST}" > ${MIG_UI_ROUTE_PATH}
+else
+    echo "Missing mig-ui route domain. Continuing without setting CORS_ALLOWED_ORIGINS."
+fi
+
+# Create copy of original KUBECONFIG that will be logged in with mig-controller SA token
 cp $KUBECONFIG $MIG_KUBECONFIG
 
 # Check for existence of migration-controller SA before logging in

--- a/hack/start-local-controller.sh
+++ b/hack/start-local-controller.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 
+# Warn user if in-cluster controller is running
+INCLUSTER_CONTROLLER_ENABLED=$(oc get migrationcontroller migration-controller -n openshift-migration -o jsonpath='{.spec.migration_controller}')
+if [ "$INCLUSTER_CONTROLLER_ENABLED" == "true" ]; then
+    echo
+    echo "[!] WARNING: migrationcontroller CR has '.spec.migration_controller=true' Running a local controller will conflict."
+    echo "[!] To resolve conflict, run 'make use-local-controller' to disable the on-cluster controller, then re-run this command."
+    echo
+fi
+
 # Pull mig-ui route host from disk to set CORS_ALLOWED_ORIGINS 
 MIG_UI_ROUTE_PATH=$KUBECONFIG-ui-route
 MIG_UI_ROUTE=$(cat $MIG_UI_ROUTE_PATH)
 if [ $? -eq 0 ]; then
     echo "Found mig-ui route domain. Setting discovery service CORS_ALLOWED_ORIGINS=$MIG_UI_ROUTE"
     export CORS_ALLOWED_ORIGINS=${MIG_UI_ROUTE}
+    rm $MIG_UI_ROUTE_PATH
 else
     echo "Missing mig-ui route domain. Continuing without setting CORS_ALLOWED_ORIGINS."
 fi

--- a/hack/start-local-controller.sh
+++ b/hack/start-local-controller.sh
@@ -9,17 +9,20 @@ if [ "$INCLUSTER_CONTROLLER_ENABLED" == "true" ]; then
     echo
 fi
 
+# CORS rules for enabling local UI to communicate with local mig-controller
+LOCAL_UI_CORS='//127.0.0.1(:|$) //localhost(:|$)'
+
 # Pull mig-ui route host from disk to set CORS_ALLOWED_ORIGINS 
 MIG_UI_ROUTE_PATH=$KUBECONFIG-ui-route
-LOCAL_UI="localhost"
 MIG_UI_ROUTE=$(cat $MIG_UI_ROUTE_PATH)
+
 if [ $? -eq 0 ]; then
-    echo "Found mig-ui route domain. Setting discovery service CORS_ALLOWED_ORIGINS=${MIG_UI_ROUTE},${LOCAL_UI}"
-    export CORS_ALLOWED_ORIGINS="${MIG_UI_ROUTE},${LOCAL_UI}"
+    export CORS_ALLOWED_ORIGINS="${MIG_UI_ROUTE} ${LOCAL_UI_CORS}"
+    echo "Found mig-ui route domain. Setting discovery service CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS}"
     rm $MIG_UI_ROUTE_PATH
 else
-    echo "Missing mig-ui route domain. Setting discovery service CORS_ALLOWED_ORIGINS=${LOCAL_UI}"
-    export CORS_ALLOWED_ORIGINS="${LOCAL_UI}"
+    export CORS_ALLOWED_ORIGINS="${LOCAL_UI_CORS}"
+    echo "Missing mig-ui route domain. Setting discovery service CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS}"
 fi
 
 # Start the controller

--- a/hack/start-local-controller.sh
+++ b/hack/start-local-controller.sh
@@ -11,13 +11,15 @@ fi
 
 # Pull mig-ui route host from disk to set CORS_ALLOWED_ORIGINS 
 MIG_UI_ROUTE_PATH=$KUBECONFIG-ui-route
+LOCAL_UI="localhost"
 MIG_UI_ROUTE=$(cat $MIG_UI_ROUTE_PATH)
 if [ $? -eq 0 ]; then
-    echo "Found mig-ui route domain. Setting discovery service CORS_ALLOWED_ORIGINS=$MIG_UI_ROUTE"
-    export CORS_ALLOWED_ORIGINS=${MIG_UI_ROUTE}
+    echo "Found mig-ui route domain. Setting discovery service CORS_ALLOWED_ORIGINS=${MIG_UI_ROUTE},${LOCAL_UI}"
+    export CORS_ALLOWED_ORIGINS="${MIG_UI_ROUTE},${LOCAL_UI}"
     rm $MIG_UI_ROUTE_PATH
 else
-    echo "Missing mig-ui route domain. Continuing without setting CORS_ALLOWED_ORIGINS."
+    echo "Missing mig-ui route domain. Setting discovery service CORS_ALLOWED_ORIGINS=${LOCAL_UI}"
+    export CORS_ALLOWED_ORIGINS="${LOCAL_UI}"
 fi
 
 # Start the controller

--- a/hack/start-local-controller.sh
+++ b/hack/start-local-controller.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Pull mig-ui route host from disk to set CORS_ALLOWED_ORIGINS 
+MIG_UI_ROUTE_PATH=$KUBECONFIG-ui-route
+MIG_UI_ROUTE=$(cat $MIG_UI_ROUTE_PATH)
+if [ $? -eq 0 ]; then
+    echo "Found mig-ui route domain. Setting discovery service CORS_ALLOWED_ORIGINS=$MIG_UI_ROUTE"
+    export CORS_ALLOWED_ORIGINS=${MIG_UI_ROUTE}
+else
+    echo "Missing mig-ui route domain. Continuing without setting CORS_ALLOWED_ORIGINS."
+fi
+
+# Start the controller
+go run -tags "${BUILDTAGS}" ./cmd/manager/main.go


### PR DESCRIPTION
We've had a pretty poor dev experience around running mig-controller locally in situations when mig-ui integration testing is also needed. Up until now you would have needed to build a container image, push it, and swap the image out in your migrationcontroller CR to test mig-controller change in mig-ui. 

I wanted to fix this to enable faster iteration time for controller devs who need to test their changes along with mig-ui

 - `make run` now handles CORS setup for discovery service automatically, enabling mig-ui to be fully functional with locally running mig-controller
 - Two new targets, `make use-local-controller` and `make use-oncluster-controller` will automatically patch the mig-operator `migrationcontroller` CR to make necessary changes for running mig-controller locally or on-cluster.

Closes #728 