### PR TITLE
Add spec descriptions for MigStorage, MigMigration and MigHook CRDs

### DIFF
--- a/config/crds/migration.openshift.io_mighooks.yaml
+++ b/config/crds/migration.openshift.io_mighooks.yaml
@@ -45,20 +45,27 @@ spec:
           type: string
         metadata:
           type: object
+          preserveUnknownFields: false
         spec:
           description: MigHookSpec defines the desired state of MigHook
           properties:
             activeDeadlineSeconds:
               format: int64
               type: integer
+              description: activeDeadlineSeconds is used to specify the highest amount of time for which the hook will run
             custom:
               type: boolean
+              description: custom implies whether the hook is a custom Ansible playbook or a pre-built image
             image:
               type: string
+              description: image is used to specify the image of the hook to be executed
             playbook:
               type: string
+              description: playbook is used to specify the contents of the custom Ansible playbook in base64 format, it
+                is used in conjunction with the custom boolean flag
             targetCluster:
               type: string
+              description: targetCluster is used to specify the cluster on which the hook is to be executed
           required:
           - custom
           - image

--- a/config/crds/migration.openshift.io_migmigrations.yaml
+++ b/config/crds/migration.openshift.io_migmigrations.yaml
@@ -56,11 +56,16 @@ spec:
           type: object
         spec:
           description: MigMigrationSpec defines the desired state of MigMigration
+          preserveUnknownFields: false
           properties:
             canceled:
               type: boolean
+              description: canceled is used to invoke the cancel migration operation, when set to true the migration controller
+                switches to cancel itinerary
             keepAnnotations:
               type: boolean
+              description: keepAnnotations is used to specify whether to retain the annotations set by the migration
+                controller or not
             migPlanRef:
               description: ObjectReference contains enough information to let you
                 inspect or modify the referred object.
@@ -100,12 +105,18 @@ spec:
               type: object
             quiescePods:
               type: boolean
+              description: quiescePods is used to specify whether to quiesce the application pods before migration or not
             rollback:
               type: boolean
+              description: rollback is used to invoke the rollback migration operation, when set to true the migration
+                controller switches to rollback itinerary
             stage:
               type: boolean
+              description: stage is used to invoke the stage operation, when set to true the migration controller
+                switches to stage itinerary
             verify:
               type: boolean
+              description: verify is used to specify whether to verify the health of the migrated pods or not
           required:
           - stage
           type: object

--- a/config/crds/migration.openshift.io_migstorages.yaml
+++ b/config/crds/migration.openshift.io_migstorages.yaml
@@ -47,6 +47,7 @@ spec:
           type: object
         spec:
           description: MigStorageSpec defines the desired state of MigStorage
+          preserveUnknownFields: false
           properties:
             backupStorageConfig:
               description: BackupStorageConfig defines config for creating and storing
@@ -54,24 +55,40 @@ spec:
               properties:
                 awsBucketName:
                   type: string
+                  description: awsBucketName is the name of the AWS S3 object storage bucket
                 awsKmsKeyId:
                   type: string
+                  description: awsKmsKeyId is ued to enable encryption of the backups stored in S3 object storage
                 awsPublicUrl:
                   type: string
+                  description: awsPublicUrl is used instead of awsS3Url if specified, this field is primarily for
+                    local storage services like MinIO
                 awsRegion:
                   type: string
+                  description: awsRegion is the AWS region where the S3 bucket is located, it is queried from AWS S3
+                    API if not provided
                 awsS3ForcePathStyle:
                   type: boolean
+                  description: awsS3ForcePathStyle is used to indicate whether to use path-style addressing instead of
+                    virtual hosted bucket addressing, set to true if using local storage service loke MinIO
                 awsS3Url:
                   type: string
+                  description: awsS3Url is used to specify the AWS S3 URL for explicitness, this field is primarily used
+                    for local storage services like MinIO
                 awsSignatureVersion:
                   type: string
+                  description: awsSignatureVersion is used to specify the version of the signature algorithm used to
+                    create signed URLs that are used by velero CLI to download backups or fetch logs
                 azureResourceGroup:
                   type: string
+                  description: azureResourceGroup is the name of the resource group containing the storage account for
+                    the backup storage location
                 azureStorageAccount:
                   type: string
+                  description: azureStorageAccount is the name of the storage account for the backup storage location
                 azureStorageContainer:
                   type: string
+                  description: azureStorageContainer is the bucket to be used for the backup storage location
                 credsSecretRef:
                   description: ObjectReference contains enough information to let
                     you inspect or modify the referred object.
@@ -111,25 +128,39 @@ spec:
                   type: object
                 gcpBucket:
                   type: string
+                  description: gcpBucket is the name of the bucket used for the backup storage location
                 insecure:
                   type: boolean
+                  description: insecure is set to true if you do not want the TLS certificate when connecting to the
+                    object store -- like for self-signed certs with MinIO. This is susceptible to man-in-the-middle
+                    attacks and is not recommended for production
                 s3CustomCABundle:
                   format: byte
                   type: string
+                  description: s3CustomCABundle is used to specify the self-signed ca certs
               type: object
             backupStorageProvider:
               type: string
+              description: backupStorageProvider is the provider name whose object storage is used for backup
+                storage location
             refresh:
               type: boolean
+              description: refresh flag is used to trigger a reconcile for the MigStorage CRD
             volumeSnapshotConfig:
               description: VolumeSnapshotConfig defines config for taking Volume Snapshots
               properties:
                 awsRegion:
                   type: string
+                  description: awsRegion is the AWS region where the S3 bucket is located, it is queried from AWS S3
+                    API if not provided
                 azureApiTimeout:
                   type: string
+                  description: azureApiTimeout is ued to specify how long to wait for an Azure API request to
+                    complete before timeout
                 azureResourceGroup:
                   type: string
+                  description: azureResourceGroup is the name of the resource group containing the storage account for
+                    the backup storage location
                 credsSecretRef:
                   description: ObjectReference contains enough information to let
                     you inspect or modify the referred object.
@@ -172,6 +203,8 @@ spec:
               type: object
             volumeSnapshotProvider:
               type: string
+              description: volumeSnapshotProvider is the provider name whose object storage is used for backup
+                storage location
           required:
           - backupStorageConfig
           - backupStorageProvider


### PR DESCRIPTION
This PR does the following:
- Adds `spec` descriptions for CRDs - MigStorage, MigMigration and MigHook
- Sets `preserveUnownFields` flag to `false`
- These changes facilitate the working of `oc explain` command for CRD spec fields