### PR TITLE
Allow configuring Rsync options through MigrationController CR

### DIFF
--- a/pkg/settings/dvm.go
+++ b/pkg/settings/dvm.go
@@ -1,0 +1,56 @@
+package settings
+
+import (
+	"os"
+	"strings"
+)
+
+// Rsync options
+const (
+	RsyncOptBwLimit   = "RSYNC_OPT_BWLIMIT"
+	RsyncOptPartial   = "RSYNC_OPT_PARTIAL"
+	RsyncOptArchive   = "RSYNC_OPT_ARCHIVE"
+	RsyncOptDelete    = "RSYNC_OPT_DELETE"
+	RsyncOptHardLinks = "RSYNC_OPT_HARDLINKS"
+	RsyncOptInfo      = "RSYNC_OPT_INFO"
+	RsyncOptExtras    = "RSYNC_OPT_EXTRAS"
+)
+
+// RsyncOpts Rsync Options
+//	BwLimit: equivalent to --bwlimit=<integer>
+//	Archive: whether to set --archive option or not
+//	Partial: whether to set --partial option or not
+//	Delete:  whether to set --delete option or not
+//	HardLinks: whether to set --hard-links option or not
+//	Extras: arbitrary rsync options provided by the user
+type RsyncOpts struct {
+	BwLimit   int
+	Archive   bool
+	Partial   bool
+	Delete    bool
+	HardLinks bool
+	Info      string
+	Extras    []string
+}
+
+// Load load rsync options
+func (r *RsyncOpts) Load() error {
+	var err error
+	r.BwLimit, err = getEnvLimit(RsyncOptBwLimit, -1)
+	if err != nil {
+		return err
+	}
+	r.Archive = getEnvBool(RsyncOptArchive, true)
+	r.Partial = getEnvBool(RsyncOptPartial, true)
+	r.Delete = getEnvBool(RsyncOptDelete, true)
+	r.HardLinks = getEnvBool(RsyncOptHardLinks, true)
+	infoOpts := os.Getenv(RsyncOptInfo)
+	if len(infoOpts) > 0 {
+		r.Info = infoOpts
+	}
+	rsyncExtraOpts := os.Getenv(RsyncOptExtras)
+	if len(rsyncExtraOpts) > 0 {
+		r.Extras = strings.Fields(rsyncExtraOpts)
+	}
+	return err
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -33,6 +33,7 @@ var Settings = _Settings{}
 type _Settings struct {
 	Discovery
 	Plan
+	RsyncOpts
 	Roles     map[string]bool
 	ProxyVars map[string]string
 }
@@ -44,6 +45,10 @@ func (r *_Settings) Load() error {
 		return err
 	}
 	err = r.Discovery.Load()
+	if err != nil {
+		return err
+	}
+	err = r.RsyncOpts.Load()
 	if err != nil {
 		return err
 	}
@@ -62,7 +67,6 @@ func (r *_Settings) Load() error {
 //
 // Load the manager role.
 // The default is ALL roles.
-
 func (r *_Settings) loadProxyVars() error {
 	r.ProxyVars = map[string]string{}
 	if s, found := os.LookupEnv(HttpProxy); found {


### PR DESCRIPTION
Fixes #872 

This PR allows configuring different Rsync options through _MigrationController_ CR

Following default options will **never** be overridden as they are required for progress reporting and logging purposes:
- --human-readable
- --log-file

Following options are controlled through variables in _MigrationController_ CR:

| Option                  	| Type   	| Default                                          	| Operator Flag       	|
|-------------------------	|--------	|--------------------------------------------------	|---------------------	|
| --bwlimit=<>            	| int    	| Not Set                                          	| rsync_opt_bwlimit   	|
| --archive               	| bool   	| True                                             	| rsync_opt_archive   	|
| --partial               	| bool   	| True                                             	| rsync_opt_partial   	|
| --delete                	| bool   	| True                                             	| rsync_opt_delete    	|
| --hard-links            	| bool   	| True                                             	| rsync_opt_hardlinks 	|
| --info=<>               	| string 	| COPY2,DEL2,REMOVE2,SKIP2,FLIST2,PROGRESS2,STATS2 	| rsync_opt_info      	|
| Any other extra options 	| string 	| Empty                                            	| rsync_opt_extras    	|

Please review accompanying operator PR : https://github.com/konveyor/mig-operator/pull/540
