### PR TITLE
Add rsync route timeout setting for dvm

### DIFF
--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -304,7 +304,9 @@ func (t *Task) createRsyncTransferRoute() error {
 	pvcMap := t.getPVCNamespaceMap()
 	dvmLabels := t.buildDVMLabels()
 	dvmLabels["purpose"] = DirectVolumeMigrationRsync
-
+	rsyncRouteAnnotations := make(map[string]string)
+	routeTimeout := fmt.Sprintf("%ss", strconv.Itoa(migsettings.Settings.DvmOpts.RsyncTransferRouteTimeout))
+	rsyncRouteAnnotations[RsyncTransferRouteTimeout] = routeTimeout
 	for ns, _ := range pvcMap {
 		svc := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -340,6 +342,7 @@ func (t *Task) createRsyncTransferRoute() error {
 				Labels: map[string]string{
 					"app": DirectVolumeMigrationRsyncTransfer,
 				},
+				Annotations: rsyncRouteAnnotations,
 			},
 			Spec: routev1.RouteSpec{
 				To: routev1.RouteTargetReference{

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -63,7 +63,11 @@ const (
 	DirectVolumeMigrationStunnel            = "stunnel"
 	MigratedByPlanLabel                     = "migration.openshift.io/migrated-by-migplan"      // (migplan UID)
 	MigratedByMigrationLabel                = "migration.openshift.io/migrated-by-migmigration" // (migmigration UID)
+)
 
+// annotations
+const (
+	RsyncTransferRouteTimeout = "haproxy.router.openshift.io/timeout"
 )
 
 // Flags

--- a/pkg/settings/dvm.go
+++ b/pkg/settings/dvm.go
@@ -7,13 +7,14 @@ import (
 
 // Rsync options
 const (
-	RsyncOptBwLimit   = "RSYNC_OPT_BWLIMIT"
-	RsyncOptPartial   = "RSYNC_OPT_PARTIAL"
-	RsyncOptArchive   = "RSYNC_OPT_ARCHIVE"
-	RsyncOptDelete    = "RSYNC_OPT_DELETE"
-	RsyncOptHardLinks = "RSYNC_OPT_HARDLINKS"
-	RsyncOptInfo      = "RSYNC_OPT_INFO"
-	RsyncOptExtras    = "RSYNC_OPT_EXTRAS"
+	RsyncOptBwLimit           = "RSYNC_OPT_BWLIMIT"
+	RsyncOptPartial           = "RSYNC_OPT_PARTIAL"
+	RsyncOptArchive           = "RSYNC_OPT_ARCHIVE"
+	RsyncOptDelete            = "RSYNC_OPT_DELETE"
+	RsyncOptHardLinks         = "RSYNC_OPT_HARDLINKS"
+	RsyncOptInfo              = "RSYNC_OPT_INFO"
+	RsyncOptExtras            = "RSYNC_OPT_EXTRAS"
+	RsyncTransferRouteTimeout = "RSYNC_TRANSFER_ROUTE_TIMEOUT"
 )
 
 // RsyncOpts Rsync Options
@@ -22,6 +23,7 @@ const (
 //	Partial: whether to set --partial option or not
 //	Delete:  whether to set --delete option or not
 //	HardLinks: whether to set --hard-links option or not
+//	Info: equivalent to --info=<string> option
 //	Extras: arbitrary rsync options provided by the user
 type RsyncOpts struct {
 	BwLimit   int
@@ -31,6 +33,11 @@ type RsyncOpts struct {
 	HardLinks bool
 	Info      string
 	Extras    []string
+}
+
+// DvmOpts DVM global options
+type DvmOpts struct {
+	RsyncTransferRouteTimeout int
 }
 
 // Load load rsync options
@@ -51,6 +58,16 @@ func (r *RsyncOpts) Load() error {
 	rsyncExtraOpts := os.Getenv(RsyncOptExtras)
 	if len(rsyncExtraOpts) > 0 {
 		r.Extras = strings.Fields(rsyncExtraOpts)
+	}
+	return err
+}
+
+// Load load dvm options
+func (d *DvmOpts) Load() error {
+	var err error
+	d.RsyncTransferRouteTimeout, err = getEnvLimit(RsyncTransferRouteTimeout, 30)
+	if err != nil {
+		return err
 	}
 	return err
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -34,6 +34,7 @@ type _Settings struct {
 	Discovery
 	Plan
 	RsyncOpts
+	DvmOpts
 	Roles     map[string]bool
 	ProxyVars map[string]string
 }
@@ -49,6 +50,10 @@ func (r *_Settings) Load() error {
 		return err
 	}
 	err = r.RsyncOpts.Load()
+	if err != nil {
+		return err
+	}
+	err = r.DvmOpts.Load()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #900 

This PR introduces a new environment variable `RSYNC_TRANSFER_ROUTE_TIMEOUT` to specify HAProxy timeout annotation value on Route created for Rsync transfer. 

Operator PR https://github.com/konveyor/mig-operator/pull/556