### PR TITLE
Add progress statistics to failed / partially failed Velero entities

### DIFF
--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -132,7 +132,7 @@ func (t *Task) annotateStageResources() (bool, error) {
 		return false, liberr.Wrap(err)
 	}
 
-  if itemsUpdated > AnnotationsPerReconcile {
+	if itemsUpdated > AnnotationsPerReconcile {
 		return false, nil
 	}
 

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -199,9 +199,11 @@ func getPodVolumeRestoresProgress(pvrList *velero.PodVolumeRestoreList) (progres
 				getPVRDuration(&pvr))
 		case velero.PodVolumeRestorePhaseFailed:
 			msg = fmt.Sprintf(
-				"PodVolumeRestore %s/%s: Failed%s",
+				"PodVolumeRestore %s/%s: Failed. %s out of %s restored%s",
 				pvr.Namespace,
 				pvr.Name,
+				bytesToSI(pvr.Status.Progress.BytesDone),
+				bytesToSI(pvr.Status.Progress.TotalBytes),
 				getPVRDuration(&pvr))
 		default:
 			msg = fmt.Sprintf(


### PR DESCRIPTION
Adds progress statistics to failed Velero objects. 

This is useful for cases when a Backup / PodVolumeBackup / PodVolumeRestore fails after some amount of work is done.  