### PR TITLE
warn a user if dvm controller is blocked because of dependency pods

### DIFF
--- a/pkg/apis/migration/v1alpha1/condition.go
+++ b/pkg/apis/migration/v1alpha1/condition.go
@@ -223,7 +223,7 @@ func (r *Conditions) SetCondition(condition Condition) {
 	condition.staged = true
 	found := r.find(condition.Type)
 	if found == nil {
-		condition.LastTransitionTime = metav1.NewTime(time.Now())
+		condition.LastTransitionTime = metav1.NewTime(time.Now().UTC())
 		r.List = append(r.List, condition)
 	} else {
 		found.Update(condition)

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -2,6 +2,7 @@ package directvolumemigration
 
 import (
 	"crypto/rsa"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -299,11 +300,34 @@ func (t *Task) Run() error {
 		}
 		if running {
 			t.Requeue = NoReQ
+			conditions := t.Owner.Status.FindConditionByCategory(Warn)
+			for _, c := range conditions {
+				if c.Reason == RsyncTransferPodsPending {
+					t.Owner.Status.DeleteCondition(RsyncTransferPodsPending)
+				}
+			}
 			if err = t.next(); err != nil {
 				return liberr.Wrap(err)
 			}
 		} else {
 			t.Requeue = PollReQ
+			t.Owner.Status.StageCondition(Running)
+			cond := t.Owner.Status.FindCondition(Running)
+			if cond == nil {
+				return fmt.Errorf("unable to find running condition")
+			}
+			now := time.Now().UTC()
+			if now.Sub(cond.LastTransitionTime.Time.UTC()) > 10*time.Minute {
+				t.Owner.Status.SetCondition(
+					migapi.Condition{
+						Type:     RsyncTransferPodsPending,
+						Status:   True,
+						Reason:   migapi.NotReady,
+						Category: Warn,
+						Message:  "Some or all transfer pods are pending for more than 10 mins on destination cluster",
+					},
+				)
+			}
 		}
 	case CreateStunnelClientPods:
 		err := t.createStunnelClientPods()
@@ -321,10 +345,36 @@ func (t *Task) Run() error {
 		}
 		if running {
 			t.Requeue = NoReQ
+			conditions := t.Owner.Status.FindConditionByCategory(Warn)
+			for _, c := range conditions {
+				if c.Reason == StunnelClientPodsPending {
+					t.Owner.Status.DeleteCondition("StunnelClientPodsPending")
+				}
+			}
 			if err = t.next(); err != nil {
 				return liberr.Wrap(err)
 			}
 		} else {
+			t.Owner.Status.StageCondition(Running)
+			cond := t.Owner.Status.FindCondition(Running)
+			if cond == nil {
+				return fmt.Errorf("`Running` condition missing on DVM %s/%s", t.Owner.Namespace, t.Owner.Name)
+			}
+			now := time.Now().UTC()
+			if now.After(cond.LastTransitionTime.Time) {
+				if now.Sub(cond.LastTransitionTime.Time).Round(time.Minute) > 10*time.Minute {
+					t.Owner.Status.SetCondition(
+						migapi.Condition{
+							Type:     StunnelClientPodsPending,
+							Status:   True,
+							Reason:   migapi.NotReady,
+							Category: Warn,
+							Message:  "Some or all stunnel client pods are pending for more than 10 mins on the source cluster",
+							Durable:  true,
+						},
+					)
+				}
+			}
 			t.Requeue = PollReQ
 		}
 	case CreatePVProgressCRs:

--- a/pkg/controller/directvolumemigration/validation.go
+++ b/pkg/controller/directvolumemigration/validation.go
@@ -21,6 +21,8 @@ const (
 	SourceClusterNotReady        = "SourceClusterNotReady"
 	DestinationClusterNotReady   = "DestinationClusterNotReady"
 	PVCsNotFoundOnSourceCluster  = "PodsNotFoundOnSourceCluster"
+	StunnelClientPodsPending     = "StunnelClientPodsPending"
+	RsyncTransferPodsPending     = "RsyncTransferPodsPending"
 	Running                      = "Running"
 	Failed                       = "Failed"
 	Succeeded                    = "Succeeded"
@@ -54,6 +56,7 @@ const (
 const (
 	Critical = migapi.Critical
 	Advisory = migapi.Advisory
+	Warn     = migapi.Warn
 )
 
 // Statuses

--- a/pkg/controller/migmigration/dvm.go
+++ b/pkg/controller/migmigration/dvm.go
@@ -117,16 +117,15 @@ func (t *Task) hasDirectVolumeMigrationCompleted(dvm *migapi.DirectVolumeMigrati
 	return completed, failureReasons, progress
 }
 
-func (t *Task) getCriticalWarningForDVM(dvm *migapi.DirectVolumeMigration) (*migapi.Condition, error) {
-	conditions := dvm.Status.Conditions.FindConditionByCategory(dvmc.Critical)
+func (t *Task) getWarningForDVM(dvm *migapi.DirectVolumeMigration) (*migapi.Condition, error) {
+	conditions := dvm.Status.Conditions.FindConditionByCategory(dvmc.Warn)
 	if len(conditions) > 0 {
 		return &migapi.Condition{
 			Type:     DirectVolumeMigrationBlocked,
 			Status:   True,
 			Reason:   migapi.NotReady,
-			Category: Critical,
+			Category: migapi.Warn,
 			Message:  joinConditionMessages(conditions),
-			Durable:  true,
 		}, nil
 	}
 

--- a/pkg/controller/migmigration/dvm.go
+++ b/pkg/controller/migmigration/dvm.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
+	"sort"
+	"strings"
+
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	dvmc "github.com/konveyor/mig-controller/pkg/controller/directvolumemigration"
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	path "path"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sort"
 )
 
 func (t *Task) createDirectVolumeMigration() error {
@@ -113,6 +115,30 @@ func (t *Task) hasDirectVolumeMigrationCompleted(dvm *migapi.DirectVolumeMigrati
 	// sort the progress report so we dont have flapping for the same progress info
 	sort.Sort(sort.StringSlice(progress))
 	return completed, failureReasons, progress
+}
+
+func (t *Task) getCriticalWarningForDVM(dvm *migapi.DirectVolumeMigration) (*migapi.Condition, error) {
+	conditions := dvm.Status.Conditions.FindConditionByCategory(dvmc.Critical)
+	if len(conditions) > 0 {
+		return &migapi.Condition{
+			Type:     DirectVolumeMigrationBlocked,
+			Status:   True,
+			Reason:   migapi.NotReady,
+			Category: Critical,
+			Message:  joinConditionMessages(conditions),
+			Durable:  true,
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func joinConditionMessages(conditions []*migapi.Condition) string {
+	messages := []string{}
+	for _, c := range conditions {
+		messages = append(messages, c.Message)
+	}
+	return strings.Join(messages, ", ")
 }
 
 // Set warning conditions on migmigration if there were any partial failures

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -669,6 +669,15 @@ func (t *Task) Run() error {
 			}
 		} else {
 			t.Requeue = PollReQ
+			criticalWarning, err := t.getCriticalWarningForDVM(dvm)
+			if err != nil {
+				return liberr.Wrap(err)
+			}
+			if criticalWarning != nil {
+				t.Owner.Status.SetCondition(*criticalWarning)
+				return nil
+			}
+			t.Owner.Status.DeleteCondition(DirectVolumeMigrationBlocked)
 		}
 	case EnsureStageBackup:
 		_, err := t.ensureStageBackup()

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -669,7 +669,7 @@ func (t *Task) Run() error {
 			}
 		} else {
 			t.Requeue = PollReQ
-			criticalWarning, err := t.getCriticalWarningForDVM(dvm)
+			criticalWarning, err := t.getWarningForDVM(dvm)
 			if err != nil {
 				return liberr.Wrap(err)
 			}

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -41,6 +41,7 @@ const (
 	StaleSrcVeleroCRsDeleted           = "StaleSrcVeleroCRsDeleted"
 	StaleDestVeleroCRsDeleted          = "StaleDestVeleroCRsDeleted"
 	StaleResticCRsDeleted              = "StaleResticCRsDeleted"
+	DirectVolumeMigrationBlocked       = "DirectVolumeMigrationBlocked"
 )
 
 // Categories


### PR DESCRIPTION
This adds the following:
- warning to dvm controllers for pending transfer and stunnel pods
- bubbles up the warnings to migmigration from the dvm controller

fixes #839 