### PR TITLE
Bug 1918789: Use Unwrap for api errors that were being checked away from point of creation

### DIFF
--- a/pkg/controller/directimagemigration/migrate.go
+++ b/pkg/controller/directimagemigration/migrate.go
@@ -18,6 +18,7 @@ package directimagemigration
 
 import (
 	"fmt"
+	"github.com/konveyor/mig-controller/pkg/errorutil"
 	"time"
 
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
@@ -40,7 +41,7 @@ func (r *ReconcileDirectImageMigration) migrate(imageMigration *migapi.DirectIma
 	}
 	err := task.Run()
 	if err != nil {
-		if errors.IsConflict(err) {
+		if errors.IsConflict(errorutil.Unwrap(err)) {
 			return FastReQ, nil
 		}
 		log.Trace(err)

--- a/pkg/controller/directimagestreammigration/migrate.go
+++ b/pkg/controller/directimagestreammigration/migrate.go
@@ -18,6 +18,7 @@ package directimagestreammigration
 
 import (
 	"fmt"
+	"github.com/konveyor/mig-controller/pkg/errorutil"
 	"time"
 
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
@@ -40,7 +41,7 @@ func (r *ReconcileDirectImageStreamMigration) migrate(imageStreamMigration *miga
 	}
 	err := task.Run()
 	if err != nil {
-		if errors.IsConflict(err) {
+		if errors.IsConflict(errorutil.Unwrap(err)) {
 			return FastReQ, nil
 		}
 		log.Trace(err)

--- a/pkg/controller/directvolumemigration/migrate.go
+++ b/pkg/controller/directvolumemigration/migrate.go
@@ -3,6 +3,7 @@ package directvolumemigration
 import (
 	"fmt"
 	liberr "github.com/konveyor/controller/pkg/error"
+	"github.com/konveyor/mig-controller/pkg/errorutil"
 	"time"
 
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
@@ -34,7 +35,7 @@ func (r *ReconcileDirectVolumeMigration) migrate(direct *migapi.DirectVolumeMigr
 	}
 	err = task.Run()
 	if err != nil {
-		if errors.IsConflict(err) {
+		if errors.IsConflict(errorutil.Unwrap(err)) {
 			return FastReQ, nil
 		}
 		log.Trace(err)

--- a/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller.go
+++ b/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller.go
@@ -19,6 +19,7 @@ package directvolumemigrationprogress
 import (
 	"context"
 	"fmt"
+	"github.com/konveyor/mig-controller/pkg/errorutil"
 	"io"
 	"k8s.io/client-go/kubernetes"
 	"path"
@@ -125,7 +126,7 @@ func (r *ReconcileDirectVolumeMigrationProgress) Reconcile(request reconcile.Req
 
 	// Report reconcile error.
 	defer func() {
-		if err == nil || errors.IsConflict(err) {
+		if err == nil || errors.IsConflict(errorutil.Unwrap(err)) {
 			return
 		}
 		pvProgress.Status.SetReconcileFailed(err)

--- a/pkg/controller/miganalytic/miganalytics_controller.go
+++ b/pkg/controller/miganalytic/miganalytics_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/konveyor/mig-controller/pkg/errorutil"
 	"strconv"
 	"strings"
 	"time"
@@ -129,7 +130,7 @@ func (r *ReconcileMigAnalytic) Reconcile(request reconcile.Request) (reconcile.R
 	defer func() {
 		log.Info("CR", "conditions", analytic.Status.Conditions)
 		analytic.Status.Conditions.RecordEvents(analytic, r.EventRecorder)
-		if err == nil || errors.IsConflict(err) {
+		if err == nil || errors.IsConflict(errorutil.Unwrap(err)) {
 			return
 		}
 		analytic.Status.SetReconcileFailed(err)

--- a/pkg/controller/migcluster/migcluster_controller.go
+++ b/pkg/controller/migcluster/migcluster_controller.go
@@ -18,6 +18,7 @@ package migcluster
 
 import (
 	"context"
+	"github.com/konveyor/mig-controller/pkg/errorutil"
 	"time"
 
 	"github.com/konveyor/controller/pkg/logging"
@@ -123,7 +124,7 @@ func (r *ReconcileMigCluster) Reconcile(request reconcile.Request) (reconcile.Re
 	defer func() {
 		log.Info("CR", "conditions", cluster.Status.Conditions)
 		cluster.Status.Conditions.RecordEvents(cluster, r.EventRecorder)
-		if err == nil || errors.IsConflict(err) {
+		if err == nil || errors.IsConflict(errorutil.Unwrap(err)) {
 			return
 		}
 		cluster.Status.SetReconcileFailed(err)

--- a/pkg/controller/mighook/mighook_controller.go
+++ b/pkg/controller/mighook/mighook_controller.go
@@ -18,6 +18,7 @@ package mighook
 
 import (
 	"context"
+	"github.com/konveyor/mig-controller/pkg/errorutil"
 
 	"github.com/konveyor/controller/pkg/logging"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
@@ -95,7 +96,7 @@ func (r *ReconcileMigHook) Reconcile(request reconcile.Request) (reconcile.Resul
 	defer func() {
 		log.Info("CR", "conditions", hook.Status.Conditions)
 		hook.Status.Conditions.RecordEvents(hook, r.EventRecorder)
-		if err == nil || errors.IsConflict(err) {
+		if err == nil || errors.IsConflict(errorutil.Unwrap(err)) {
 			return
 		}
 		hook.Status.SetReconcileFailed(err)

--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -19,6 +19,7 @@ package migmigration
 import (
 	"context"
 	"fmt"
+	"github.com/konveyor/mig-controller/pkg/errorutil"
 	"time"
 
 	liberr "github.com/konveyor/controller/pkg/error"
@@ -170,7 +171,7 @@ func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.
 	defer func() {
 		log.Info("CR", "conditions", migration.Status.Conditions)
 		migration.Status.Conditions.RecordEvents(migration, r.EventRecorder)
-		if err == nil || errors.IsConflict(err) {
+		if err == nil || errors.IsConflict(errorutil.Unwrap(err)) {
 			return
 		}
 		migration.Status.SetReconcileFailed(err)

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -18,6 +18,7 @@ package migmigration
 
 import (
 	"fmt"
+	"github.com/konveyor/mig-controller/pkg/errorutil"
 	"time"
 
 	mapset "github.com/deckarep/golang-set"
@@ -63,7 +64,7 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (time.Du
 	}
 	err = task.Run()
 	if err != nil {
-		if errors.IsConflict(err) {
+		if errors.IsConflict(errorutil.Unwrap(err)) {
 			return FastReQ, nil
 		}
 		log.Trace(err)

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -18,6 +18,7 @@ package migplan
 
 import (
 	"context"
+	"github.com/konveyor/mig-controller/pkg/errorutil"
 	"sort"
 	"strconv"
 	"time"
@@ -184,7 +185,7 @@ func (r *ReconcileMigPlan) Reconcile(request reconcile.Request) (reconcile.Resul
 	defer func() {
 		log.Info("CR", "conditions", plan.Status.Conditions)
 		plan.Status.Conditions.RecordEvents(plan, r.EventRecorder)
-		if err == nil || errors.IsConflict(err) {
+		if err == nil || errors.IsConflict(errorutil.Unwrap(err)) {
 			return
 		}
 		plan.Status.SetReconcileFailed(err)

--- a/pkg/controller/migstorage/migstorage_controller.go
+++ b/pkg/controller/migstorage/migstorage_controller.go
@@ -18,6 +18,7 @@ package migstorage
 
 import (
 	"context"
+	"github.com/konveyor/mig-controller/pkg/errorutil"
 	"time"
 
 	"github.com/konveyor/controller/pkg/logging"
@@ -121,7 +122,7 @@ func (r *ReconcileMigStorage) Reconcile(request reconcile.Request) (reconcile.Re
 	defer func() {
 		log.Info("CR", "conditions", storage.Status.Conditions)
 		storage.Status.Conditions.RecordEvents(storage, r.EventRecorder)
-		if err == nil || errors.IsConflict(err) {
+		if err == nil || errors.IsConflict(errorutil.Unwrap(err)) {
 			return
 		}
 		storage.Status.SetReconcileFailed(err)

--- a/pkg/errorutil/unwrap.go
+++ b/pkg/errorutil/unwrap.go
@@ -1,0 +1,10 @@
+package errorutil
+
+import "errors"
+
+func Unwrap(err error) error {
+	if err1 := errors.Unwrap(err); err1 != nil {
+		return err1
+	}
+	return err
+}

--- a/pkg/errorutil/unwrap_test.go
+++ b/pkg/errorutil/unwrap_test.go
@@ -1,0 +1,37 @@
+package errorutil
+
+import (
+	"fmt"
+	"testing"
+
+	liberr "github.com/konveyor/controller/pkg/error"
+)
+
+func TestUnwrap(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "test when Unwrap is implemented",
+			args:    args{err: liberr.Wrap(fmt.Errorf("wrap is implemented"))},
+			wantErr: true,
+		},
+		{
+			name:    "test when Unwrap is not implemented",
+			args:    args{err: fmt.Errorf("wrap is not implemented")},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := Unwrap(tt.args.err); (err != nil) != tt.wantErr {
+				t.Errorf("Unwrap() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…creation (#902)

* add error util

* use errorutil instead of standard errors lib

(cherry picked from commit 235e2849ef4ac04698dc49e094bb3d3bae7c9526)