### PR TITLE
Bug 1906810: Failing migration if registry pods are in ImagePullBackOff state

### DIFF
--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -391,7 +391,7 @@ func (t *Task) Run() error {
 		nEnsured, message, err := ensureRegistryHealth(t.Client, t.Owner)
 		if err != nil {
 			if err.Error() == "ImagePullBackOff" {
-				t.fail("WaitForRegistriesReady", []string{message})
+				t.fail(WaitForRegistriesReady, []string{message})
 			} else {
 				return liberr.Wrap(err)
 			}

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -390,7 +390,11 @@ func (t *Task) Run() error {
 		// After this, registry health is continuously checked in validation.go
 		nEnsured, message, err := ensureRegistryHealth(t.Client, t.Owner)
 		if err != nil {
-			return liberr.Wrap(err)
+			if err.Error() == "ImagePullBackOff" {
+				t.fail("WaitForRegistriesReady", []string{message})
+			} else {
+				return liberr.Wrap(err)
+			}
 		}
 		if nEnsured == 2 && message == "" {
 			setMigRegistryHealthyCondition(t.Owner)

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -313,6 +313,7 @@ func ensureRegistryHealth(c k8sclient.Client, migration *migapi.MigMigration) (i
 	return nEnsured, "", nil
 }
 
+// Checking the health of registry pod, return health status, pod and container status of the pod.
 func isRegistryPodUnHealthy(registryPods corev1.PodList) (bool, corev1.Pod, string) {
 	unHealthyPod := corev1.Pod{}
 	for _, registryPod := range registryPods.Items {
@@ -320,8 +321,11 @@ func isRegistryPodUnHealthy(registryPods corev1.PodList) (bool, corev1.Pod, stri
 			if !containerStatus.Ready {
 				if containerStatus.State.Waiting != nil {
 					return true, registryPod, containerStatus.State.Waiting.Reason
+				} else if containerStatus.State.Terminated != nil {
+					return true, registryPod, "Terminating"
+				} else {
+					return true, registryPod, "Running"
 				}
-				return true, registryPod, "Running"
 			}
 		}
 	}

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -318,7 +318,10 @@ func isRegistryPodUnHealthy(registryPods corev1.PodList) (bool, corev1.Pod, stri
 	for _, registryPod := range registryPods.Items {
 		for _, containerStatus := range registryPod.Status.ContainerStatuses {
 			if !containerStatus.Ready {
-				return true, registryPod, containerStatus.State.Waiting.Reason
+				if containerStatus.State.Waiting != nil {
+					return true, registryPod, containerStatus.State.Waiting.Reason
+				}
+				return true, registryPod, "Running"
 			}
 		}
 	}


### PR DESCRIPTION
This PR resolves [bug-1906810](https://bugzilla.redhat.com/show_bug.cgi?id=1906810)

If the registry pods are in the `ImagePullBackOff` state then fail the migration.