### PR TITLE
Remove unused clusterregistry from scheme

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -5,7 +5,6 @@ required = [
     "k8s.io/client-go/plugin/pkg/client/auth/gcp", # for development against gcp
     "k8s.io/code-generator/cmd/client-gen", # for go generate
     "k8s.io/code-generator/cmd/deepcopy-gen", # for go generate
-    "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1", # for cluster-registry Cluster
     "sigs.k8s.io/controller-tools/cmd/controller-gen", # for crd/rbac generation
     "sigs.k8s.io/controller-runtime/pkg/client/config",
     "sigs.k8s.io/controller-runtime/pkg/controller",

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -31,7 +31,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	clusterregv1alpha1 "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -85,10 +84,6 @@ func main() {
 	}
 	if err := routev1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "unable to add OpenShift route APIs to scheme")
-		os.Exit(1)
-	}
-	if err := clusterregv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Error(err, "unable to add Cluster Registry APIs to scheme")
 		os.Exit(1)
 	}
 	if err := conversion.RegisterConversions(mgr.GetScheme()); err != nil {


### PR DESCRIPTION
Not sure if you guys remember when we were using the clusterregistry CR. It's long been defunct. This PR just deletes it. I didn't re-solve Gopkg.lock at this time since I know we are merging go mod very soon (and I was hitting some error resolving a podman image dep).

Closes #699 