### PR TITLE
Apply appropriate labels on PVCs to facilitate DVM rollback

### DIFF
--- a/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
+++ b/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
@@ -91,6 +91,10 @@ func (r *DirectVolumeMigration) GetDestinationCluster(client k8sclient.Client) (
 	return GetCluster(client, r.Spec.DestMigClusterRef)
 }
 
+func (r *DirectVolumeMigration) GetMigrationForDVM(client k8sclient.Client) (*MigMigration, error) {
+	return GetMigrationForDVM(client, r.OwnerReferences)
+}
+
 // Add (de-duplicated) errors.
 func (r *DirectVolumeMigration) AddErrors(errors []string) {
 	m := map[string]bool{}

--- a/pkg/apis/migration/v1alpha1/model.go
+++ b/pkg/apis/migration/v1alpha1/model.go
@@ -2,7 +2,8 @@ package v1alpha1
 
 import (
 	"context"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	liberr "github.com/konveyor/controller/pkg/error"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strconv"
 
 	imagev1 "github.com/openshift/api/image/v1"
@@ -134,7 +135,7 @@ func GetStorage(client k8sclient.Client, ref *kapi.ObjectReference) (*MigStorage
 
 // Get a referenced Migration for DVM.
 // Return nil if the reference cannot be resolved.
-func GetMigrationForDVM(client k8sclient.Client, owners []v1.OwnerReference) (*MigMigration, error) {
+func GetMigrationForDVM(client k8sclient.Client, owners []metav1.OwnerReference) (*MigMigration, error) {
 	if len(owners) == 0 {
 		return nil, nil
 	}
@@ -145,22 +146,15 @@ func GetMigrationForDVM(client k8sclient.Client, owners []v1.OwnerReference) (*M
 			Name:      migrationName,
 			Namespace: OpenshiftMigrationNamespace,
 		}, &migrationObject)
-	//objectList := MigMigrationList{}
-	//err := client.List(context.TODO(), &k8sclient.ListOptions{
-	//	LabelSelector: k8sLabels.SelectorFromSet(dvmLabels),
-	//}, &objectList)
 
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil
 		} else {
-			return nil, err
+			return nil, liberr.Wrap(err)
 		}
 	}
-
-	if &migrationObject == nil {
-		return nil, nil
-	}
+	
 	return &migrationObject, nil
 }
 

--- a/pkg/apis/migration/v1alpha1/model.go
+++ b/pkg/apis/migration/v1alpha1/model.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"context"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strconv"
 
 	imagev1 "github.com/openshift/api/image/v1"
@@ -129,6 +130,38 @@ func GetStorage(client k8sclient.Client, ref *kapi.ObjectReference) (*MigStorage
 	}
 
 	return &object, err
+}
+
+// Get a referenced Migration for DVM.
+// Return nil if the reference cannot be resolved.
+func GetMigrationForDVM(client k8sclient.Client, owners []v1.OwnerReference) (*MigMigration, error) {
+	if len(owners) == 0 {
+		return nil, nil
+	}
+	migrationName := owners[0].Name
+	migrationObject := MigMigration{}
+	err := client.Get(context.TODO(),
+		k8sclient.ObjectKey{
+			Name:      migrationName,
+			Namespace: OpenshiftMigrationNamespace,
+		}, &migrationObject)
+	//objectList := MigMigrationList{}
+	//err := client.List(context.TODO(), &k8sclient.ListOptions{
+	//	LabelSelector: k8sLabels.SelectorFromSet(dvmLabels),
+	//}, &objectList)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		} else {
+			return nil, err
+		}
+	}
+
+	if &migrationObject == nil {
+		return nil, nil
+	}
+	return &migrationObject, nil
 }
 
 // List MigStorage

--- a/pkg/controller/directvolumemigration/migrate.go
+++ b/pkg/controller/directvolumemigration/migrate.go
@@ -12,34 +12,9 @@ import (
 
 func (r *ReconcileDirectVolumeMigration) migrate(direct *migapi.DirectVolumeMigration) (time.Duration, error) {
 
-	migration := migapi.MigMigration{}
-	planResources := &migapi.PlanResources{}
-
-	if len(direct.OwnerReferences) > 0{
-		// Ready
-		migration, err := direct.GetMigrationForDVM(r)
-		if err != nil {
-			return 0, liberr.Wrap(err)
-		}
-		if migration == nil {
-			log.Info("Migration not found for DVM", "name", direct.Name)
-			return 0, liberr.Wrap(err)
-		}
-
-		plan, err := migration.GetPlan(r)
-		if err != nil {
-			return 0, liberr.Wrap(err)
-		}
-		if !plan.Status.IsReady() {
-			log.Info("Plan not ready.", "name", migration.Name)
-			return 0, liberr.Wrap(err)
-		}
-
-		// Resources
-		planResources, err = plan.GetRefResources(r)
-		if err != nil {
-			return 0, liberr.Wrap(err)
-		}
+	migration, planResources, err := r.getDVMMigrationAndPlanResources(direct)
+	if err != nil {
+		return 0, liberr.Wrap(err)
 	}
 
 	// Started
@@ -57,7 +32,7 @@ func (r *ReconcileDirectVolumeMigration) migrate(direct *migapi.DirectVolumeMigr
 		PlanResources:    planResources,
 		MigrationUID:     string(migration.UID),
 	}
-	err := task.Run()
+	err = task.Run()
 	if err != nil {
 		if errors.IsConflict(err) {
 			return FastReQ, nil
@@ -101,4 +76,42 @@ func (r *ReconcileDirectVolumeMigration) migrate(direct *migapi.DirectVolumeMigr
 	})
 
 	return task.Requeue, nil
+}
+
+// fetches DVM Migration object and Migplan resources if DVM has an owner reference
+func (r *ReconcileDirectVolumeMigration) getDVMMigrationAndPlanResources(direct *migapi.DirectVolumeMigration) (*migapi.MigMigration, *migapi.PlanResources, error) {
+
+	if len(direct.OwnerReferences) > 0 {
+
+		migration := &migapi.MigMigration{}
+		planResources := &migapi.PlanResources{}
+
+		// Ready
+		migration, err := direct.GetMigrationForDVM(r)
+		if err != nil {
+			return migration, planResources, liberr.Wrap(err)
+		}
+
+		if migration == nil {
+			log.Info("Migration not found for DVM", "name", direct.Name)
+			return migration, planResources, liberr.Wrap(err)
+		}
+
+		plan, err := migration.GetPlan(r)
+		if err != nil {
+			return migration, planResources, liberr.Wrap(err)
+		}
+		if !plan.Status.IsReady() {
+			log.Info("Plan not ready.", "name", migration.Name)
+			return migration, planResources, liberr.Wrap(err)
+		}
+
+		// Resources
+		planResources, err = plan.GetRefResources(r)
+		if err != nil {
+			return migration, planResources, liberr.Wrap(err)
+		}
+		return migration, planResources, nil
+	}
+	return &migapi.MigMigration{}, &migapi.PlanResources{}, nil
 }

--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -48,9 +48,8 @@ func (t *Task) createDestinationPVCs() error {
 			pvcLabels = make(map[string]string)
 		}
 
-		pvcLabels[MigMigrationLabel] = t.MigrationUID
-		pvcLabels[MigPlanLabel] = string(t.PlanResources.MigPlan.UID)
-
+		pvcLabels[MigratedByMigrationLabel] = t.MigrationUID
+		pvcLabels[MigratedByPlanLabel] = string(t.PlanResources.MigPlan.UID)
 
 		// Create pvc on destination with same metadata + spec
 		destPVC := corev1.PersistentVolumeClaim{

--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -48,8 +48,10 @@ func (t *Task) createDestinationPVCs() error {
 			pvcLabels = make(map[string]string)
 		}
 
-		pvcLabels[MigratedByMigrationLabel] = t.MigrationUID
-		pvcLabels[MigratedByPlanLabel] = string(t.PlanResources.MigPlan.UID)
+		if t.MigrationUID != "" && t.PlanResources.MigPlan != nil {
+			pvcLabels[MigratedByMigrationLabel] = t.MigrationUID
+			pvcLabels[MigratedByPlanLabel] = string(t.PlanResources.MigPlan.UID)
+		}
 
 		// Create pvc on destination with same metadata + spec
 		destPVC := corev1.PersistentVolumeClaim{

--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -42,12 +42,22 @@ func (t *Task) createDestinationPVCs() error {
 		newSpec.AccessModes = pvc.TargetAccessModes
 		newSpec.VolumeName = ""
 
+		//Add src labels and rollback labels
+		pvcLabels := srcPVC.Labels
+		if pvcLabels == nil {
+			pvcLabels = make(map[string]string)
+		}
+
+		pvcLabels[MigMigrationLabel] = t.MigrationUID
+		pvcLabels[MigPlanLabel] = string(t.PlanResources.MigPlan.UID)
+
+
 		// Create pvc on destination with same metadata + spec
 		destPVC := corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      pvc.Name,
 				Namespace: pvc.Namespace,
-				Labels:    srcPVC.Labels,
+				Labels:    pvcLabels,
 			},
 			Spec: newSpec,
 		}

--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -75,7 +75,7 @@ func (t *Task) areRsyncTransferPodsRunning() (bool, error) {
 
 	pvcMap := t.getPVCNamespaceMap()
 	dvmLabels := t.getDVMLabels()
-	dvmLabels["purpose"] = Rsync
+	dvmLabels["purpose"] = DirectVolumeMigrationRsync
 	selector := labels.SelectorFromSet(dvmLabels)
 
 	for ns, _ := range pvcMap {
@@ -275,7 +275,7 @@ func (t *Task) createRsyncTransferRoute() error {
 	}
 	pvcMap := t.getPVCNamespaceMap()
 	dvmLabels := t.getDVMLabels()
-	dvmLabels["purpose"] = Rsync
+	dvmLabels["purpose"] = DirectVolumeMigrationRsync
 
 	for ns, _ := range pvcMap {
 		svc := corev1.Service{
@@ -289,7 +289,7 @@ func (t *Task) createRsyncTransferRoute() error {
 			Spec: corev1.ServiceSpec{
 				Ports: []corev1.ServicePort{
 					{
-						Name:       Stunnel,
+						Name:       DirectVolumeMigrationStunnel,
 						Protocol:   corev1.ProtocolTCP,
 						Port:       int32(2222),
 						TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 2222},
@@ -475,7 +475,7 @@ func (t *Task) createRsyncTransferPods() error {
 		})
 
 		dvmLabels := t.getDVMLabels()
-		dvmLabels["purpose"] = Rsync
+		dvmLabels["purpose"] = DirectVolumeMigrationRsync
 
 		transferPod := corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -516,7 +516,7 @@ func (t *Task) createRsyncTransferPods() error {
 						Command: []string{"/bin/stunnel", "/etc/stunnel/stunnel.conf"},
 						Ports: []corev1.ContainerPort{
 							{
-								Name:          Stunnel,
+								Name:          DirectVolumeMigrationStunnel,
 								Protocol:      corev1.ProtocolTCP,
 								ContainerPort: int32(2222),
 							},
@@ -755,7 +755,7 @@ func (t *Task) createRsyncClientPods() error {
 					fmt.Sprintf("/mnt/%s/%s/", ns, vol), fmt.Sprintf("rsync://root@%s/%s", ip, vol)},
 				Ports: []corev1.ContainerPort{
 					{
-						Name:          RsyncClient,
+						Name:          DirectVolumeMigrationRsyncClient,
 						Protocol:      corev1.ProtocolTCP,
 						ContainerPort: int32(22),
 					},
@@ -773,7 +773,7 @@ func (t *Task) createRsyncClientPods() error {
 					Namespace: ns,
 					Labels: map[string]string{
 						"app":                   DirectVolumeMigrationRsyncTransfer,
-						"directvolumemigration": RsyncClient,
+						"directvolumemigration": DirectVolumeMigrationRsyncClient,
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -511,7 +511,7 @@ func (t *Task) createRsyncTransferPods() error {
 						},
 					},
 					{
-						Name:    "stunnel",
+						Name:    DirectVolumeMigrationStunnel,
 						Image:   transferImage,
 						Command: []string{"/bin/stunnel", "/etc/stunnel/stunnel.conf"},
 						Ports: []corev1.ContainerPort{
@@ -734,7 +734,7 @@ func (t *Task) createRsyncClientPods() error {
 				},
 			})
 			containers = append(containers, corev1.Container{
-				Name:  "rsync-client",
+				Name:  DirectVolumeMigrationRsyncClient,
 				Image: transferImage,
 				Env: []corev1.EnvVar{
 					{

--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -74,7 +74,7 @@ func (t *Task) areRsyncTransferPodsRunning() (bool, error) {
 	}
 
 	pvcMap := t.getPVCNamespaceMap()
-	dvmLabels := t.getDVMLabels()
+	dvmLabels := t.buildDVMLabels()
 	dvmLabels["purpose"] = DirectVolumeMigrationRsync
 	selector := labels.SelectorFromSet(dvmLabels)
 
@@ -274,7 +274,7 @@ func (t *Task) createRsyncTransferRoute() error {
 		return err
 	}
 	pvcMap := t.getPVCNamespaceMap()
-	dvmLabels := t.getDVMLabels()
+	dvmLabels := t.buildDVMLabels()
 	dvmLabels["purpose"] = DirectVolumeMigrationRsync
 
 	for ns, _ := range pvcMap {
@@ -474,7 +474,7 @@ func (t *Task) createRsyncTransferPods() error {
 			SubPath:   "rsyncd.secrets",
 		})
 
-		dvmLabels := t.getDVMLabels()
+		dvmLabels := t.buildDVMLabels()
 		dvmLabels["purpose"] = DirectVolumeMigrationRsync
 
 		transferPod := corev1.Pod{

--- a/pkg/controller/directvolumemigration/stunnel.go
+++ b/pkg/controller/directvolumemigration/stunnel.go
@@ -340,7 +340,7 @@ func (t *Task) createStunnelClientPods() error {
 
 	pvcMap := t.getPVCNamespaceMap()
 
-	dvmLabels := t.getDVMLabels()
+	dvmLabels := t.buildDVMLabels()
 	dvmLabels["purpose"] = DirectVolumeMigrationStunnel
 
 	for ns, _ := range pvcMap {
@@ -432,7 +432,7 @@ func (t *Task) createStunnelClientPods() error {
 			},
 		})
 
-		dvmLabels := t.getDVMLabels()
+		dvmLabels := t.buildDVMLabels()
 		dvmLabels["purpose"] = DirectVolumeMigrationStunnel
 
 		clientPod := corev1.Pod{
@@ -474,7 +474,7 @@ func (t *Task) areStunnelClientPodsRunning() (bool, error) {
 
 	pvcMap := t.getPVCNamespaceMap()
 
-	dvmLabels := t.getDVMLabels()
+	dvmLabels := t.buildDVMLabels()
 	dvmLabels["purpose"] = DirectVolumeMigrationStunnel
 	selector := labels.SelectorFromSet(dvmLabels)
 

--- a/pkg/controller/directvolumemigration/stunnel.go
+++ b/pkg/controller/directvolumemigration/stunnel.go
@@ -341,7 +341,7 @@ func (t *Task) createStunnelClientPods() error {
 	pvcMap := t.getPVCNamespaceMap()
 
 	dvmLabels := t.getDVMLabels()
-	dvmLabels["purpose"] = Stunnel
+	dvmLabels["purpose"] = DirectVolumeMigrationStunnel
 
 	for ns, _ := range pvcMap {
 		svc := corev1.Service{
@@ -433,7 +433,7 @@ func (t *Task) createStunnelClientPods() error {
 		})
 
 		dvmLabels := t.getDVMLabels()
-		dvmLabels["purpose"] = Stunnel
+		dvmLabels["purpose"] = DirectVolumeMigrationStunnel
 
 		clientPod := corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -475,7 +475,7 @@ func (t *Task) areStunnelClientPodsRunning() (bool, error) {
 	pvcMap := t.getPVCNamespaceMap()
 
 	dvmLabels := t.getDVMLabels()
-	dvmLabels["purpose"] = Stunnel
+	dvmLabels["purpose"] = DirectVolumeMigrationStunnel
 	selector := labels.SelectorFromSet(dvmLabels)
 
 	for ns, _ := range pvcMap {

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -64,17 +64,12 @@ const (
 	DirectVolumeMigrationStunnelCerts       = "directvolumemigration-stunnel-certs"
 	DirectVolumeMigrationRsyncPass          = "directvolumemigration-rsync-pass"
 	DirectVolumeMigrationStunnelTransfer    = "directvolumemigration-stunnel-transfer"
-	// Identifies associated migplan
-	// to allow migplan restored resources rollback
-	// The value is Task.PlanResources.MigPlan.UID
-	MigPlanLabel = "migration.openshift.io/migrated-by-migplan" // (migplan UID)
-	// Identifies the resource as migrated by us
-	// for easy search or application rollback.
-	// The value is the Task.UID().
-	MigMigrationLabel = "migration.openshift.io/migrated-by-migmigration" // (migmigration UID)
-	Rsync             = "rsync"
-	RsyncClient       = "rsync-client"
-	Stunnel           = "stunnel"
+	DirectVolumeMigrationRsync              = "rsync"
+	DirectVolumeMigrationRsyncClient        = "rsync-client"
+	DirectVolumeMigrationStunnel            = "stunnel"
+	MigratedByPlanLabel                     = "migration.openshift.io/migrated-by-migplan"      // (migplan UID)
+	MigratedByMigrationLabel                = "migration.openshift.io/migrated-by-migmigration" // (migmigration UID)
+
 )
 
 // Flags

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -52,6 +52,31 @@ const (
 	MigrationFailed                      = "MigrationFailed"
 )
 
+// labels
+const (
+	DirectVolumeMigration                   = "directvolumemigration"
+	DirectVolumeMigrationRsyncTransfer      = "directvolumemigration-rsync-transfer"
+	DirectVolumeMigrationRsyncConfig        = "directvolumemigration-rsync-config"
+	DirectVolumeMigrationRsyncCreds         = "directvolumemigration-rsync-creds"
+	DirectVolumeMigrationRsyncTransferSvc   = "directvolumemigration-rsync-transfer-svc"
+	DirectVolumeMigrationRsyncTransferRoute = "directvolumemigration-rsync-transfer-route"
+	DirectVolumeMigrationStunnelConfig      = "directvolumemigration-stunnel-config"
+	DirectVolumeMigrationStunnelCerts       = "directvolumemigration-stunnel-certs"
+	DirectVolumeMigrationRsyncPass          = "directvolumemigration-rsync-pass"
+	DirectVolumeMigrationStunnelTransfer    = "directvolumemigration-stunnel-transfer"
+	// Identifies associated migplan
+	// to allow migplan restored resources rollback
+	// The value is Task.PlanResources.MigPlan.UID
+	MigPlanLabel = "migration.openshift.io/migrated-by-migplan" // (migplan UID)
+	// Identifies the resource as migrated by us
+	// for easy search or application rollback.
+	// The value is the Task.UID().
+	MigMigrationLabel = "migration.openshift.io/migrated-by-migmigration" // (migmigration UID)
+	Rsync             = "rsync"
+	RsyncClient       = "rsync-client"
+	Stunnel           = "stunnel"
+)
+
 // Flags
 // TODO: are there any phases to skip?
 /*const (
@@ -141,6 +166,8 @@ type Task struct {
 	RsyncRoutes      map[string]string
 	Phase            string
 	PhaseDescription string
+	PlanResources    *migapi.PlanResources
+	MigrationUID     string
 	Requeue          time.Duration
 	Itinerary        Itinerary
 	Errors           []string
@@ -453,4 +480,14 @@ func (t *Task) getDestinationClient() (compat.Client, error) {
 		return nil, err
 	}
 	return client, nil
+}
+
+// Get DVM labels for the migration
+func (t *Task) getDVMLabels() map[string]string {
+	dvmLabels := make(map[string]string)
+
+	dvmLabels["app"] = DirectVolumeMigrationRsyncTransfer
+	dvmLabels["owner"] = DirectVolumeMigration
+
+	return dvmLabels
 }

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -478,7 +478,7 @@ func (t *Task) getDestinationClient() (compat.Client, error) {
 }
 
 // Get DVM labels for the migration
-func (t *Task) getDVMLabels() map[string]string {
+func (t *Task) buildDVMLabels() map[string]string {
 	dvmLabels := make(map[string]string)
 
 	dvmLabels["app"] = DirectVolumeMigrationRsyncTransfer


### PR DESCRIPTION
The PR does the following:
- Adds two new attributes `PlanResources` and `MigrationUID` to the DVM task struct.
- Adds a new function `GetMigrationForDVM` based on owner reference.
- Adds `MigMigrationLabel` and `MigPlanLabel` on destination PVCs to facilitate rollback.
- Adds a new function to fetch common dvm labels `getDVMLabels()`.
- Converts labels strings to const strings.
- Fixes https://github.com/konveyor/mig-controller/issues/840