### PR TITLE
[MIG-119] Add: Requeue to Annotation/Label phase

### DIFF
--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -98,49 +98,49 @@ func (t *Task) annotateStageResources() error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-	itemsUpdate := 0
+	itemsUpdated := 0
 	// Namespaces
-	itemsUpdate, err = t.labelNamespaces(sourceClient, itemsUpdate)
+	itemsUpdated, err = t.labelNamespaces(sourceClient, itemsUpdated)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-	if itemsUpdate > 50 {
+	if itemsUpdated > 50 {
 		t.Requeue = FastReQ
 		return nil
 	}
 	// Pods
-	itemsUpdate, serviceAccounts, err := t.annotatePods(sourceClient, itemsUpdate)
+	itemsUpdated, serviceAccounts, err := t.annotatePods(sourceClient, itemsUpdated)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-	if itemsUpdate > 50 {
+	if itemsUpdated > 50 {
 		t.Requeue = FastReQ
 		return nil
 	}
 	// PV & PVCs
-	itemsUpdate, err = t.annotatePVs(sourceClient, itemsUpdate)
+	itemsUpdated, err = t.annotatePVs(sourceClient, itemsUpdated)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-	if itemsUpdate > 50 {
+	if itemsUpdated > 50 {
 		t.Requeue = FastReQ
 		return nil
 	}
 	// Service accounts used by stage pods.
-	itemsUpdate, err = t.labelServiceAccounts(sourceClient, serviceAccounts, itemsUpdate)
+	itemsUpdated, err = t.labelServiceAccounts(sourceClient, serviceAccounts, itemsUpdated)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-	if itemsUpdate > 50 {
+	if itemsUpdated > 50 {
 		t.Requeue = FastReQ
 		return nil
 	}
 
-	itemsUpdate, err = t.labelImageStreams(sourceClient, itemsUpdate)
+	itemsUpdated, err = t.labelImageStreams(sourceClient, itemsUpdated)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-	if itemsUpdate > 50 {
+	if itemsUpdated > 50 {
 		t.Requeue = FastReQ
 		return nil
 	}

--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -139,7 +139,7 @@ func (t *Task) annotateStageResources() (bool, error) {
 	if itemsUpdated > 50 {
 		return false, nil
 	}
-	return false, nil
+	return true, nil
 }
 
 // Gets a list of restic volumes and restic verify volumes for a pod

--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -78,6 +78,9 @@ const (
 	StagePodLabel = "migration.openshift.io/is-stage-pod"
 )
 
+// Bucket limit for number of items annotated in one Reconcile
+const NumberOfItems = 50
+
 // Set of Service Accounts.
 // Keyed by namespace (name) with value of map keyed by SA name.
 type ServiceAccounts map[string]map[string]bool
@@ -104,7 +107,7 @@ func (t *Task) annotateStageResources() (bool, error) {
 	if err != nil {
 		return false, liberr.Wrap(err)
 	}
-	if itemsUpdated > 50 {
+	if itemsUpdated > NumberOfItems {
 		return false, nil
 	}
 	// Pods
@@ -112,7 +115,7 @@ func (t *Task) annotateStageResources() (bool, error) {
 	if err != nil {
 		return false, liberr.Wrap(err)
 	}
-	if itemsUpdated > 50 {
+	if itemsUpdated > NumberOfItems {
 		return false, nil
 	}
 	// PV & PVCs
@@ -120,7 +123,7 @@ func (t *Task) annotateStageResources() (bool, error) {
 	if err != nil {
 		return false, liberr.Wrap(err)
 	}
-	if itemsUpdated > 50 {
+	if itemsUpdated > NumberOfItems {
 		return false, nil
 	}
 	// Service accounts used by stage pods.
@@ -128,7 +131,7 @@ func (t *Task) annotateStageResources() (bool, error) {
 	if err != nil {
 		return false, liberr.Wrap(err)
 	}
-	if itemsUpdated > 50 {
+	if itemsUpdated > NumberOfItems {
 		return false, nil
 	}
 
@@ -136,7 +139,7 @@ func (t *Task) annotateStageResources() (bool, error) {
 	if err != nil {
 		return false, liberr.Wrap(err)
 	}
-	if itemsUpdated > 50 {
+	if itemsUpdated > NumberOfItems {
 		return false, nil
 	}
 	return true, nil
@@ -207,7 +210,7 @@ func (t *Task) labelNamespaces(client k8sclient.Client, itemsUpdated int) (int, 
 			"name",
 			namespace.Name)
 		itemsUpdated++
-		if itemsUpdated > 50 {
+		if itemsUpdated > NumberOfItems {
 			t.setProgress([]string{fmt.Sprintf("%v/%v Namespaces labeled", i, total)})
 			return itemsUpdated, nil
 		}
@@ -271,7 +274,7 @@ func (t *Task) annotatePods(client k8sclient.Client, itemsUpdated int) (int, Ser
 			names[sa] = true
 		}
 
-		if itemsUpdated > 50 {
+		if itemsUpdated > NumberOfItems {
 			t.setProgress([]string{fmt.Sprintf("%v/%v Pod annotations/labels added.", i, total)})
 			return itemsUpdated, serviceAccounts, nil
 		}
@@ -375,7 +378,7 @@ func (t *Task) annotatePVs(client k8sclient.Client, itemsUpdated int) (int, erro
 			"name",
 			pv.PVC.Name)
 		itemsUpdated++
-		if itemsUpdated > 50 {
+		if itemsUpdated > NumberOfItems {
 			t.setProgress([]string{fmt.Sprintf("%v/%v PV annotations/labels added.", i, total), fmt.Sprintf("%v/%v PVC annotations/labels added.", i, total)})
 			return itemsUpdated, nil
 		}
@@ -420,7 +423,7 @@ func (t *Task) labelServiceAccounts(client k8sclient.Client, serviceAccounts Ser
 				"name",
 				sa.Name)
 			itemsUpdated++
-			if itemsUpdated > 50 {
+			if itemsUpdated > NumberOfItems {
 				t.setProgress([]string{fmt.Sprintf("%v/%v SA annotations/labels added in the namespace: %s", i, total, sa.Namespace)})
 				return itemsUpdated, nil
 			}
@@ -459,7 +462,7 @@ func (t *Task) labelImageStreams(client compat.Client, itemsUpdated int) (int, e
 				"name",
 				is.Name)
 			itemsUpdated++
-			if itemsUpdated > 50 {
+			if itemsUpdated > NumberOfItems {
 				t.setProgress([]string{fmt.Sprintf("%v/%v ImageStream labels added. in the namespace: %s", i, total, is.Namespace)})
 				return itemsUpdated, nil
 			}

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -504,8 +504,10 @@ func (t *Task) Run() error {
 		if err != nil {
 			return liberr.Wrap(err)
 		}
-		if err = t.next(); err != nil {
-			return liberr.Wrap(err)
+		if t.Requeue != FastReQ {
+			if err = t.next(); err != nil {
+				return liberr.Wrap(err)
+			}
 		}
 	case EnsureStagePodsFromRunning:
 		err := t.ensureStagePodsFromRunning()

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -500,11 +500,11 @@ func (t *Task) Run() error {
 			t.Requeue = PollReQ
 		}
 	case AnnotateResources:
-		err := t.annotateStageResources()
+		finished, err := t.annotateStageResources()
 		if err != nil {
 			return liberr.Wrap(err)
 		}
-		if t.Requeue != FastReQ {
+		if finished {
 			if err = t.next(); err != nil {
 				return liberr.Wrap(err)
 			}


### PR DESCRIPTION
Adding Requeue logic to `AnnotateResource` phase to allow mid-phase updates to `migmigration` CR and break the phase between multiple reconcile. A bit skeptical about having a 3-second interval for a requeue. On my cluster, this interval is way to large to have a requeue. The entire phase takes less than 3 seconds for the migration I carried out.