### PR TITLE
fixups: fix typo in arguments

### DIFF
--- a/pkg/apis/migration/v1alpha1/condition.go
+++ b/pkg/apis/migration/v1alpha1/condition.go
@@ -381,6 +381,6 @@ func (r *Conditions) RecordEvents(obj runtime.Object, recorder record.EventRecor
 		default:
 			eventType = kapi.EventTypeNormal
 		}
-		recorder.Event(obj, cond.Reason, eventType, cond.Message)
+		recorder.Event(obj, eventType, cond.Type, cond.Message)
 	}
 }


### PR DESCRIPTION
use cond.Type which is always preset as reason for our conditions