### PR TITLE
Bug 1883212: Warning message should be given to user indicating empty project migration.

### DIFF
--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -335,6 +335,7 @@ func (t *Task) Run() error {
 	t.Requeue = FastReQ
 	t.Log.Info("[RUN]", "stage", t.stage(), "phase", t.Phase)
 
+	// Init method
 	err := t.init()
 	if err != nil {
 		return err

--- a/pkg/controller/migplan/gvk.go
+++ b/pkg/controller/migplan/gvk.go
@@ -1,6 +1,9 @@
 package migplan
 
 import (
+	"fmt"
+	"strings"
+
 	liberr "github.com/konveyor/controller/pkg/error"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/konveyor/mig-controller/pkg/gvk"
@@ -23,6 +26,16 @@ func (r ReconcileMigPlan) compareGVK(plan *migapi.MigPlan) error {
 	incompatibleMapping, err := gvkCompare.Compare()
 	if err != nil {
 		err = liberr.Wrap(err)
+	}
+
+	if len(gvkCompare.EmptyNamespaces) == 0 {
+		msg := fmt.Sprintf("Following namespaces are not empty [%s]. Elapsed time %f", strings.Join(gvkCompare.EmptyNamespaces, ", "), gvkCompare.Elapsed)
+		plan.Status.SetCondition(migapi.Condition{
+			Type:     NsEmpty,
+			Status:   True,
+			Category: Warn,
+			Message:  msg,
+		})
 	}
 
 	reportGVK(plan, incompatibleMapping)

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -43,6 +43,7 @@ const (
 	NsNotFoundOnDestinationCluster             = "NamespaceNotFoundOnDestinationCluster"
 	NsLimitExceeded                            = "NamespaceLimitExceeded"
 	NsLengthExceeded                           = "NamespaceLengthExceeded"
+	NsEmpty                                    = "NamespacesEmpty"
 	NsHaveNodeSelectors                        = "NamespacesHaveNodeSelectors"
 	PodLimitExceeded                           = "PodLimitExceeded"
 	SourceClusterProxySecretMisconfigured      = "SourceClusterProxySecretMisconfigured"


### PR DESCRIPTION
Following snapshots indicate the warning messages introduced by the bug-fix, for empty and non-empty (nginx) namespaces:

### Empty Namespace [Stage]:
![image](https://user-images.githubusercontent.com/67090431/99771038-7668c600-2b2e-11eb-8de3-2707f77436e0.png)
### Empty Namespace [Migrate]:
![image](https://user-images.githubusercontent.com/67090431/99771091-884a6900-2b2e-11eb-8099-babe642703f5.png)
### NGinx Example Namespace [Stage and Migrate]:
![image](https://user-images.githubusercontent.com/67090431/99771129-9bf5cf80-2b2e-11eb-9c53-71ebed79f176.png)



Signed-off-by: seshapad <seshapad@in.ibm.com>