### PR TITLE
Use ubi8/go-toolset:1.14.7 to avoid ratelimit build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.14.4 as builder
+FROM quay.io/konveyor/golang:1.14.4 as builder
 
 # Copy in the go src
 WORKDIR /go/src/github.com/konveyor/mig-controller

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-# Build the manager binary
-FROM quay.io/konveyor/golang:1.14.4 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.14.7 AS builder
 
 # Copy in the go src
-WORKDIR /go/src/github.com/konveyor/mig-controller
-COPY pkg/    pkg/
-COPY cmd/    cmd/
-COPY vendor/ vendor/
+ENV GOPATH=$APP_ROOT
+COPY pkg    $APP_ROOT/src/github.com/konveyor/mig-controller/pkg
+COPY cmd    $APP_ROOT/src/github.com/konveyor/mig-controller/cmd
+COPY vendor $APP_ROOT/src/github.com/konveyor/mig-controller/vendor
 ENV BUILDTAGS containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp exclude_graphdriver_overlay
 
 # Build
@@ -14,5 +13,5 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags "$BUILDTAGS" -a -o manager github.co
 # Copy the controller-manager into a thin image
 FROM registry.access.redhat.com/ubi8-minimal
 WORKDIR /
-COPY --from=builder /go/src/github.com/konveyor/mig-controller/manager .
+COPY --from=builder /opt/app-root/src/manager .
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Dockerhub introduced some new rate limiting rules that require a paid account to overcome, and quay.io auto-builds are now  failing most of the time.

To overcome this we changed the builder image to `go-toolset:1.14.7`

_Just to give an idea of the current scope of upstream build failures due to this_
![image](https://user-images.githubusercontent.com/7576968/99433740-e6cbd900-28db-11eb-9d60-9a64de83eba4.png)
