### PR TITLE
Adding github actions for automation for BZ automation

### DIFF
--- a/.github/workflows/bz-pr-action.yml
+++ b/.github/workflows/bz-pr-action.yml
@@ -1,0 +1,38 @@
+# This is a basic workflow to help you get started with Actions
+
+name: BZ PR Creation
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  pull_request:
+    branches:
+    - "*"
+    types:  
+    - opened
+    - edited
+    - reopened
+    - synchronize
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  bz-on-pr-create:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: docker://quay.io/konveyor/pr-bz-github-action 
+        name: update bugzilla with posted pr
+        with:
+          bugzilla_token: ${{ secrets.BUGZILLA_TOKEN }}
+          org_repo: ${{ github.repository }}
+          pr_number: ${{ github.event.pull_request.number }}
+          bz_product: "Migration Toolkit for Containers"
+          title: ${{ github.event.pull_request.title }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -1,0 +1,37 @@
+# This is a basic workflow to help you get started with Actions
+
+name: BZ Merge
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  pull_request:
+    branches:
+    - "*"
+    types:
+    - closed
+    
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in pnamearallel
+jobs:
+  # This workflow contains a single job called "build"
+  bq-on-pr-merge:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: docker://quay.io/konveyor/pr-merge-github-action
+        name: update bugzilla to modified
+        with:
+          bugzilla_token: ${{ secrets.BUGZILLA_TOKEN }}
+          org_repo: ${{ github.repository }}
+          pr_number: ${{ github.event.pull_request.number }}
+          bz_product: "Migration Toolkit for Containers"
+          title: ${{ github.event.pull_request.title }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch_to_release: "release-1.3.2:1.3.z,release-1.4.0:1.4.0,master:1.5.0"
+          base_branch: ${{ github.base_ref }}


### PR DESCRIPTION
* Adding BZ automation for when a PR is created for a BZ, it will be attached to the BZ
* Verifies that the BZ is in the valid state to be work (one of "New, "Assigned", "Post")
* Will alert the user with comments on the PR to tell them if the association was successful
* Adding BZ automation for when a PR is merged.
* Maps branch to target releases to determine if the fix is for the bug or not.
  * example merging bz fix into master then cherry picking will only mark bz modified on the cherry-pick
  * Will handle if more then 1 PR is attached that is open, it will not mark the BZ as modified until all PR's are closed that are attached


TODO: Before this merges need to create a BZ robot account