### PR TITLE
Remove backup replication progress message

### DIFF
--- a/pkg/controller/migmigration/backup.go
+++ b/pkg/controller/migmigration/backup.go
@@ -403,7 +403,6 @@ func (t *Task) deleteBackups() error {
 
 // Determine whether backups are replicated by velero on the destination cluster.
 func (t *Task) isBackupReplicated(backup *velero.Backup) (bool, error) {
-	progress := []string{}
 	client, err := t.getDestinationClient()
 	if err != nil {
 		return false, err
@@ -421,15 +420,7 @@ func (t *Task) isBackupReplicated(backup *velero.Backup) (bool, error) {
 	}
 	if k8serrors.IsNotFound(err) {
 		err = nil
-		progress = append(
-			progress,
-			fmt.Sprintf(
-				"Backup %s/%s: Not replicated",
-				backup.Namespace,
-				backup.Name,
-			))
 	}
-	t.setProgress(progress)
 	return false, err
 }
 


### PR DESCRIPTION
This progress message creates unnecessary complications in the UI for Backup progress messages. Since Backup progress is more important than this, I want to get rid of this progress message until I figure out a better solution. 