### PR TITLE
Bug 1919366: Using non-root rsyncd conf for direct volume migration

### DIFF
--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -80,8 +80,8 @@ data:
     [{{ $pvc.Name }}]
         comment = archive for {{ $pvc.Name }}
         path = /mnt/{{ $.Namespace }}/{{ $pvc.Name }}
-        uid = root
-        gid = root
+        use chroot = no
+        fake super = yes
         list = yes
         hosts allow = ::1, 127.0.0.1, localhost
         auth users = {{ $.SshUser }}


### PR DESCRIPTION
* Fixing a inefficent call for image streams and pvcs that was causing slowdown
* using fake super user to perserve file attributes
* using no chroot to prevent chroot to mount which we don't have permissions for