### PR TITLE
Cleanup Direct migration Resources when the Cancel operation is invoked

### DIFF
--- a/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
+++ b/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
@@ -117,9 +117,3 @@ func (r *DirectVolumeMigration) HasErrors() bool {
 func init() {
 	SchemeBuilder.Register(&DirectVolumeMigration{}, &DirectVolumeMigrationList{})
 }
-
-func (r *DirectVolumeMigration) DirectVolumeMigrationLabels() map[string]string {
-	labels := r.GetCorrelationLabels()
-	labels["directvolumemigration"] = string(r.UID)
-	return labels
-}

--- a/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
+++ b/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
@@ -117,3 +117,9 @@ func (r *DirectVolumeMigration) HasErrors() bool {
 func init() {
 	SchemeBuilder.Register(&DirectVolumeMigration{}, &DirectVolumeMigrationList{})
 }
+
+func (r *DirectVolumeMigration) DirectVolumeMigrationLabels() map[string]string {
+	labels := r.GetCorrelationLabels()
+	labels["directvolumemigration"] = string(r.UID)
+	return labels
+}

--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -1017,11 +1017,13 @@ func (t *Task) createRsyncClientPods() error {
 // Create rsync PV progress CR on destination cluster
 func (t *Task) createPVProgressCR() error {
 	pvcMap := t.getPVCNamespaceMap()
+	labels := t.Owner.DirectVolumeMigrationLabels()
 	for ns, vols := range pvcMap {
 		for _, vol := range vols {
 			dvmp := migapi.DirectVolumeMigrationProgress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      getMD5Hash(t.Owner.Name + vol + ns),
+					Labels:    labels,
 					Namespace: migapi.OpenshiftMigrationNamespace,
 				},
 				Spec: migapi.DirectVolumeMigrationProgressSpec{

--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -1017,7 +1017,7 @@ func (t *Task) createRsyncClientPods() error {
 // Create rsync PV progress CR on destination cluster
 func (t *Task) createPVProgressCR() error {
 	pvcMap := t.getPVCNamespaceMap()
-	labels := t.Owner.DirectVolumeMigrationLabels()
+	labels := t.Owner.GetCorrelationLabels()
 	for ns, vols := range pvcMap {
 		for _, vol := range vols {
 			dvmp := migapi.DirectVolumeMigrationProgress{

--- a/pkg/controller/migmigration/directimagemigration.go
+++ b/pkg/controller/migmigration/directimagemigration.go
@@ -120,24 +120,10 @@ func (t *Task) deleteDirectImageMigrationResources() error {
 		return liberr.Wrap(err)
 	}
 
-	if dim != nil {
-		// fetch the corresponding DISM instance
-		dism, err := t.getDirectImageStreamMigrationForDIM(dim)
-		if err != nil {
-			return liberr.Wrap(err)
-		}
-
-		// delete the DISM instance
-		err = t.Client.Delete(context.TODO(), dism)
-		if err != nil {
-			return liberr.Wrap(err)
-		}
-
-		// delete the DIM instance from destination cluster
-		err = t.Client.Delete(context.TODO(), dim)
-		if err != nil {
-			return liberr.Wrap(err)
-		}
+	// delete the DIM instance
+	err = t.Client.Delete(context.TODO(), dim)
+	if err != nil {
+		return liberr.Wrap(err)
 	}
 
 	return nil

--- a/pkg/controller/migmigration/directimagemigration.go
+++ b/pkg/controller/migmigration/directimagemigration.go
@@ -57,7 +57,11 @@ func (t *Task) getDirectImageStreamMigrationForDIM(dim *migapi.DirectImageMigrat
 		return nil, liberr.Wrap(err)
 	}
 
-	return &dismList.Items[0], nil
+	if len(dismList.Items) > 0 {
+		return &dismList.Items[0], nil
+	}
+
+	return nil, nil
 }
 
 func (t *Task) createDirectImageMigration() error {

--- a/pkg/controller/migmigration/directimagemigration.go
+++ b/pkg/controller/migmigration/directimagemigration.go
@@ -40,7 +40,6 @@ func (t *Task) getDirectImageMigration() (*migapi.DirectImageMigration, error) {
 	return nil, nil
 }
 
-
 func (t *Task) createDirectImageMigration() error {
 	dim, err := t.getDirectImageMigration()
 	if err != nil {
@@ -97,10 +96,12 @@ func (t *Task) deleteDirectImageMigrationResources() error {
 		return liberr.Wrap(err)
 	}
 
-	// delete the DIM instance
-	err = t.Client.Delete(context.TODO(), dim)
-	if err != nil {
-		return liberr.Wrap(err)
+	if dim != nil {
+		// delete the DIM instance
+		err = t.Client.Delete(context.TODO(), dim)
+		if err != nil {
+			return liberr.Wrap(err)
+		}
 	}
 
 	return nil

--- a/pkg/controller/migmigration/directimagemigration.go
+++ b/pkg/controller/migmigration/directimagemigration.go
@@ -19,8 +19,6 @@ package migmigration
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/labels"
-
 	liberr "github.com/konveyor/controller/pkg/error"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,27 +40,6 @@ func (t *Task) getDirectImageMigration() (*migapi.DirectImageMigration, error) {
 	return nil, nil
 }
 
-func (t *Task) getDirectImageStreamMigrationForDIM(dim *migapi.DirectImageMigration) (*migapi.DirectImageStreamMigration, error) {
-
-	dimLabels := dim.GetCorrelationLabels()
-	selector := labels.SelectorFromSet(dimLabels)
-	dismList := migapi.DirectImageStreamMigrationList{}
-	err := t.Client.List(context.TODO(),
-		&k8sclient.ListOptions{
-			LabelSelector: selector,
-		},
-		&dismList)
-
-	if err != nil {
-		return nil, liberr.Wrap(err)
-	}
-
-	if len(dismList.Items) > 0 {
-		return &dismList.Items[0], nil
-	}
-
-	return nil, nil
-}
 
 func (t *Task) createDirectImageMigration() error {
 	dim, err := t.getDirectImageMigration()

--- a/pkg/controller/migmigration/dvm.go
+++ b/pkg/controller/migmigration/dvm.go
@@ -95,7 +95,11 @@ func (t *Task) getDirectVolumeMigrationProgressForDVM(dvm *migapi.DirectVolumeMi
 		return nil, liberr.Wrap(err)
 	}
 
-	return &dvmpList.Items[0], nil
+	if len(dvmpList.Items) > 0 {
+		return &dvmpList.Items[0], nil
+	}
+
+	return nil, nil
 }
 
 // Check if the DVM has completed.

--- a/pkg/controller/migmigration/dvm.go
+++ b/pkg/controller/migmigration/dvm.go
@@ -79,7 +79,6 @@ func (t *Task) getDirectVolumeMigration() (*migapi.DirectVolumeMigration, error)
 	return nil, nil
 }
 
-
 // Check if the DVM has completed.
 // Returns if it has completed, why it failed, and it's progress results
 func (t *Task) hasDirectVolumeMigrationCompleted(dvm *migapi.DirectVolumeMigration) (completed bool, failureReasons, progress []string) {
@@ -208,10 +207,12 @@ func (t *Task) deleteDirectVolumeMigrationResources() error {
 		return liberr.Wrap(err)
 	}
 
-	// delete the DVM instance
-	err = t.Client.Delete(context.TODO(), dvm)
-	if err != nil {
-		return liberr.Wrap(err)
+	if dvm != nil {
+		// delete the DVM instance
+		err = t.Client.Delete(context.TODO(), dvm)
+		if err != nil {
+			return liberr.Wrap(err)
+		}
 	}
 
 	return nil

--- a/pkg/controller/migmigration/dvm.go
+++ b/pkg/controller/migmigration/dvm.go
@@ -13,7 +13,6 @@ import (
 	dvmc "github.com/konveyor/mig-controller/pkg/controller/directvolumemigration"
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -80,27 +79,6 @@ func (t *Task) getDirectVolumeMigration() (*migapi.DirectVolumeMigration, error)
 	return nil, nil
 }
 
-func (t *Task) getDirectVolumeMigrationProgressForDVM(dvm *migapi.DirectVolumeMigration) (*migapi.DirectVolumeMigrationProgress, error) {
-
-	dvmLabels := dvm.GetCorrelationLabels()
-	selector := labels.SelectorFromSet(dvmLabels)
-	dvmpList := migapi.DirectVolumeMigrationProgressList{}
-	err := t.Client.List(context.TODO(),
-		&k8sclient.ListOptions{
-			LabelSelector: selector,
-		},
-		&dvmpList)
-
-	if err != nil {
-		return nil, liberr.Wrap(err)
-	}
-
-	if len(dvmpList.Items) > 0 {
-		return &dvmpList.Items[0], nil
-	}
-
-	return nil, nil
-}
 
 // Check if the DVM has completed.
 // Returns if it has completed, why it failed, and it's progress results

--- a/pkg/controller/migmigration/dvm.go
+++ b/pkg/controller/migmigration/dvm.go
@@ -230,24 +230,10 @@ func (t *Task) deleteDirectVolumeMigrationResources() error {
 		return liberr.Wrap(err)
 	}
 
-	if dvm != nil {
-		// fetch the corresponding DVMP instance
-		dvmp, err := t.getDirectVolumeMigrationProgressForDVM(dvm)
-		if err != nil {
-			return liberr.Wrap(err)
-		}
-
-		// delete the DVMP instance
-		err = t.Client.Delete(context.TODO(), dvmp)
-		if err != nil {
-			return liberr.Wrap(err)
-		}
-
-		// delete the DVM instance from destination cluster
-		err = t.Client.Delete(context.TODO(), dvm)
-		if err != nil {
-			return liberr.Wrap(err)
-		}
+	// delete the DVM instance
+	err = t.Client.Delete(context.TODO(), dvm)
+	if err != nil {
+		return liberr.Wrap(err)
 	}
 
 	return nil


### PR DESCRIPTION
This PR does the following:
- Adds two new phases in `Cancel` Itinerary - `DeleteDirectVolumeMigrationResources` and `DeleteDirectImageMigrationResources`.
- The phase `DeleteDirectVolumeMigrationResources` fetches DVM and DVMP for a particular migration and deletes it.
- The phase `DeleteDirectImageMigrationResources` fetches DIM and DISM for a particular migration and deletes it.
- These two phases are only invoked when the `Cancel` operation is performed for a Direct Migration.
- Fixes https://github.com/konveyor/mig-controller/issues/865.
- Also, adds correlation labels on DVMP.