### PR TITLE
Revert "Update DVM PVC check to include determination whether PVCs ar…

### DIFF
--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -112,12 +112,12 @@ var VolumeMigration = Itinerary{
 		{phase: CreateDestinationNamespaces},
 		{phase: DestinationNamespacesCreated},
 		{phase: CreateDestinationPVCs},
+		{phase: DestinationPVCsCreated},
 		{phase: CreateRsyncRoute},
 		{phase: CreateRsyncConfig},
 		{phase: CreateStunnelConfig},
 		{phase: CreatePVProgressCRs},
 		{phase: CreateRsyncTransferPods},
-		{phase: DestinationPVCsCreated},
 		{phase: WaitForRsyncTransferPodsRunning},
 		{phase: CreateStunnelClientPods},
 		{phase: WaitForStunnelClientPodsRunning},
@@ -241,15 +241,13 @@ func (t *Task) Run() error {
 		}
 	case DestinationPVCsCreated:
 		// Get the PVCs on the destination and confirm they are bound
-		next, err := t.areDestinationPVCsBound()
+		err := t.getDestinationPVCs()
 		if err != nil {
 			return liberr.Wrap(err)
 		}
-		if next {
-			t.Requeue = NoReQ
-			if err = t.next(); err != nil {
-				return liberr.Wrap(err)
-			}
+		t.Requeue = NoReQ
+		if err = t.next(); err != nil {
+			return liberr.Wrap(err)
 		}
 	case CreateRsyncRoute:
 		err := t.createRsyncTransferRoute()

--- a/pkg/controller/directvolumemigration/validation.go
+++ b/pkg/controller/directvolumemigration/validation.go
@@ -13,21 +13,19 @@ import (
 
 // Types
 const (
-	InvalidSourceClusterRef         = "InvalidSourceClusterRef"
-	InvalidDestinationClusterRef    = "InvalidDestinationClusterRef"
-	InvalidSourceCluster            = "InvalidSourceCluster"
-	InvalidDestinationCluster       = "InvalidDestinationCluster"
-	InvalidPVCs                     = "InvalidPVCs"
-	SourceClusterNotReady           = "SourceClusterNotReady"
-	DestinationClusterNotReady      = "DestinationClusterNotReady"
-	PVCsNotFoundOnSourceCluster     = "PodsNotFoundOnSourceCluster"
-	StunnelClientPodsPending        = "StunnelClientPodsPending"
-	RsyncTransferPodsPending        = "RsyncTransferPodsPending"
-	Running                         = "Running"
-	PVCNotBoundOnDestinationCluster = "PVCNotBoundOnDestinationCluster"
-	PVCNotFoundOnDestinationCluster = "PVCNotFoundOnDestinationCluster"
-	Failed                          = "Failed"
-	Succeeded                       = "Succeeded"
+	InvalidSourceClusterRef      = "InvalidSourceClusterRef"
+	InvalidDestinationClusterRef = "InvalidDestinationClusterRef"
+	InvalidSourceCluster         = "InvalidSourceCluster"
+	InvalidDestinationCluster    = "InvalidDestinationCluster"
+	InvalidPVCs                  = "InvalidPVCs"
+	SourceClusterNotReady        = "SourceClusterNotReady"
+	DestinationClusterNotReady   = "DestinationClusterNotReady"
+	PVCsNotFoundOnSourceCluster  = "PodsNotFoundOnSourceCluster"
+	StunnelClientPodsPending     = "StunnelClientPodsPending"
+	RsyncTransferPodsPending     = "RsyncTransferPodsPending"
+	Running                      = "Running"
+	Failed                       = "Failed"
+	Succeeded                    = "Succeeded"
 )
 
 // Reasons


### PR DESCRIPTION
…e bound and usable (#852)"

This reverts commit 8b5de2ef

The original PR assumes that we add migration labels to pvc. There are two problems with it:

1. PVC's could be pre-created in customer env and not having the labels, migration will be stuck if that is the case
2. It is not right to add labels like `app: xxx`, `owner: yyy` to pvc, they might have their own labels with same key that can conflict

Given the above, we should revert the change and fix it cleanly post 1.4.0