### PR TITLE
fix the issue where transfer pod is stuck in terminating state

### DIFF
--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -959,7 +959,7 @@ func (t *Task) findAndDeleteResources(client compat.Client) error {
 
 		// Delete pods
 		for _, pod := range podList.Items {
-			err = client.Delete(context.TODO(), &pod, k8sclient.PropagationPolicy(metav1.DeletePropagationForeground))
+			err = client.Delete(context.TODO(), &pod, k8sclient.PropagationPolicy(metav1.DeletePropagationBackground))
 			if err != nil && !k8serror.IsNotFound(err) {
 				return err
 			}
@@ -967,7 +967,7 @@ func (t *Task) findAndDeleteResources(client compat.Client) error {
 
 		// Delete secrets
 		for _, secret := range secretList.Items {
-			err = client.Delete(context.TODO(), &secret, k8sclient.PropagationPolicy(metav1.DeletePropagationForeground))
+			err = client.Delete(context.TODO(), &secret, k8sclient.PropagationPolicy(metav1.DeletePropagationBackground))
 			if err != nil && !k8serror.IsNotFound(err) {
 				return err
 			}
@@ -975,7 +975,7 @@ func (t *Task) findAndDeleteResources(client compat.Client) error {
 
 		// Delete routes
 		for _, route := range routeList.Items {
-			err = client.Delete(context.TODO(), &route, k8sclient.PropagationPolicy(metav1.DeletePropagationForeground))
+			err = client.Delete(context.TODO(), &route, k8sclient.PropagationPolicy(metav1.DeletePropagationBackground))
 			if err != nil && !k8serror.IsNotFound(err) {
 				return err
 			}
@@ -983,7 +983,7 @@ func (t *Task) findAndDeleteResources(client compat.Client) error {
 
 		// Delete svcs
 		for _, svc := range svcList.Items {
-			err = client.Delete(context.TODO(), &svc, k8sclient.PropagationPolicy(metav1.DeletePropagationForeground))
+			err = client.Delete(context.TODO(), &svc, k8sclient.PropagationPolicy(metav1.DeletePropagationBackground))
 			if err != nil && !k8serror.IsNotFound(err) {
 				return err
 			}
@@ -991,7 +991,7 @@ func (t *Task) findAndDeleteResources(client compat.Client) error {
 
 		// Delete configmaps
 		for _, cm := range cmList.Items {
-			err = client.Delete(context.TODO(), &cm, k8sclient.PropagationPolicy(metav1.DeletePropagationForeground))
+			err = client.Delete(context.TODO(), &cm, k8sclient.PropagationPolicy(metav1.DeletePropagationBackground))
 			if err != nil && !k8serror.IsNotFound(err) {
 				return err
 			}
@@ -1010,7 +1010,7 @@ func (t *Task) deleteProgressReportingCRs(client k8sclient.Client) error {
 					Name:      fmt.Sprintf("directvolumemigration-rsync-transfer-%s", vol),
 					Namespace: ns,
 				},
-			}, k8sclient.PropagationPolicy(metav1.DeletePropagationForeground))
+			}, k8sclient.PropagationPolicy(metav1.DeletePropagationBackground))
 			if err != nil && !k8serror.IsNotFound(err) {
 				return err
 			}


### PR DESCRIPTION
fixes #831 

The delete policy foreground waits for all the dependent of the resource to be deleted before the object itself being deleted. It looked like the finalizer for this delete policy was not being removed by the controller manager because it was unable to find/delete some dependent resources. This is weird because logically our transfer pods do not "own" any other resources. Converting this to background will unblock the deletion and move the Itinerary forward.