### PR TITLE
Update rollback with unquiesce step being run always

### DIFF
--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -221,7 +221,7 @@ var RollbackItinerary = Itinerary{
 		{Name: EnsureAnnotationsDeleted, Step: StepFinal, any: HasPVs | HasISs},
 		{Name: DeleteMigrated, Step: StepFinal},
 		{Name: EnsureMigratedDeleted, Step: StepFinal},
-		{Name: UnQuiesceApplications, Step: StepFinal, all: Quiesce},
+		{Name: UnQuiesceApplications, Step: StepFinal},
 		{Name: Completed, Step: StepFinal},
 	},
 }


### PR DESCRIPTION
Rollback should include unquiesce step always regardless the quiescePods flag on its migmigration CR.

Removing conditional lookup for such flag.

Related to https://github.com/konveyor/mig-controller/issues/701