### PR TITLE
Start quietly when mig-ui is not deployed

### DIFF
--- a/hack/controller-sa-login.sh
+++ b/hack/controller-sa-login.sh
@@ -14,11 +14,9 @@ MIG_KUBECONFIG=$KUBECONFIG-$KUBECONFIG_POSTFIX
 MIG_UI_ROUTE_PATH=$MIG_KUBECONFIG-ui-route
 
 # Interrogate mig-ui route to set CORS_ALLOWED_ORIGINS 
-MIG_UI_ROUTE_HOST=$(oc get route migration -n openshift-migration migration -o=jsonpath='{.items[0].spec.host}')
+MIG_UI_ROUTE_HOST=$(oc get route migration -n openshift-migration -o=jsonpath='{.spec.host}' 2>/dev/null)
 if [ $? -eq 0 ]; then
     echo "${MIG_UI_ROUTE_HOST}" > ${MIG_UI_ROUTE_PATH}
-else
-    echo "Missing mig-ui route domain. Continuing without setting CORS_ALLOWED_ORIGINS."
 fi
 
 # Create copy of original KUBECONFIG that will be logged in with mig-controller SA token

--- a/hack/start-local-controller.sh
+++ b/hack/start-local-controller.sh
@@ -14,7 +14,7 @@ LOCAL_UI_CORS='//127.0.0.1(:|$) //localhost(:|$)'
 
 # Pull mig-ui route host from disk to set CORS_ALLOWED_ORIGINS 
 MIG_UI_ROUTE_PATH=$KUBECONFIG-ui-route
-MIG_UI_ROUTE=$(cat $MIG_UI_ROUTE_PATH)
+MIG_UI_ROUTE=$(cat $MIG_UI_ROUTE_PATH 2>/dev/null)
 
 if [ $? -eq 0 ]; then
     export CORS_ALLOWED_ORIGINS="${MIG_UI_ROUTE} ${LOCAL_UI_CORS}"


### PR DESCRIPTION
@sseago reported that `make run` was dumping an error message when mig-ui wasn't running. This PR fixes that issue. 

```
make run                                                                                                                                                                        
./hack/conversion-gen-`go env GOOS` --go-header-file ./hack/boilerplate.go.txt --output-file-base zz_conversion_generated -i ./pkg/compat/conversion/...                                                              
go generate ./pkg/... ./cmd/...                                                                                                                                                                                       
go fmt ./pkg/... ./cmd/...                                                                                                                                                                                            
go vet -tags "containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp exclude_graphdriver_overlay" ./pkg/... ./cmd/...
./hack/controller-sa-login.sh                                                                                                                                                                                         
Found migration-controller SA. Performing token login...                                                                                                                                                              
KUBECONFIG=/Users/dwhatley/.kube/awsconfig-mig-controller ./hack/start-local-controller.sh                                                                                                                            
Missing mig-ui route domain. Setting discovery service CORS_ALLOWED_ORIGINS=//127.0.0.1(:|$) //localhost(:|$)     
```