### PR TITLE
Schedule Rsync client pods on the same nodes as the volumes

### DIFF
--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -641,6 +641,36 @@ func (t *Task) deleteRsyncPassword() error {
 	return nil
 }
 
+//Returns a map of PVCNamespacedName to the pod.NodeName
+func (t *Task) getPVCNodeNameMap() (map[string]string, error) {
+	nodeNameMap := map[string]string{}
+	pvcMap := t.getPVCNamespaceMap()
+	nsPodList := corev1.PodList{}
+	srcClient, err := t.getSourceClient()
+	if err != nil {
+		return nil, err
+	}
+
+	for ns, _ := range pvcMap {
+		err = srcClient.List(context.TODO(), k8sclient.InNamespace(ns), &nsPodList)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, pod := range nsPodList.Items {
+		if pod.Status.Phase == corev1.PodRunning {
+			for _, vol := range pod.Spec.Volumes {
+				if vol.PersistentVolumeClaim != nil {
+					pvcNsName := pod.ObjectMeta.Namespace + "/" + vol.PersistentVolumeClaim.ClaimName
+					nodeNameMap[pvcNsName] = pod.Spec.NodeName
+				}
+			}
+		}
+	}
+	return nodeNameMap, nil
+}
+
 // Create rsync client pods
 func (t *Task) createRsyncClientPods() error {
 	// Get client for destination
@@ -663,6 +693,12 @@ func (t *Task) createRsyncClientPods() error {
 
 		trueBool := true
 		runAsUser := int64(0)
+
+		pvcNodeMap, err := t.getPVCNodeNameMap()
+
+		if err != nil {
+			return err
+		}
 
 		// Add PVC volume mounts
 		for _, vol := range vols {
@@ -728,6 +764,7 @@ func (t *Task) createRsyncClientPods() error {
 					RestartPolicy: corev1.RestartPolicyNever,
 					Volumes:       volumes,
 					Containers:    containers,
+					NodeName:      pvcNodeMap[ns+"/"+vol],
 				},
 			}
 			err = srcClient.Create(context.TODO(), &clientPod)


### PR DESCRIPTION
This PR does the following:
- Adds a new function `getPVCNodeNameMap()` which returns a PVCNamespacedName : NodeName map
- Schedules Rsync client pods on the same nodes as the persistent volume claims
- Fixes https://github.com/konveyor/mig-controller/issues/834