### PR TITLE
read the pod configurations from configmap

### DIFF
--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -364,7 +364,7 @@ func (t *Task) createRsyncTransferPods() error {
 	if err != nil {
 		return err
 	}
-	limits, requests, err := getPodConfig(t.Client, []string{"TRANSFER_POD_CPU_LIMIT", "TRANSFER_POD_MEMORY_LIMIT", "TRANSFER_POD_CPU_REQUEST", "TRANSFER_POD_MEMORY_REQUEST"})
+	limits, requests, err := getPodConfig(t.Client, "TRANSFER_POD_CPU_LIMIT", "TRANSFER_POD_MEMORY_LIMIT", "TRANSFER_POD_CPU_REQUEST", "TRANSFER_POD_MEMORY_REQUEST")
 	if err != nil {
 		return err
 	}
@@ -564,28 +564,34 @@ func (t *Task) createRsyncTransferPods() error {
 	return nil
 }
 
-func getPodConfig(client k8sclient.Client, keys []string) (corev1.ResourceList, corev1.ResourceList, error) {
+func getPodConfig(client k8sclient.Client, cpu_limit string, memory_limit string, cpu_request string, memory_request string, ) (corev1.ResourceList, corev1.ResourceList, error) {
 	podConfigMap := &corev1.ConfigMap{}
 	err := client.Get(context.TODO(), types.NamespacedName{Name: "migration-controller", Namespace: migapi.OpenshiftMigrationNamespace}, podConfigMap)
 	if err != nil {
 		return nil, nil, err
 	}
-	limits := corev1.ResourceList{}
-	if _, exists := podConfigMap.Data[keys[0]]; exists {
-		cpu := resource.MustParse(podConfigMap.Data[keys[0]])
-		if _, exists := podConfigMap.Data[keys[1]]; exists {
-			memory := resource.MustParse(podConfigMap.Data[keys[1]])
+	limits := corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse("1Gi"),
+		corev1.ResourceCPU: resource.MustParse("1"),
+	}
+	if _, exists := podConfigMap.Data[cpu_limit]; exists {
+		cpu := resource.MustParse(podConfigMap.Data[cpu_limit])
+		if _, exists := podConfigMap.Data[memory_limit]; exists {
+			memory := resource.MustParse(podConfigMap.Data[memory_limit])
 			limits = corev1.ResourceList{
 				corev1.ResourceCPU:    cpu,
 				corev1.ResourceMemory: memory,
 			}
 		}
 	}
-	requests := corev1.ResourceList{}
-	if _, exists := podConfigMap.Data[keys[2]]; exists {
-		cpu := resource.MustParse(podConfigMap.Data[keys[2]])
-		if _, exists := podConfigMap.Data[keys[3]]; exists {
-			memory := resource.MustParse(podConfigMap.Data[keys[3]])
+	requests := corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse("1Gi"),
+		corev1.ResourceCPU: resource.MustParse("400m"),
+	}
+	if _, exists := podConfigMap.Data[cpu_request]; exists {
+		cpu := resource.MustParse(podConfigMap.Data[cpu_request])
+		if _, exists := podConfigMap.Data[memory_request]; exists {
+			memory := resource.MustParse(podConfigMap.Data[memory_request])
 			requests = corev1.ResourceList{
 				corev1.ResourceCPU:    cpu,
 				corev1.ResourceMemory: memory,
@@ -789,7 +795,7 @@ func (t *Task) createRsyncClientPods() error {
 		return err
 	}
 
-	limits, requests, err := getPodConfig(t.Client, []string{"CLIENT_POD_CPU_LIMIT", "CLIENT_POD_MEMORY_LIMIT", "CLIENT_POD_CPU_REQUEST", "CLIENT_POD_MEMORY_REQUEST"})
+	limits, requests, err := getPodConfig(t.Client, "CLIENT_POD_CPU_LIMIT", "CLIENT_POD_MEMORY_LIMIT", "CLIENT_POD_CPU_REQUEST", "CLIENT_POD_MEMORY_REQUEST")
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -38,6 +38,21 @@ type rsyncConfig struct {
 	PVCList   []pvc
 }
 
+const (
+	TRANSFER_POD_CPU_LIMIT      = "TRANSFER_POD_CPU_LIMIT"
+	TRANSFER_POD_MEMORY_LIMIT   = "TRANSFER_POD_MEMORY_LIMIT"
+	TRANSFER_POD_CPU_REQUEST    = "TRANSFER_POD_CPU_REQUEST"
+	TRANSFER_POD_MEMORY_REQUEST = "TRANSFER_POD_MEMORY_REQUEST"
+	CLIENT_POD_CPU_LIMIT        = "CLIENT_POD_CPU_LIMIT"
+	CLIENT_POD_MEMORY_LIMIT     = "CLIENT_POD_MEMORY_LIMIT"
+	CLIENT_POD_CPU_REQUEST      = "CLIENT_POD_CPU_REQUEST"
+	CLIENT_POD_MEMORY_REQUEST   = "CLIENT_POD_MEMORY_REQUEST"
+	STUNNEL_POD_CPU_LIMIT       = "STUNNEL_POD_CPU_LIMIT"
+	STUNNEL_POD_MEMORY_LIMIT    = "STUNNEL_POD_MEMORY_LIMIT"
+	STUNNEL_POD_CPU_REQUEST     = "STUNNEL_POD_CPU_REQUEST"
+	STUNNEL_POD_MEMORY_REQUEST  = "STUNNEL_POD_MEMORY_REQUEST"
+)
+
 // TODO: Parameterize this more to support custom
 // user/pass/networking configs from directvolumemigration spec
 const rsyncConfigTemplate = `apiVersion: v1
@@ -364,7 +379,7 @@ func (t *Task) createRsyncTransferPods() error {
 	if err != nil {
 		return err
 	}
-	limits, requests, err := getPodConfig(t.Client, "TRANSFER_POD_CPU_LIMIT", "TRANSFER_POD_MEMORY_LIMIT", "TRANSFER_POD_CPU_REQUEST", "TRANSFER_POD_MEMORY_REQUEST")
+	limits, requests, err := getPodConfig(t.Client, TRANSFER_POD_CPU_LIMIT, TRANSFER_POD_MEMORY_LIMIT, TRANSFER_POD_CPU_REQUEST, TRANSFER_POD_MEMORY_REQUEST)
 	if err != nil {
 		return err
 	}
@@ -517,7 +532,7 @@ func (t *Task) createRsyncTransferPods() error {
 							ReadOnlyRootFilesystem: &trueBool,
 						},
 						Resources: corev1.ResourceRequirements{
-							Limits: limits,
+							Limits:   limits,
 							Requests: requests,
 						},
 					},
@@ -572,7 +587,7 @@ func getPodConfig(client k8sclient.Client, cpu_limit string, memory_limit string
 	}
 	limits := corev1.ResourceList{
 		corev1.ResourceMemory: resource.MustParse("1Gi"),
-		corev1.ResourceCPU: resource.MustParse("1"),
+		corev1.ResourceCPU:    resource.MustParse("1"),
 	}
 	if _, exists := podConfigMap.Data[cpu_limit]; exists {
 		cpu := resource.MustParse(podConfigMap.Data[cpu_limit])
@@ -586,7 +601,7 @@ func getPodConfig(client k8sclient.Client, cpu_limit string, memory_limit string
 	}
 	requests := corev1.ResourceList{
 		corev1.ResourceMemory: resource.MustParse("1Gi"),
-		corev1.ResourceCPU: resource.MustParse("400m"),
+		corev1.ResourceCPU:    resource.MustParse("400m"),
 	}
 	if _, exists := podConfigMap.Data[cpu_request]; exists {
 		cpu := resource.MustParse(podConfigMap.Data[cpu_request])
@@ -795,7 +810,7 @@ func (t *Task) createRsyncClientPods() error {
 		return err
 	}
 
-	limits, requests, err := getPodConfig(t.Client, "CLIENT_POD_CPU_LIMIT", "CLIENT_POD_MEMORY_LIMIT", "CLIENT_POD_CPU_REQUEST", "CLIENT_POD_MEMORY_REQUEST")
+	limits, requests, err := getPodConfig(t.Client, CLIENT_POD_CPU_LIMIT, CLIENT_POD_MEMORY_LIMIT, CLIENT_POD_CPU_REQUEST, CLIENT_POD_MEMORY_REQUEST)
 	if err != nil {
 		return err
 	}
@@ -857,7 +872,7 @@ func (t *Task) createRsyncClientPods() error {
 					ReadOnlyRootFilesystem: &trueBool,
 				},
 				Resources: corev1.ResourceRequirements{
-					Limits: limits,
+					Limits:   limits,
 					Requests: requests,
 				},
 			})

--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -379,7 +379,7 @@ func (t *Task) createRsyncTransferPods() error {
 	if err != nil {
 		return err
 	}
-	limits, requests, err := getPodresourceLists(t.Client, TRANSFER_POD_CPU_LIMIT, TRANSFER_POD_MEMORY_LIMIT, TRANSFER_POD_CPU_REQUEST, TRANSFER_POD_MEMORY_REQUEST)
+	limits, requests, err := getPodResourceLists(t.Client, TRANSFER_POD_CPU_LIMIT, TRANSFER_POD_MEMORY_LIMIT, TRANSFER_POD_CPU_REQUEST, TRANSFER_POD_MEMORY_REQUEST)
 	if err != nil {
 		return err
 	}
@@ -579,7 +579,7 @@ func (t *Task) createRsyncTransferPods() error {
 	return nil
 }
 
-func getPodresourceLists(client k8sclient.Client, cpu_limit string, memory_limit string, cpu_request string, memory_request string ) (corev1.ResourceList, corev1.ResourceList, error) {
+func getPodResourceLists(client k8sclient.Client, cpu_limit string, memory_limit string, cpu_request string, memory_request string ) (corev1.ResourceList, corev1.ResourceList, error) {
 	podConfigMap := &corev1.ConfigMap{}
 	err := client.Get(context.TODO(), types.NamespacedName{Name: "migration-controller", Namespace: migapi.OpenshiftMigrationNamespace}, podConfigMap)
 	if err != nil {
@@ -806,7 +806,7 @@ func (t *Task) createRsyncClientPods() error {
 		return err
 	}
 
-	limits, requests, err := getPodresourceLists(t.Client, CLIENT_POD_CPU_LIMIT, CLIENT_POD_MEMORY_LIMIT, CLIENT_POD_CPU_REQUEST, CLIENT_POD_MEMORY_REQUEST)
+	limits, requests, err := getPodResourceLists(t.Client, CLIENT_POD_CPU_LIMIT, CLIENT_POD_MEMORY_LIMIT, CLIENT_POD_CPU_REQUEST, CLIENT_POD_MEMORY_REQUEST)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/directvolumemigration/stunnel.go
+++ b/pkg/controller/directvolumemigration/stunnel.go
@@ -338,7 +338,7 @@ func (t *Task) createStunnelClientPods() error {
 		return err
 	}
 
-	limits, requests, err := getPodConfig(t.Client, "STUNNEL_POD_CPU_LIMIT", "STUNNEL_POD_MEMORY_LIMIT", "STUNNEL_POD_CPU_REQUEST", "STUNNEL_POD_MEMORY_REQUEST")
+	limits, requests, err := getPodConfig(t.Client, STUNNEL_POD_CPU_LIMIT, STUNNEL_POD_MEMORY_LIMIT, STUNNEL_POD_CPU_REQUEST, STUNNEL_POD_MEMORY_REQUEST)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/directvolumemigration/stunnel.go
+++ b/pkg/controller/directvolumemigration/stunnel.go
@@ -338,6 +338,10 @@ func (t *Task) createStunnelClientPods() error {
 		return err
 	}
 
+	limits, requests, err := getPodConfig(t.Client, []string{"STUNNEL_POD_CPU_LIMIT", "STUNNEL_POD_MEMORY_LIMIT", "STUNNEL_POD_CPU_REQUEST", "STUNNEL_POD_MEMORY_REQUEST"})
+	if err != nil {
+		return err
+	}
 	pvcMap := t.getPVCNamespaceMap()
 
 	dvmLabels := t.buildDVMLabels()
@@ -429,6 +433,10 @@ func (t *Task) createStunnelClientPods() error {
 				Privileged:             &trueBool,
 				RunAsUser:              &runAsUser,
 				ReadOnlyRootFilesystem: &trueBool,
+			},
+			Resources: corev1.ResourceRequirements{
+				Limits: limits,
+				Requests: requests,
 			},
 		})
 

--- a/pkg/controller/directvolumemigration/stunnel.go
+++ b/pkg/controller/directvolumemigration/stunnel.go
@@ -338,7 +338,7 @@ func (t *Task) createStunnelClientPods() error {
 		return err
 	}
 
-	limits, requests, err := getPodConfig(t.Client, STUNNEL_POD_CPU_LIMIT, STUNNEL_POD_MEMORY_LIMIT, STUNNEL_POD_CPU_REQUEST, STUNNEL_POD_MEMORY_REQUEST)
+	limits, requests, err := getPodresourceLists(t.Client, STUNNEL_POD_CPU_LIMIT, STUNNEL_POD_MEMORY_LIMIT, STUNNEL_POD_CPU_REQUEST, STUNNEL_POD_MEMORY_REQUEST)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/directvolumemigration/stunnel.go
+++ b/pkg/controller/directvolumemigration/stunnel.go
@@ -338,7 +338,7 @@ func (t *Task) createStunnelClientPods() error {
 		return err
 	}
 
-	limits, requests, err := getPodresourceLists(t.Client, STUNNEL_POD_CPU_LIMIT, STUNNEL_POD_MEMORY_LIMIT, STUNNEL_POD_CPU_REQUEST, STUNNEL_POD_MEMORY_REQUEST)
+	limits, requests, err := getPodResourceLists(t.Client, STUNNEL_POD_CPU_LIMIT, STUNNEL_POD_MEMORY_LIMIT, STUNNEL_POD_CPU_REQUEST, STUNNEL_POD_MEMORY_REQUEST)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/directvolumemigration/stunnel.go
+++ b/pkg/controller/directvolumemigration/stunnel.go
@@ -338,7 +338,7 @@ func (t *Task) createStunnelClientPods() error {
 		return err
 	}
 
-	limits, requests, err := getPodConfig(t.Client, []string{"STUNNEL_POD_CPU_LIMIT", "STUNNEL_POD_MEMORY_LIMIT", "STUNNEL_POD_CPU_REQUEST", "STUNNEL_POD_MEMORY_REQUEST"})
+	limits, requests, err := getPodConfig(t.Client, "STUNNEL_POD_CPU_LIMIT", "STUNNEL_POD_MEMORY_LIMIT", "STUNNEL_POD_CPU_REQUEST", "STUNNEL_POD_MEMORY_REQUEST")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR requires operator change (needs values in `migration-controller` configMap), The PR for the same can be found https://github.com/konveyor/mig-operator/pull/533. 

This PR reads the respective values from `migration-controller` configMap and configures the rsync transfer, rsync client, and stunnel pods.

Fixes #863 