### PR TITLE
Exit miganalytic reconcile early if analytics gathered successfully in past reconcile

### DIFF
--- a/pkg/controller/miganalytic/miganalytics_controller.go
+++ b/pkg/controller/miganalytic/miganalytics_controller.go
@@ -120,6 +120,11 @@ func (r *ReconcileMigAnalytic) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{Requeue: true}, nil
 	}
 
+	// Exit early if the MigAnalytic already has a ready condition
+	if analytic.Status.IsReady() {
+		return reconcile.Result{}, nil
+	}
+
 	// Report reconcile error.
 	defer func() {
 		log.Info("CR", "conditions", analytic.Status.Conditions)


### PR DESCRIPTION
Closes #791 

The UI will simply delete and recreate the MigAnalytic CR if updates are needed. I tested this with the UI, it works.

Fixing this issue just reduces spammy log output. It doesn't impact the controller functioning properly, hence the lack of associated BZ.