### PR TITLE
Update DVM PVC check to include determination whether PVCs are bound and usable

### DIFF
--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -100,35 +100,12 @@ func (t *Task) getDestinationPVCs() (bool, error) {
 			return false, err
 		}
 		for _, pvc := range pvcList.Items {
-			t.Log.Info("mounted PVC", pvc.Name, pvc.Status.Phase)
-			if pvc.Status.Phase != corev1.ClaimBound {
+			if pvc.Status.Phase == corev1.ClaimLost {
+				t.Log.Info("The PVC in lost state", pvc.Name, pvc.Status.Phase)
+			} else if pvc.Status.Phase != corev1.ClaimBound {
 				return false, nil
 			}
 		}
 	}
-
-	//selector = labels.SelectorFromSet(map[string]string{
-	//	"app":     "directvolumemigration-rsync-transfer",
-	//	"owner":   "directvolumemigration",
-	//	"purpose": "rsync",
-	//})
-	//for ns, _ := range pvcMap {
-	//	pods := corev1.PodList{}
-	//	err = destClient.List(
-	//		context.TODO(),
-	//		&k8sclient.ListOptions{
-	//			Namespace:     ns,
-	//			LabelSelector: selector,
-	//		},
-	//		&pods)
-	//	if err != nil {
-	//		return false, err
-	//	}
-	//	podToPVC := make(map[string]string)
-	//	for _, pod := range pods.Items {
-	//		t.Log.Info("mounted PVC", "mount", pod.Spec.Volumes)
-	//
-	//	}
-	//}
 	return true, nil
 }

--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -107,7 +107,7 @@ func (t *Task) areDestinationPVCsBound() (bool, error) {
 						Type:     PVCNotBoundOnDestinationCluster,
 						Status:   True,
 						Reason:   migapi.NotReady,
-						Category: Critical,
+						Category: migapi.Warn,
 						Message:  fmt.Sprintf("PVC %s of %s namespace is in %s state", pvc.Name, pvc.Namespace, pvc.Status.Phase),
 						Durable:  true,
 					})
@@ -116,7 +116,7 @@ func (t *Task) areDestinationPVCsBound() (bool, error) {
 			}
 		}
 	}
-	conditions := t.Owner.Status.Conditions.FindConditionByCategory(Critical)
+	conditions := t.Owner.Status.Conditions.FindConditionByCategory(migapi.Warn)
 	if len(conditions) > 0 {
 		t.Owner.Status.DeleteCondition(PVCNotBoundOnDestinationCluster)
 	}

--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -104,7 +104,7 @@ func (t *Task) areDestinationPVCsBound() (bool, error) {
 			if pvc.Status.Phase != corev1.ClaimBound {
 				if time.Now().Sub(pvc.CreationTimestamp.Time) > time.Minute*10 {
 					t.Owner.Status.SetCondition(migapi.Condition{
-						Type:     PVCUnBound,
+						Type:     PVCNotBoundOnDestinationCluster,
 						Status:   True,
 						Reason:   t.Phase,
 						Category: Critical,

--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 func (t *Task) areSourcePVCsUnattached() error {
@@ -102,15 +101,11 @@ func (t *Task) areDestinationPVCsBound() (bool, error) {
 		}
 		for _, pvc := range pvcList.Items {
 			if pvc.Status.Phase != corev1.ClaimBound {
-				category := Advisory
-				if time.Now().Sub(pvc.CreationTimestamp.Time) > time.Minute*10 {
-					category = Critical
-				}
 				t.Owner.Status.SetCondition(migapi.Condition{
 					Type:     Running,
 					Status:   True,
 					Reason:   t.Phase,
-					Category: category,
+					Category: Critical,
 					Message:  fmt.Sprintf("PVC %s of %s namespace is in %s state", pvc.Name, pvc.Namespace, pvc.Status.Phase),
 					Durable:  true,
 				})

--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -106,7 +106,7 @@ func (t *Task) areDestinationPVCsBound() (bool, error) {
 					t.Owner.Status.SetCondition(migapi.Condition{
 						Type:     PVCNotBoundOnDestinationCluster,
 						Status:   True,
-						Reason:   t.Phase,
+						Reason:   migapi.NotReady,
 						Category: Critical,
 						Message:  fmt.Sprintf("PVC %s of %s namespace is in %s state", pvc.Name, pvc.Namespace, pvc.Status.Phase),
 						Durable:  true,

--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -118,7 +118,7 @@ func (t *Task) areDestinationPVCsBound() (bool, error) {
 	}
 	conditions := t.Owner.Status.Conditions.FindConditionByCategory(Critical)
 	if len(conditions) > 0 {
-		t.Owner.Status.DeleteCondition(Critical)
+		t.Owner.Status.DeleteCondition(PVCNotBoundOnDestinationCluster)
 	}
 	return true, nil
 }

--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
 )
 
 func (t *Task) areSourcePVCsUnattached() error {
@@ -101,11 +102,15 @@ func (t *Task) areDestinationPVCsBound() (bool, error) {
 		}
 		for _, pvc := range pvcList.Items {
 			if pvc.Status.Phase != corev1.ClaimBound {
+				category := Advisory
+				if time.Now().Sub(pvc.CreationTimestamp.Time) > time.Minute*10 {
+					category = Critical
+				}
 				t.Owner.Status.SetCondition(migapi.Condition{
 					Type:     Running,
 					Status:   True,
 					Reason:   t.Phase,
-					Category: Advisory,
+					Category: category,
 					Message:  fmt.Sprintf("PVC %s of %s namespace is in %s state", pvc.Name, pvc.Namespace, pvc.Status.Phase),
 					Durable:  true,
 				})

--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -116,7 +116,6 @@ func (t *Task) areDestinationPVCsBound() (bool, error) {
 							Reason:   migapi.NotReady,
 							Category: Warn,
 							Message:  fmt.Sprintf("dvm cr : %s/%s expected %v, found %v", t.Owner.Namespace, t.Owner.Name,len(pvcMap[ns]), len(pvcList.Items)),
-							Durable:  true,
 						},
 					)
 				}

--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -40,7 +40,7 @@ func (t *Task) createDestinationPVCs() error {
 		}
 
 		newSpec := srcPVC.Spec
-		srcPVC.Labels["owner"] = "directvolumemigration"
+		srcPVC.Labels = t.buildDVMLabels()
 		newSpec.StorageClassName = &pvc.TargetStorageClass
 		newSpec.AccessModes = pvc.TargetAccessModes
 		newSpec.VolumeName = ""
@@ -84,9 +84,7 @@ func (t *Task) getDestinationPVCs() (bool, error) {
 	}
 
 	pvcMap := t.getPVCNamespaceMap()
-	selector := labels.SelectorFromSet(map[string]string{
-		"owner": "directvolumemigration",
-	})
+	selector := labels.SelectorFromSet(t.buildDVMLabels())
 	for ns, _ := range pvcMap {
 		pvcList := corev1.PersistentVolumeClaimList{}
 		err = destClient.List(

--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -116,5 +116,9 @@ func (t *Task) areDestinationPVCsBound() (bool, error) {
 			}
 		}
 	}
+	conditions := t.Owner.Status.Conditions.FindConditionByCategory(Critical)
+	if len(conditions) > 0 {
+		t.Owner.Status.DeleteCondition(Critical)
+	}
 	return true, nil
 }

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -241,7 +241,7 @@ func (t *Task) Run() error {
 		}
 	case DestinationPVCsCreated:
 		// Get the PVCs on the destination and confirm they are bound
-		next, err := t.getDestinationPVCs()
+		next, err := t.areDestinationPVCsBound()
 		if err != nil {
 			return liberr.Wrap(err)
 		}

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -112,12 +112,12 @@ var VolumeMigration = Itinerary{
 		{phase: CreateDestinationNamespaces},
 		{phase: DestinationNamespacesCreated},
 		{phase: CreateDestinationPVCs},
-		{phase: DestinationPVCsCreated},
 		{phase: CreateRsyncRoute},
 		{phase: CreateRsyncConfig},
 		{phase: CreateStunnelConfig},
 		{phase: CreatePVProgressCRs},
 		{phase: CreateRsyncTransferPods},
+		{phase: DestinationPVCsCreated},
 		{phase: WaitForRsyncTransferPodsRunning},
 		{phase: CreateStunnelClientPods},
 		{phase: WaitForStunnelClientPodsRunning},
@@ -241,13 +241,15 @@ func (t *Task) Run() error {
 		}
 	case DestinationPVCsCreated:
 		// Get the PVCs on the destination and confirm they are bound
-		err := t.getDestinationPVCs()
+		next, err := t.getDestinationPVCs()
 		if err != nil {
 			return liberr.Wrap(err)
 		}
-		t.Requeue = NoReQ
-		if err = t.next(); err != nil {
-			return liberr.Wrap(err)
+		if next {
+			t.Requeue = NoReQ
+			if err = t.next(); err != nil {
+				return liberr.Wrap(err)
+			}
 		}
 	case CreateRsyncRoute:
 		err := t.createRsyncTransferRoute()

--- a/pkg/controller/directvolumemigration/validation.go
+++ b/pkg/controller/directvolumemigration/validation.go
@@ -24,6 +24,7 @@ const (
 	StunnelClientPodsPending     = "StunnelClientPodsPending"
 	RsyncTransferPodsPending     = "RsyncTransferPodsPending"
 	Running                      = "Running"
+	PVCUnBound					 = "PVCNotBoundOnDestinationCluster"
 	Failed                       = "Failed"
 	Succeeded                    = "Succeeded"
 )

--- a/pkg/controller/directvolumemigration/validation.go
+++ b/pkg/controller/directvolumemigration/validation.go
@@ -24,7 +24,7 @@ const (
 	StunnelClientPodsPending     = "StunnelClientPodsPending"
 	RsyncTransferPodsPending     = "RsyncTransferPodsPending"
 	Running                      = "Running"
-	PVCUnBound					 = "PVCNotBoundOnDestinationCluster"
+	PVCUnBound                   = "PVCNotBoundOnDestinationCluster"
 	Failed                       = "Failed"
 	Succeeded                    = "Succeeded"
 )

--- a/pkg/controller/directvolumemigration/validation.go
+++ b/pkg/controller/directvolumemigration/validation.go
@@ -13,20 +13,21 @@ import (
 
 // Types
 const (
-	InvalidSourceClusterRef      = "InvalidSourceClusterRef"
-	InvalidDestinationClusterRef = "InvalidDestinationClusterRef"
-	InvalidSourceCluster         = "InvalidSourceCluster"
-	InvalidDestinationCluster    = "InvalidDestinationCluster"
-	InvalidPVCs                  = "InvalidPVCs"
-	SourceClusterNotReady        = "SourceClusterNotReady"
-	DestinationClusterNotReady   = "DestinationClusterNotReady"
-	PVCsNotFoundOnSourceCluster  = "PodsNotFoundOnSourceCluster"
-	StunnelClientPodsPending     = "StunnelClientPodsPending"
-	RsyncTransferPodsPending     = "RsyncTransferPodsPending"
-	Running                      = "Running"
-	PVCUnBound                   = "PVCNotBoundOnDestinationCluster"
-	Failed                       = "Failed"
-	Succeeded                    = "Succeeded"
+	InvalidSourceClusterRef         = "InvalidSourceClusterRef"
+	InvalidDestinationClusterRef    = "InvalidDestinationClusterRef"
+	InvalidSourceCluster            = "InvalidSourceCluster"
+	InvalidDestinationCluster       = "InvalidDestinationCluster"
+	InvalidPVCs                     = "InvalidPVCs"
+	SourceClusterNotReady           = "SourceClusterNotReady"
+	DestinationClusterNotReady      = "DestinationClusterNotReady"
+	PVCsNotFoundOnSourceCluster     = "PodsNotFoundOnSourceCluster"
+	StunnelClientPodsPending        = "StunnelClientPodsPending"
+	RsyncTransferPodsPending        = "RsyncTransferPodsPending"
+	Running                         = "Running"
+	PVCNotBoundOnDestinationCluster = "PVCNotBoundOnDestinationCluster"
+	PVCNotFoundOnDestinationCluster = "PVCNotFoundOnDestinationCluster"
+	Failed                          = "Failed"
+	Succeeded                       = "Succeeded"
 )
 
 // Reasons


### PR DESCRIPTION
This PR checks the state of the PVCs on the destination cluster to make sure PVCs are in the bound state before completing DVM.

Fixes #829 