### PR TITLE
Bug 1906724: Delete moved NFS PVs during rollback

### DIFF
--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -69,7 +69,7 @@ func (r *Compare) Compare() (map[string][]schema.GroupVersionResource, error) {
 		return nil, err
 	}
 
-	dstResourceList, err := collectResources(r.DstDiscovery)
+	dstResourceList, err := collectNamespacedResources(r.DstDiscovery)
 	if err != nil {
 		return nil, err
 	}
@@ -119,8 +119,8 @@ func toSet(strSlice []string) mapset.Set {
 	return mapset.NewSetFromSlice(interfaceSlice)
 }
 
-// collectResources collects all namespaced scoped apiResources from the cluster
-func collectResources(discovery discovery.DiscoveryInterface) ([]*metav1.APIResourceList, error) {
+// collectNamespacedResources collects all namespace-scoped apiResources from the cluster
+func collectNamespacedResources(discovery discovery.DiscoveryInterface) ([]*metav1.APIResourceList, error) {
 	resources, err := discovery.ServerResources()
 	if err != nil {
 		return nil, err
@@ -170,8 +170,8 @@ func convertToGVRList(resourceList []*metav1.APIResourceList) ([]schema.GroupVer
 	return GVRs, nil
 }
 
-// GetGVRsForCluster collects all namespaced scoped GVRs for the provided cluster compatible client
-func GetGVRsForCluster(cluster *migapi.MigCluster, c client.Client) (dynamic.Interface, []schema.GroupVersionResource, error) {
+// GetNamespacedGVRsForCluster collects all namespace-scoped GVRs for the provided cluster compatible client
+func GetNamespacedGVRsForCluster(cluster *migapi.MigCluster, c client.Client) (dynamic.Interface, []schema.GroupVersionResource, error) {
 	compat, err := cluster.GetClient(c)
 	if err != nil {
 		return nil, nil, err
@@ -180,7 +180,7 @@ func GetGVRsForCluster(cluster *migapi.MigCluster, c client.Client) (dynamic.Int
 	if err != nil {
 		return nil, nil, err
 	}
-	resourceList, err := collectResources(compat)
+	resourceList, err := collectNamespacedResources(compat)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1906724

This PR will rollback (delete) NFS PV resources that were moved over to the target cluster during a migration so that the next migration attempt can succeed.

For some additional context: PVs are normally removed by their provisioner when we delete the corresponding PVC (already handled in rollback). In the NFS move case, we create PVs along with PVCs. This is a special case since PVs are cluster-scoped and prior to this PR, rollback didn't handle cluster-scoped resources.

---

I spoke with @sseago on this and he suggested that we should only delete dest PVs during rollback when these 3 are true:

1. The PV was migrated by our migplan
2. The PV is NFS
3. The PV has `ReclaimPolicy=Retain`

---

I've seen success with `migrate -> rollback -> migrate` using this PR.

![image](https://user-images.githubusercontent.com/7576968/103944491-b8ab8e00-5101-11eb-957b-d7bd7b1462ff.png)
