### PR TITLE
Adding comments for each resource spec fields

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -99,6 +99,8 @@ There are several useful Makefile targets for mig-controller that developers sho
 | `make docker-build` | Build the controller-manager into a container image. Requires support for multi-stage builds. |
 
 ---
+***Note***: controller-runtime version 0.3.0 is desired for development.   
+
 ## Invoking CI on pull requests
 
 You can invoke CI via webhook with an appropriate pull request comment command. CI will run a stateless migration and return results as a comment on the relevant PR where CI was requested.

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ deploy: manifests
 	kustomize build config/default | kubectl apply -f -
 
 # Provide CRDs that work back to k8s 1.11
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
 # Generate manifests e.g. CRD, Webhooks
 manifests:

--- a/config/crds/migration.openshift.io_directimagemigrations.yaml
+++ b/config/crds/migration.openshift.io_directimagemigrations.yaml
@@ -76,8 +76,8 @@ spec:
                   type: string
               type: object
             namespaces:
-              description: A list of all namespaces to run DIM to get all the imagestreams
-                in these namespaces.
+              description: Holds names of all namespaces to run DIM to get all the
+                imagestreams in these namespaces.
               items:
                 type: string
               type: array

--- a/config/crds/migration.openshift.io_directimagemigrations.yaml
+++ b/config/crds/migration.openshift.io_directimagemigrations.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: directimagemigrations.migration.openshift.io
 spec:
@@ -16,6 +16,7 @@ spec:
     shortNames:
     - dim
     singular: directimagemigration
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -75,6 +76,8 @@ spec:
                   type: string
               type: object
             namespaces:
+              description: A list of all namespaces to run DIM to get all the imagestreams
+                in these namespaces.
               items:
                 type: string
               type: array

--- a/config/crds/migration.openshift.io_directimagemigrations.yaml
+++ b/config/crds/migration.openshift.io_directimagemigrations.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: directimagemigrations.migration.openshift.io
 spec:

--- a/config/crds/migration.openshift.io_directimagestreammigrations.yaml
+++ b/config/crds/migration.openshift.io_directimagestreammigrations.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: directimagestreammigrations.migration.openshift.io
 spec:

--- a/config/crds/migration.openshift.io_directimagestreammigrations.yaml
+++ b/config/crds/migration.openshift.io_directimagestreammigrations.yaml
@@ -77,8 +77,8 @@ spec:
                   type: string
               type: object
             destNamespace:
-              description: ' A string holding the name of the namespace on destination
-                cluster where imagestreams should be migrated.'
+              description: ' Holds the name of the namespace on destination cluster
+                where imagestreams should be migrated.'
               type: string
             imageStreamRef:
               description: ObjectReference contains enough information to let you

--- a/config/crds/migration.openshift.io_directimagestreammigrations.yaml
+++ b/config/crds/migration.openshift.io_directimagestreammigrations.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: directimagestreammigrations.migration.openshift.io
 spec:
@@ -16,6 +16,7 @@ spec:
     shortNames:
     - dism
     singular: directimagestreammigration
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -76,6 +77,8 @@ spec:
                   type: string
               type: object
             destNamespace:
+              description: ' A string holding the name of the namespace on destination
+                cluster where imagestreams should be migrated.'
               type: string
             imageStreamRef:
               description: ObjectReference contains enough information to let you

--- a/config/crds/migration.openshift.io_directvolumemigrationprogresses.yaml
+++ b/config/crds/migration.openshift.io_directvolumemigrationprogresses.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: directvolumemigrationprogresses.migration.openshift.io
 spec:
@@ -35,6 +35,7 @@ spec:
     shortNames:
     - dvmp
     singular: directvolumemigrationprogress
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/config/crds/migration.openshift.io_directvolumemigrationprogresses.yaml
+++ b/config/crds/migration.openshift.io_directvolumemigrationprogresses.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: directvolumemigrationprogresses.migration.openshift.io
 spec:

--- a/config/crds/migration.openshift.io_directvolumemigrations.yaml
+++ b/config/crds/migration.openshift.io_directvolumemigrations.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: directvolumemigrations.migration.openshift.io
 spec:

--- a/config/crds/migration.openshift.io_directvolumemigrations.yaml
+++ b/config/crds/migration.openshift.io_directvolumemigrations.yaml
@@ -39,12 +39,11 @@ spec:
           description: DirectVolumeMigrationSpec defines the desired state of DirectVolumeMigration
           properties:
             createDestinationNamespaces:
-              description: A boolean flag that is set True to create namespaces in
-                destination cluster
+              description: Set true to create namespaces in destination cluster
               type: boolean
             deleteProgressReportingCRs:
-              description: A boolean flag to specify if progress reporting CRs needs
-                to be deleted or not
+              description: Specifies if progress reporting CRs needs to be deleted
+                or not
               type: boolean
             destMigClusterRef:
               description: ObjectReference contains enough information to let you
@@ -84,7 +83,7 @@ spec:
                   type: string
               type: object
             persistentVolumeClaims:
-              description: ' A list of all the PVCs that are to be migrated with direct
+              description: ' Holds all the PVCs that are to be migrated with direct
                 volume migration'
               items:
                 properties:

--- a/config/crds/migration.openshift.io_directvolumemigrations.yaml
+++ b/config/crds/migration.openshift.io_directvolumemigrations.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: directvolumemigrations.migration.openshift.io
 spec:
@@ -16,6 +16,7 @@ spec:
     shortNames:
     - dvm
     singular: directvolumemigration
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -38,8 +39,12 @@ spec:
           description: DirectVolumeMigrationSpec defines the desired state of DirectVolumeMigration
           properties:
             createDestinationNamespaces:
+              description: A boolean flag that is set True to create namespaces in
+                destination cluster
               type: boolean
             deleteProgressReportingCRs:
+              description: A boolean flag to specify if progress reporting CRs needs
+                to be deleted or not
               type: boolean
             destMigClusterRef:
               description: ObjectReference contains enough information to let you
@@ -79,6 +84,8 @@ spec:
                   type: string
               type: object
             persistentVolumeClaims:
+              description: ' A list of all the PVCs that are to be migrated with direct
+                volume migration'
               items:
                 properties:
                   apiVersion:
@@ -119,9 +126,12 @@ spec:
                   uid:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
+                  verify:
+                    type: boolean
                 required:
                 - targetAccessModes
                 - targetStorageClass
+                - verify
                 type: object
               type: array
             srcMigClusterRef:

--- a/config/crds/migration.openshift.io_miganalytics.yaml
+++ b/config/crds/migration.openshift.io_miganalytics.yaml
@@ -65,22 +65,22 @@ spec:
           description: MigAnalyticSpec defines the desired state of MigAnalytic
           properties:
             analyzeImageCount:
-              description: A boolean flag to enable analysis of image count. This
-                is a required field.
+              description: Enables analysis of image count, if set true. This is a
+                required field.
               type: boolean
             analyzeK8SResources:
-              description: A boolean flag to enable analysis of k8s resources. This
-                is a required field.
+              description: Enables analysis of k8s resources, if set true. This is
+                a required field.
               type: boolean
             analyzePVCapacity:
-              description: A boolean flag to enable analysis of persistent volume
-                capacity. This is a required field.
+              description: Enables analysis of persistent volume capacity, if set
+                true. This is a required field.
               type: boolean
             listImages:
-              description: A boolean flag to enable used in analysis of image count
+              description: Enable used in analysis of image count, if set true.
               type: boolean
             listImagesLimit:
-              description: An integer representing limit on image counts
+              description: Represents limit on image counts
               type: integer
             migPlanRef:
               description: ObjectReference contains enough information to let you

--- a/config/crds/migration.openshift.io_miganalytics.yaml
+++ b/config/crds/migration.openshift.io_miganalytics.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: miganalytics.migration.openshift.io
 spec:
@@ -42,6 +42,7 @@ spec:
     listKind: MigAnalyticList
     plural: miganalytics
     singular: miganalytic
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:
@@ -64,14 +65,22 @@ spec:
           description: MigAnalyticSpec defines the desired state of MigAnalytic
           properties:
             analyzeImageCount:
+              description: A boolean flag to enable analysis of image count. This
+                is a required field.
               type: boolean
             analyzeK8SResources:
+              description: A boolean flag to enable analysis of k8s resources. This
+                is a required field.
               type: boolean
             analyzePVCapacity:
+              description: A boolean flag to enable analysis of persistent volume
+                capacity. This is a required field.
               type: boolean
             listImages:
+              description: A boolean flag to enable used in analysis of image count
               type: boolean
             listImagesLimit:
+              description: An integer representing limit on image counts
               type: integer
             migPlanRef:
               description: ObjectReference contains enough information to let you

--- a/config/crds/migration.openshift.io_miganalytics.yaml
+++ b/config/crds/migration.openshift.io_miganalytics.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: miganalytics.migration.openshift.io
 spec:

--- a/config/crds/migration.openshift.io_migclusters.yaml
+++ b/config/crds/migration.openshift.io_migclusters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: migclusters.migration.openshift.io
 spec:

--- a/config/crds/migration.openshift.io_migclusters.yaml
+++ b/config/crds/migration.openshift.io_migclusters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: migclusters.migration.openshift.io
 spec:
@@ -27,6 +27,7 @@ spec:
     listKind: MigClusterList
     plural: migclusters
     singular: migcluster
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:
@@ -49,19 +50,32 @@ spec:
           description: MigClusterSpec defines the desired state of MigCluster
           properties:
             azureResourceGroup:
+              description: For azure clusters -- it's the resource group that in-cluster
+                volumes use.
               type: string
             caBundle:
+              description: If the migcluster needs SSL verification for connections
+                a user can supply a custom CA bundle.
               format: byte
               type: string
             exposedRegistryPath:
+              description: Stores the path of registry route when using direct migration.
               type: string
             insecure:
+              description: If set false, user will need to provide CA bundle for TSL
+                connection to the remote cluster.
               type: boolean
             isHostCluster:
+              description: Specifies if the cluster is host (where the controller
+                is installed) or not. This is a required field.
               type: boolean
             refresh:
+              description: If set True, forces the controller to run a full suite
+                of validations on migcluster.
               type: boolean
             restartRestic:
+              description: An override setting to tell the controller that the source
+                cluster restic needs to be restarted after stage pod creation.
               type: boolean
             serviceAccountSecretRef:
               description: ObjectReference contains enough information to let you
@@ -101,6 +115,8 @@ spec:
                   type: string
               type: object
             url:
+              description: Stores the url of the remote cluster. The field is only
+                required for the source cluster object.
               type: string
           required:
           - isHostCluster

--- a/config/crds/migration.openshift.io_migclusters.yaml
+++ b/config/crds/migration.openshift.io_migclusters.yaml
@@ -55,14 +55,15 @@ spec:
               type: string
             caBundle:
               description: If the migcluster needs SSL verification for connections
-                a user can supply a custom CA bundle.
+                a user can supply a custom CA bundle. This field is required only
+                when spec.Insecure is set false
               format: byte
               type: string
             exposedRegistryPath:
               description: Stores the path of registry route when using direct migration.
               type: string
             insecure:
-              description: If set false, user will need to provide CA bundle for TSL
+              description: If set false, user will need to provide CA bundle for TLS
                 connection to the remote cluster.
               type: boolean
             isHostCluster:

--- a/config/crds/migration.openshift.io_mighooks.yaml
+++ b/config/crds/migration.openshift.io_mighooks.yaml
@@ -56,8 +56,7 @@ spec:
               type: integer
             custom:
               description: Specifies whether the hook is a custom Ansible playbook
-                or a pre-built image. The value of this field is required. This is
-                a required field.
+                or a pre-built image. This is a required field.
               type: boolean
             image:
               description: Specifies the image of the hook to be executed. This is

--- a/config/crds/migration.openshift.io_mighooks.yaml
+++ b/config/crds/migration.openshift.io_mighooks.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: mighooks.migration.openshift.io
 spec:
@@ -55,9 +55,9 @@ spec:
               format: int64
               type: integer
             custom:
-              description: Implies whether the hook is a custom Ansible playbook or
-                a pre-built image. The value of this field is required. This is a
-                required field.
+              description: Specifies whether the hook is a custom Ansible playbook
+                or a pre-built image. The value of this field is required. This is
+                a required field.
               type: boolean
             image:
               description: Specifies the image of the hook to be executed. This is

--- a/config/crds/migration.openshift.io_mighooks.yaml
+++ b/config/crds/migration.openshift.io_mighooks.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: mighooks.migration.openshift.io
 spec:
@@ -27,6 +27,7 @@ spec:
     listKind: MigHookList
     plural: mighooks
     singular: mighook
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:
@@ -49,15 +50,26 @@ spec:
           description: MigHookSpec defines the desired state of MigHook
           properties:
             activeDeadlineSeconds:
+              description: Specifies the highest amount of time for which the hook
+                will run.
               format: int64
               type: integer
             custom:
+              description: Implies whether the hook is a custom Ansible playbook or
+                a pre-built image. The value of this field is required. This is a
+                required field.
               type: boolean
             image:
+              description: Specifies the image of the hook to be executed. This is
+                a required field.
               type: string
             playbook:
+              description: Specifies the contents of the custom Ansible playbook in
+                base64 format, it is used in conjunction with the custom boolean flag.
               type: string
             targetCluster:
+              description: Specifies the cluster on which the hook is to be executed.
+                This is a required field.
               type: string
           required:
           - custom

--- a/config/crds/migration.openshift.io_migmigrations.yaml
+++ b/config/crds/migration.openshift.io_migmigrations.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: migmigrations.migration.openshift.io
 spec:
@@ -104,8 +104,8 @@ spec:
                   type: string
               type: object
             quiescePods:
-              description: Specifies whether to quiesce the application pods before
-                migration or not.
+              description: Specifies whether to quiesce the application Pods before
+                migrating Persistent Volume data.
               type: boolean
             rollback:
               description: Invokes the rollback migration operation, when set to true

--- a/config/crds/migration.openshift.io_migmigrations.yaml
+++ b/config/crds/migration.openshift.io_migmigrations.yaml
@@ -60,7 +60,8 @@ spec:
           properties:
             canceled:
               description: Invokes the cancel migration operation, when set to true
-                the migration controller switches to cancel itinerary.
+                the migration controller switches to cancel itinerary. This field
+                can be used on-demand to cancel the running migration.
               type: boolean
             keepAnnotations:
               description: Specifies whether to retain the annotations set by the
@@ -109,7 +110,8 @@ spec:
               type: boolean
             rollback:
               description: Invokes the rollback migration operation, when set to true
-                the migration controller switches to rollback itinerary.
+                the migration controller switches to rollback itinerary. This field
+                needs to be set prior to creation of a MigMigration.
               type: boolean
             stage:
               description: Invokes the stage operation, when set to true the migration

--- a/config/crds/migration.openshift.io_migmigrations.yaml
+++ b/config/crds/migration.openshift.io_migmigrations.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: migmigrations.migration.openshift.io
 spec:
@@ -36,6 +36,7 @@ spec:
     listKind: MigMigrationList
     plural: migmigrations
     singular: migmigration
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:
@@ -58,8 +59,12 @@ spec:
           description: MigMigrationSpec defines the desired state of MigMigration
           properties:
             canceled:
+              description: Invokes the cancel migration operation, when set to true
+                the migration controller switches to cancel itinerary.
               type: boolean
             keepAnnotations:
+              description: Specifies whether to retain the annotations set by the
+                migration controller or not.
               type: boolean
             migPlanRef:
               description: ObjectReference contains enough information to let you
@@ -99,12 +104,20 @@ spec:
                   type: string
               type: object
             quiescePods:
+              description: Specifies whether to quiesce the application pods before
+                migration or not.
               type: boolean
             rollback:
+              description: Invokes the rollback migration operation, when set to true
+                the migration controller switches to rollback itinerary.
               type: boolean
             stage:
+              description: Invokes the stage operation, when set to true the migration
+                controller switches to stage itinerary. This is a required field.
               type: boolean
             verify:
+              description: Specifies whether to verify the health of the migrated
+                pods or not.
               type: boolean
           required:
           - stage

--- a/config/crds/migration.openshift.io_migplans.yaml
+++ b/config/crds/migration.openshift.io_migplans.yaml
@@ -200,8 +200,7 @@ spec:
                   type: string
               type: object
             namespaces:
-              description: ' A list of string of all the namespaces to be included
-                in migration.'
+              description: Holds names of all the namespaces to be included in migration.
               items:
                 type: string
               type: array

--- a/config/crds/migration.openshift.io_migplans.yaml
+++ b/config/crds/migration.openshift.io_migplans.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: migplans.migration.openshift.io
 spec:
@@ -30,6 +30,7 @@ spec:
     listKind: MigPlanList
     plural: migplans
     singular: migplan
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:
@@ -52,6 +53,9 @@ spec:
           description: MigPlanSpec defines the desired state of MigPlan
           properties:
             closed:
+              description: If the migration was successful for a migplan, this value
+                can be set True indicating that after one successful migration no
+                new migrations can be carried out for this migplan.
               type: boolean
             destMigClusterRef:
               description: ObjectReference contains enough information to let you
@@ -91,13 +95,18 @@ spec:
                   type: string
               type: object
             hooks:
+              description: Holds a reference to a MigHook along with the desired phase
+                to run it in.
               items:
                 description: MigPlanHook hold a reference to a MigHook along with
                   the desired phase to run it in
                 properties:
                   executionNamespace:
+                    description: Holds the name of the namespace where hooks should
+                      be implemented.
                     type: string
                   phase:
+                    description: Indicates the phase when the hooks will be executed.
                     type: string
                   reference:
                     description: ObjectReference contains enough information to let
@@ -137,6 +146,8 @@ spec:
                         type: string
                     type: object
                   serviceAccount:
+                    description: Holds the name of the service account to be used
+                      for running hooks.
                     type: string
                 required:
                 - executionNamespace
@@ -146,8 +157,10 @@ spec:
                 type: object
               type: array
             indirectImageMigration:
+              description: If set True, disables direct image migrations.
               type: boolean
             indirectVolumeMigration:
+              description: If set True, disables direct volume migrations.
               type: boolean
             migStorageRef:
               description: ObjectReference contains enough information to let you
@@ -187,6 +200,8 @@ spec:
                   type: string
               type: object
             namespaces:
+              description: ' A list of string of all the namespaces to be included
+                in migration.'
               items:
                 type: string
               type: array
@@ -263,6 +278,8 @@ spec:
                 type: object
               type: array
             refresh:
+              description: If set True, the controller is forces to check if the migplan
+                is in Ready state or not.
               type: boolean
             srcMigClusterRef:
               description: ObjectReference contains enough information to let you

--- a/config/crds/migration.openshift.io_migplans.yaml
+++ b/config/crds/migration.openshift.io_migplans.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: migplans.migration.openshift.io
 spec:

--- a/config/crds/migration.openshift.io_migplans.yaml
+++ b/config/crds/migration.openshift.io_migplans.yaml
@@ -106,7 +106,9 @@ spec:
                       be implemented.
                     type: string
                   phase:
-                    description: Indicates the phase when the hooks will be executed.
+                    description: 'Indicates the phase when the hooks will be executed.
+                      Acceptable values are: PreBackup, PostBackup, PreRestore, and
+                      PostRestore.'
                     type: string
                   reference:
                     description: ObjectReference contains enough information to let
@@ -277,7 +279,7 @@ spec:
                 type: object
               type: array
             refresh:
-              description: If set True, the controller is forces to check if the migplan
+              description: If set True, the controller is forced to check if the migplan
                 is in Ready state or not.
               type: boolean
             srcMigClusterRef:

--- a/config/crds/migration.openshift.io_migstorages.yaml
+++ b/config/crds/migration.openshift.io_migstorages.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: migstorages.migration.openshift.io
 spec:
@@ -27,6 +27,7 @@ spec:
     listKind: MigStorageList
     plural: migstorages
     singular: migstorage
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:
@@ -49,8 +50,8 @@ spec:
           description: MigStorageSpec defines the desired state of MigStorage
           properties:
             backupStorageConfig:
-              description: BackupStorageConfig defines config for creating and storing
-                Backups
+              description: Defines config for creating and storing Backups. This is
+                a required field.
               properties:
                 awsBucketName:
                   type: string
@@ -118,11 +119,15 @@ spec:
                   type: string
               type: object
             backupStorageProvider:
+              description: Holds the provider name whose object storage is used for
+                backup storage location. This is a required field.
               type: string
             refresh:
+              description: A boolean used to trigger a reconcile for the MigStorage
+                CRD.
               type: boolean
             volumeSnapshotConfig:
-              description: VolumeSnapshotConfig defines config for taking Volume Snapshots
+              description: Defines config for taking Volume Snapshots.
               properties:
                 awsRegion:
                   type: string
@@ -171,6 +176,8 @@ spec:
                   type: string
               type: object
             volumeSnapshotProvider:
+              description: Holds the provider name whose object storage is used for
+                backup storage location.
               type: string
           required:
           - backupStorageConfig

--- a/config/crds/migration.openshift.io_migstorages.yaml
+++ b/config/crds/migration.openshift.io_migstorages.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: migstorages.migration.openshift.io
 spec:

--- a/config/crds/migration.openshift.io_migstorages.yaml
+++ b/config/crds/migration.openshift.io_migstorages.yaml
@@ -123,8 +123,7 @@ spec:
                 backup storage location. This is a required field.
               type: string
             refresh:
-              description: A boolean used to trigger a reconcile for the MigStorage
-                CRD.
+              description: Triggers a reconcile for the MigStorage CRD.
               type: boolean
             volumeSnapshotConfig:
               description: Defines config for taking Volume Snapshots.

--- a/pkg/apis/migration/v1alpha1/directimagemigration_types.go
+++ b/pkg/apis/migration/v1alpha1/directimagemigration_types.go
@@ -32,7 +32,7 @@ type DirectImageMigrationSpec struct {
 	SrcMigClusterRef  *kapi.ObjectReference `json:"srcMigClusterRef,omitempty"`
 	DestMigClusterRef *kapi.ObjectReference `json:"destMigClusterRef,omitempty"`
 
-	// A list of all namespaces to run DIM to get all the imagestreams in these namespaces.
+	// Holds names of all namespaces to run DIM to get all the imagestreams in these namespaces.
 	Namespaces        []string              `json:"namespaces,omitempty"`
 }
 

--- a/pkg/apis/migration/v1alpha1/directimagemigration_types.go
+++ b/pkg/apis/migration/v1alpha1/directimagemigration_types.go
@@ -31,6 +31,8 @@ import (
 type DirectImageMigrationSpec struct {
 	SrcMigClusterRef  *kapi.ObjectReference `json:"srcMigClusterRef,omitempty"`
 	DestMigClusterRef *kapi.ObjectReference `json:"destMigClusterRef,omitempty"`
+
+	// A list of all namespaces to run DIM to get all the imagestreams in these namespaces.
 	Namespaces        []string              `json:"namespaces,omitempty"`
 }
 

--- a/pkg/apis/migration/v1alpha1/directimagestreammigration_types.go
+++ b/pkg/apis/migration/v1alpha1/directimagestreammigration_types.go
@@ -30,6 +30,8 @@ type DirectImageStreamMigrationSpec struct {
 	SrcMigClusterRef  *kapi.ObjectReference `json:"srcMigClusterRef,omitempty"`
 	DestMigClusterRef *kapi.ObjectReference `json:"destMigClusterRef,omitempty"`
 	ImageStreamRef    *kapi.ObjectReference `json:"imageStreamRef,omitempty"`
+
+	//  A string holding the name of the namespace on destination cluster where imagestreams should be migrated.
 	DestNamespace     string                `json:"destNamespace,omitempty"`
 }
 

--- a/pkg/apis/migration/v1alpha1/directimagestreammigration_types.go
+++ b/pkg/apis/migration/v1alpha1/directimagestreammigration_types.go
@@ -31,7 +31,7 @@ type DirectImageStreamMigrationSpec struct {
 	DestMigClusterRef *kapi.ObjectReference `json:"destMigClusterRef,omitempty"`
 	ImageStreamRef    *kapi.ObjectReference `json:"imageStreamRef,omitempty"`
 
-	//  A string holding the name of the namespace on destination cluster where imagestreams should be migrated.
+	//  Holds the name of the namespace on destination cluster where imagestreams should be migrated.
 	DestNamespace     string                `json:"destNamespace,omitempty"`
 }
 

--- a/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
+++ b/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
@@ -34,13 +34,13 @@ type DirectVolumeMigrationSpec struct {
 	SrcMigClusterRef            *kapi.ObjectReference `json:"srcMigClusterRef,omitempty"`
 	DestMigClusterRef           *kapi.ObjectReference `json:"destMigClusterRef,omitempty"`
 
-	//  A list of all the PVCs that are to be migrated with direct volume migration
+	//  Holds all the PVCs that are to be migrated with direct volume migration
 	PersistentVolumeClaims      []PVCToMigrate        `json:"persistentVolumeClaims,omitempty"`
 
-	// A boolean flag that is set True to create namespaces in destination cluster
+	// Set true to create namespaces in destination cluster
 	CreateDestinationNamespaces bool                  `json:"createDestinationNamespaces,omitempty"`
 
-	// A boolean flag to specify if progress reporting CRs needs to be deleted or not
+	// Specifies if progress reporting CRs needs to be deleted or not
 	DeleteProgressReportingCRs  bool                  `json:"deleteProgressReportingCRs,omitempty"`
 }
 

--- a/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
+++ b/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
@@ -33,8 +33,14 @@ type PVCToMigrate struct {
 type DirectVolumeMigrationSpec struct {
 	SrcMigClusterRef            *kapi.ObjectReference `json:"srcMigClusterRef,omitempty"`
 	DestMigClusterRef           *kapi.ObjectReference `json:"destMigClusterRef,omitempty"`
+
+	//  A list of all the PVCs that are to be migrated with direct volume migration
 	PersistentVolumeClaims      []PVCToMigrate        `json:"persistentVolumeClaims,omitempty"`
+
+	// A boolean flag that is set True to create namespaces in destination cluster
 	CreateDestinationNamespaces bool                  `json:"createDestinationNamespaces,omitempty"`
+
+	// A boolean flag to specify if progress reporting CRs needs to be deleted or not
 	DeleteProgressReportingCRs  bool                  `json:"deleteProgressReportingCRs,omitempty"`
 }
 

--- a/pkg/apis/migration/v1alpha1/miganalytic_types.go
+++ b/pkg/apis/migration/v1alpha1/miganalytic_types.go
@@ -26,10 +26,20 @@ import (
 // MigAnalyticSpec defines the desired state of MigAnalytic
 type MigAnalyticSpec struct {
 	MigPlanRef          *kapi.ObjectReference `json:"migPlanRef"`
+
+	// A boolean flag to enable analysis of persistent volume capacity. This is a required field.
 	AnalyzePVCapacity   bool                  `json:"analyzePVCapacity"`
+
+	// A boolean flag to enable analysis of image count. This is a required field.
 	AnalyzeImageCount   bool                  `json:"analyzeImageCount"`
+
+	// A boolean flag to enable analysis of k8s resources. This is a required field.
 	AnalyzeK8SResources bool                  `json:"analyzeK8SResources"`
+
+	// A boolean flag to enable used in analysis of image count
 	ListImages          bool                  `json:"listImages,omitempty"`
+
+	// An integer representing limit on image counts
 	ListImagesLimit     int                   `json:"listImagesLimit,omitempty"`
 }
 

--- a/pkg/apis/migration/v1alpha1/miganalytic_types.go
+++ b/pkg/apis/migration/v1alpha1/miganalytic_types.go
@@ -27,19 +27,19 @@ import (
 type MigAnalyticSpec struct {
 	MigPlanRef          *kapi.ObjectReference `json:"migPlanRef"`
 
-	// A boolean flag to enable analysis of persistent volume capacity. This is a required field.
+	// Enables analysis of persistent volume capacity, if set true. This is a required field.
 	AnalyzePVCapacity   bool                  `json:"analyzePVCapacity"`
 
-	// A boolean flag to enable analysis of image count. This is a required field.
+	// Enables analysis of image count, if set true. This is a required field.
 	AnalyzeImageCount   bool                  `json:"analyzeImageCount"`
 
-	// A boolean flag to enable analysis of k8s resources. This is a required field.
+	// Enables analysis of k8s resources, if set true. This is a required field.
 	AnalyzeK8SResources bool                  `json:"analyzeK8SResources"`
 
-	// A boolean flag to enable used in analysis of image count
+	// Enable used in analysis of image count, if set true.
 	ListImages          bool                  `json:"listImages,omitempty"`
 
-	// An integer representing limit on image counts
+	// Represents limit on image counts
 	ListImagesLimit     int                   `json:"listImagesLimit,omitempty"`
 }
 

--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -62,14 +62,30 @@ const (
 
 // MigClusterSpec defines the desired state of MigCluster
 type MigClusterSpec struct {
+	// Specifies if the cluster is host (where the controller is installed) or not. This is a required field.
 	IsHostCluster           bool                  `json:"isHostCluster"`
+
+	// Stores the url of the remote cluster. The field is only required for the source cluster object.
 	URL                     string                `json:"url,omitempty"`
+
 	ServiceAccountSecretRef *kapi.ObjectReference `json:"serviceAccountSecretRef,omitempty"`
+
+	// If the migcluster needs SSL verification for connections a user can supply a custom CA bundle.
 	CABundle                []byte                `json:"caBundle,omitempty"`
+
+	// For azure clusters -- it's the resource group that in-cluster volumes use.
 	AzureResourceGroup      string                `json:"azureResourceGroup,omitempty"`
+
+	// If set false, user will need to provide CA bundle for TSL connection to the remote cluster.
 	Insecure                bool                  `json:"insecure,omitempty"`
+
+	// An override setting to tell the controller that the source cluster restic needs to be restarted after stage pod creation.
 	RestartRestic           *bool                 `json:"restartRestic,omitempty"`
+
+	// If set True, forces the controller to run a full suite of validations on migcluster.
 	Refresh                 bool                  `json:"refresh,omitempty"`
+
+	// Stores the path of registry route when using direct migration.
 	ExposedRegistryPath     string                `json:"exposedRegistryPath,omitempty"`
 }
 

--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -70,13 +70,13 @@ type MigClusterSpec struct {
 
 	ServiceAccountSecretRef *kapi.ObjectReference `json:"serviceAccountSecretRef,omitempty"`
 
-	// If the migcluster needs SSL verification for connections a user can supply a custom CA bundle.
+	// If the migcluster needs SSL verification for connections a user can supply a custom CA bundle. This field is required only when spec.Insecure is set false
 	CABundle                []byte                `json:"caBundle,omitempty"`
 
 	// For azure clusters -- it's the resource group that in-cluster volumes use.
 	AzureResourceGroup      string                `json:"azureResourceGroup,omitempty"`
 
-	// If set false, user will need to provide CA bundle for TSL connection to the remote cluster.
+	// If set false, user will need to provide CA bundle for TLS connection to the remote cluster.
 	Insecure                bool                  `json:"insecure,omitempty"`
 
 	// An override setting to tell the controller that the source cluster restic needs to be restarted after stage pod creation.

--- a/pkg/apis/migration/v1alpha1/mighook_types.go
+++ b/pkg/apis/migration/v1alpha1/mighook_types.go
@@ -36,7 +36,7 @@ const (
 
 // MigHookSpec defines the desired state of MigHook
 type MigHookSpec struct {
-	// Specifies whether the hook is a custom Ansible playbook or a pre-built image. The value of this field is required. This is a required field.
+	// Specifies whether the hook is a custom Ansible playbook or a pre-built image. This is a required field.
 	Custom                bool   `json:"custom"`
 
 	// Specifies the image of the hook to be executed. This is a required field.

--- a/pkg/apis/migration/v1alpha1/mighook_types.go
+++ b/pkg/apis/migration/v1alpha1/mighook_types.go
@@ -36,10 +36,19 @@ const (
 
 // MigHookSpec defines the desired state of MigHook
 type MigHookSpec struct {
+	// Implies whether the hook is a custom Ansible playbook or a pre-built image. The value of this field is required. This is a required field.
 	Custom                bool   `json:"custom"`
+
+	// Specifies the image of the hook to be executed. This is a required field.
 	Image                 string `json:"image"`
+
+	// Specifies the contents of the custom Ansible playbook in base64 format, it is used in conjunction with the custom boolean flag.
 	Playbook              string `json:"playbook,omitempty"`
+
+	// Specifies the cluster on which the hook is to be executed. This is a required field.
 	TargetCluster         string `json:"targetCluster"`
+
+	// Specifies the highest amount of time for which the hook will run.
 	ActiveDeadlineSeconds int64  `json:"activeDeadlineSeconds,omitempty"`
 }
 

--- a/pkg/apis/migration/v1alpha1/mighook_types.go
+++ b/pkg/apis/migration/v1alpha1/mighook_types.go
@@ -36,7 +36,7 @@ const (
 
 // MigHookSpec defines the desired state of MigHook
 type MigHookSpec struct {
-	// Implies whether the hook is a custom Ansible playbook or a pre-built image. The value of this field is required. This is a required field.
+	// Specifies whether the hook is a custom Ansible playbook or a pre-built image. The value of this field is required. This is a required field.
 	Custom                bool   `json:"custom"`
 
 	// Specifies the image of the hook to be executed. This is a required field.

--- a/pkg/apis/migration/v1alpha1/migmigration_types.go
+++ b/pkg/apis/migration/v1alpha1/migmigration_types.go
@@ -43,10 +43,10 @@ type MigMigrationSpec struct {
 	// Specifies whether to verify the health of the migrated pods or not.
 	Verify          bool                  `json:"verify,omitempty"`
 
-	// Invokes the cancel migration operation, when set to true the migration controller switches to cancel itinerary.
+	// Invokes the cancel migration operation, when set to true the migration controller switches to cancel itinerary. This field can be used on-demand to cancel the running migration.
 	Canceled        bool                  `json:"canceled,omitempty"`
 
-	// Invokes the rollback migration operation, when set to true the migration controller switches to rollback itinerary.
+	// Invokes the rollback migration operation, when set to true the migration controller switches to rollback itinerary. This field needs to be set prior to creation of a MigMigration.
 	Rollback        bool                  `json:"rollback,omitempty"`
 }
 

--- a/pkg/apis/migration/v1alpha1/migmigration_types.go
+++ b/pkg/apis/migration/v1alpha1/migmigration_types.go
@@ -34,7 +34,7 @@ type MigMigrationSpec struct {
 	// Invokes the stage operation, when set to true the migration controller switches to stage itinerary. This is a required field.
 	Stage           bool                  `json:"stage"`
 
-	// Specifies whether to quiesce the application pods before migration or not.
+	// Specifies whether to quiesce the application Pods before migrating Persistent Volume data.
 	QuiescePods     bool                  `json:"quiescePods,omitempty"`
 
 	// Specifies whether to retain the annotations set by the migration controller or not.

--- a/pkg/apis/migration/v1alpha1/migmigration_types.go
+++ b/pkg/apis/migration/v1alpha1/migmigration_types.go
@@ -30,11 +30,23 @@ const (
 // MigMigrationSpec defines the desired state of MigMigration
 type MigMigrationSpec struct {
 	MigPlanRef      *kapi.ObjectReference `json:"migPlanRef,omitempty"`
+
+	// Invokes the stage operation, when set to true the migration controller switches to stage itinerary. This is a required field.
 	Stage           bool                  `json:"stage"`
+
+	// Specifies whether to quiesce the application pods before migration or not.
 	QuiescePods     bool                  `json:"quiescePods,omitempty"`
+
+	// Specifies whether to retain the annotations set by the migration controller or not.
 	KeepAnnotations bool                  `json:"keepAnnotations,omitempty"`
+
+	// Specifies whether to verify the health of the migrated pods or not.
 	Verify          bool                  `json:"verify,omitempty"`
+
+	// Invokes the cancel migration operation, when set to true the migration controller switches to cancel itinerary.
 	Canceled        bool                  `json:"canceled,omitempty"`
+
+	// Invokes the rollback migration operation, when set to true the migration controller switches to rollback itinerary.
 	Rollback        bool                  `json:"rollback,omitempty"`
 }
 

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -65,10 +65,10 @@ type MigPlanHook struct {
 // MigPlanSpec defines the desired state of MigPlan
 type MigPlanSpec struct {
 
-	// Holds list of all the persistent volumes found for the namespaces included in migplan. Each entry in the list is a persistent volume with the information. Name - The PV name. Capacity - The PV storage capacity. StorageClass - The PV storage class name. Supported - Lists of what is supported. Selection - Choices made from supported. PVC - Associated PVC. NFS - NFS properties. staged - A PV has been explicitly added/updated.
+	// Holds all the persistent volumes found for the namespaces included in migplan. Each entry is a persistent volume with the information. Name - The PV name. Capacity - The PV storage capacity. StorageClass - The PV storage class name. Supported - Lists of what is supported. Selection - Choices made from supported. PVC - Associated PVC. NFS - NFS properties. staged - A PV has been explicitly added/updated.
 	PersistentVolumes       `json:",inline"`
 
-	//  A list of string of all the namespaces to be included in migration.
+	// Holds names of all the namespaces to be included in migration.
 	Namespaces              []string              `json:"namespaces,omitempty"`
 
 	SrcMigClusterRef        *kapi.ObjectReference `json:"srcMigClusterRef,omitempty"`

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -51,22 +51,45 @@ const (
 // MigPlanHook hold a reference to a MigHook along with the desired phase to run it in
 type MigPlanHook struct {
 	Reference          *kapi.ObjectReference `json:"reference"`
+
+	// Indicates the phase when the hooks will be executed.
 	Phase              string                `json:"phase"`
+
+	// Holds the name of the namespace where hooks should be implemented.
 	ExecutionNamespace string                `json:"executionNamespace"`
+
+	// Holds the name of the service account to be used for running hooks.
 	ServiceAccount     string                `json:"serviceAccount"`
 }
 
 // MigPlanSpec defines the desired state of MigPlan
 type MigPlanSpec struct {
+
+	// Holds list of all the persistent volumes found for the namespaces included in migplan. Each entry in the list is a persistent volume with the information. Name - The PV name. Capacity - The PV storage capacity. StorageClass - The PV storage class name. Supported - Lists of what is supported. Selection - Choices made from supported. PVC - Associated PVC. NFS - NFS properties. staged - A PV has been explicitly added/updated.
 	PersistentVolumes       `json:",inline"`
+
+	//  A list of string of all the namespaces to be included in migration.
 	Namespaces              []string              `json:"namespaces,omitempty"`
+
 	SrcMigClusterRef        *kapi.ObjectReference `json:"srcMigClusterRef,omitempty"`
+
 	DestMigClusterRef       *kapi.ObjectReference `json:"destMigClusterRef,omitempty"`
+
 	MigStorageRef           *kapi.ObjectReference `json:"migStorageRef,omitempty"`
+
+	// If the migration was successful for a migplan, this value can be set True indicating that after one successful migration no new migrations can be carried out for this migplan.
 	Closed                  bool                  `json:"closed,omitempty"`
+
+	// Holds a reference to a MigHook along with the desired phase to run it in.
 	Hooks                   []MigPlanHook         `json:"hooks,omitempty"`
+
+	// If set True, the controller is forces to check if the migplan is in Ready state or not.
 	Refresh                 bool                  `json:"refresh,omitempty"`
+
+	// If set True, disables direct image migrations.
 	IndirectImageMigration  bool                  `json:"indirectImageMigration,omitempty"`
+
+	// If set True, disables direct volume migrations.
 	IndirectVolumeMigration bool                  `json:"indirectVolumeMigration,omitempty"`
 }
 

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -52,7 +52,7 @@ const (
 type MigPlanHook struct {
 	Reference          *kapi.ObjectReference `json:"reference"`
 
-	// Indicates the phase when the hooks will be executed.
+	// Indicates the phase when the hooks will be executed. Acceptable values are: PreBackup, PostBackup, PreRestore, and PostRestore.
 	Phase              string                `json:"phase"`
 
 	// Holds the name of the namespace where hooks should be implemented.
@@ -83,7 +83,7 @@ type MigPlanSpec struct {
 	// Holds a reference to a MigHook along with the desired phase to run it in.
 	Hooks                   []MigPlanHook         `json:"hooks,omitempty"`
 
-	// If set True, the controller is forces to check if the migplan is in Ready state or not.
+	// If set True, the controller is forced to check if the migplan is in Ready state or not.
 	Refresh                 bool                  `json:"refresh,omitempty"`
 
 	// If set True, disables direct image migrations.

--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -47,7 +47,7 @@ type MigStorageSpec struct {
 	// Defines config for taking Volume Snapshots.
 	VolumeSnapshotConfig   `json:"volumeSnapshotConfig,omitempty"`
 
-	// A boolean used to trigger a reconcile for the MigStorage CRD.
+	// Triggers a reconcile for the MigStorage CRD.
 	Refresh                bool `json:"refresh,omitempty"`
 }
 

--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -35,10 +35,19 @@ const (
 
 // MigStorageSpec defines the desired state of MigStorage
 type MigStorageSpec struct {
+	// Holds the provider name whose object storage is used for backup storage location. This is a required field.
 	BackupStorageProvider  string `json:"backupStorageProvider"`
+
+	// Defines config for creating and storing Backups. This is a required field.
 	BackupStorageConfig    `json:"backupStorageConfig"`
+
+	// Holds the provider name whose object storage is used for backup storage location.
 	VolumeSnapshotProvider string `json:"volumeSnapshotProvider,omitempty"`
+
+	// Defines config for taking Volume Snapshots.
 	VolumeSnapshotConfig   `json:"volumeSnapshotConfig,omitempty"`
+
+	// A boolean used to trigger a reconcile for the MigStorage CRD.
 	Refresh                bool `json:"refresh,omitempty"`
 }
 


### PR DESCRIPTION
This PR is adding comments for each spec field for all resources to add descriptions in CRDs for the respective spec fields for which the comment is added. 

Also updating `MakeFile` to generate CRDs with `preserveUnknownField` set to `false` to enable the use of `oc explain` command.