### PR TITLE
Bug 1908270 - Change DVM route name to 3 characters

### DIFF
--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -51,7 +51,7 @@ const (
 	DirectVolumeMigrationRsyncConfig        = "directvolumemigration-rsync-config"
 	DirectVolumeMigrationRsyncCreds         = "directvolumemigration-rsync-creds"
 	DirectVolumeMigrationRsyncTransferSvc   = "directvolumemigration-rsync-transfer-svc"
-	DirectVolumeMigrationRsyncTransferRoute = "directvolumemigration-rsync-transfer-route"
+	DirectVolumeMigrationRsyncTransferRoute = "dvm"
 	DirectVolumeMigrationStunnelConfig      = "directvolumemigration-stunnel-config"
 	DirectVolumeMigrationStunnelCerts       = "directvolumemigration-stunnel-certs"
 	DirectVolumeMigrationRsyncPass          = "directvolumemigration-rsync-pass"


### PR DESCRIPTION
This is to unblock QE. There will be a follow up PR to allow a user to manually set the subdomain value in the operator config and to add validation for any namespaces 59 chars+.