### PR TITLE
Add Validation for Exposed Registry Route

### DIFF
--- a/pkg/apis/migration/v1alpha1/model.go
+++ b/pkg/apis/migration/v1alpha1/model.go
@@ -154,7 +154,7 @@ func GetMigrationForDVM(client k8sclient.Client, owners []metav1.OwnerReference)
 			return nil, liberr.Wrap(err)
 		}
 	}
-	
+
 	return &migrationObject, nil
 }
 

--- a/pkg/controller/migcluster/validation.go
+++ b/pkg/controller/migcluster/validation.go
@@ -258,7 +258,7 @@ func (r ReconcileMigCluster) validateRegistryRoute(cluster *migapi.MigCluster) e
 				Status:   True,
 				Reason:   RouteTestFailed,
 				Category: Critical,
-				Message:  fmt.Sprintf("Exposed registry route is invalid, Error : %#v", err),
+				Message:  fmt.Sprintf("Exposed registry route is invalid, Error : %#v", err.Error()),
 				Items:    []string{err.Error()},
 			})
 			return nil

--- a/pkg/controller/migcluster/validation.go
+++ b/pkg/controller/migcluster/validation.go
@@ -258,8 +258,19 @@ func (r ReconcileMigCluster) validateRegistryRoute(cluster *migapi.MigCluster) e
 				Status:   True,
 				Reason:   RouteTestFailed,
 				Category: Critical,
-				Message:  fmt.Sprintf("Exposed registry route is invalid, response received : %#v", res),
+				Message:  fmt.Sprintf("Exposed registry route is invalid, Error : %#v", err),
 				Items:    []string{err.Error()},
+			})
+			return nil
+		}
+
+		if res.StatusCode != 200 {
+			cluster.Status.SetCondition(migapi.Condition{
+				Type:     InvalidRegistryRoute,
+				Status:   True,
+				Reason:   RouteTestFailed,
+				Category: Critical,
+				Message:  fmt.Sprintf("Exposed registry route connection test failed, Response code received: %#v", res.StatusCode),
 			})
 			return nil
 		}

--- a/pkg/controller/migcluster/validation.go
+++ b/pkg/controller/migcluster/validation.go
@@ -228,9 +228,6 @@ func (r ReconcileMigCluster) testConnection(cluster *migapi.MigCluster) error {
 
 // Validate the Exposed registry route
 func (r ReconcileMigCluster) validateRegistryRoute(cluster *migapi.MigCluster) error {
-	if cluster.Spec.IsHostCluster {
-		return nil
-	}
 
 	if cluster.Status.HasCriticalCondition() {
 		return nil

--- a/pkg/controller/migcluster/validation.go
+++ b/pkg/controller/migcluster/validation.go
@@ -2,7 +2,9 @@ package migcluster
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"net/url"
 	"path"
 	"strings"
@@ -20,6 +22,7 @@ const (
 	InvalidURL           = "InvalidURL"
 	InvalidSaSecretRef   = "InvalidSaSecretRef"
 	InvalidSaToken       = "InvalidSaToken"
+	InvalidRegistryRoute = "InvalidRegistryRoute"
 	TestConnectFailed    = "TestConnectFailed"
 	SaTokenNotPrivileged = "SaTokenNotPrivileged"
 )
@@ -31,12 +34,13 @@ const (
 
 // Reasons
 const (
-	NotSet        = "NotSet"
-	NotFound      = "NotFound"
-	ConnectFailed = "ConnectFailed"
-	Malformed     = "Malformed"
-	InvalidScheme = "InvalidScheme"
-	Unauthorized  = "Unauthorized"
+	NotSet          = "NotSet"
+	NotFound        = "NotFound"
+	ConnectFailed   = "ConnectFailed"
+	Malformed       = "Malformed"
+	RouteTestFailed = "RouteTestFailed"
+	InvalidScheme   = "InvalidScheme"
+	Unauthorized    = "Unauthorized"
 )
 
 // Statuses
@@ -68,6 +72,12 @@ func (r ReconcileMigCluster) validate(cluster *migapi.MigCluster) error {
 
 	// Token privileges
 	err = r.validateSaTokenPrivileges(cluster)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+
+	// Exposed registry route
+	err = r.validateRegistryRoute(cluster)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
@@ -213,6 +223,50 @@ func (r ReconcileMigCluster) testConnection(cluster *migapi.MigCluster) error {
 		return nil
 	}
 
+	return nil
+}
+
+// Validate the Exposed registry route
+func (r ReconcileMigCluster) validateRegistryRoute(cluster *migapi.MigCluster) error {
+	if cluster.Spec.IsHostCluster {
+		return nil
+	}
+
+	if cluster.Status.HasCriticalCondition() {
+		return nil
+	}
+
+	if cluster.Spec.ExposedRegistryPath != "" {
+		url := "https://" + cluster.Spec.ExposedRegistryPath + "/v2/"
+		restConfig, err := cluster.BuildRestConfig(r.Client)
+		token := restConfig.BearerToken
+
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client := &http.Client{Transport: tr}
+
+		req, err := http.NewRequest("GET", url, nil)
+
+		if err != nil {
+			return liberr.Wrap(err)
+		}
+
+		req.Header.Set("Authorization", "bearer "+token)
+
+		res, err := client.Do(req)
+		if err != nil {
+			cluster.Status.SetCondition(migapi.Condition{
+				Type:     InvalidRegistryRoute,
+				Status:   True,
+				Reason:   RouteTestFailed,
+				Category: Critical,
+				Message:  fmt.Sprintf("Exposed registry route is invalid, response received : %#v", res),
+				Items:    []string{err.Error()},
+			})
+			return nil
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
This PR does the following:
- Adds a new `MigCluster` validation called `validateRegistryRoute`
- This validation checks if the exposed image registry route added by the user for a cluster is valid or not
- The validation is done based on https://github.com/konveyor/mig-controller/issues/780#issuecomment-741869357
- Fixes https://github.com/konveyor/mig-controller/issues/780