### PR TITLE
Bug 1859998: Use and propagate direct_image_copy flag

### DIFF
--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -26,6 +26,9 @@ import (
 	"strings"
 
 	liberr "github.com/konveyor/controller/pkg/error"
+	pvdr "github.com/konveyor/mig-controller/pkg/cloudprovider"
+	migref "github.com/konveyor/mig-controller/pkg/reference"
+	"github.com/konveyor/mig-controller/pkg/settings"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	kapi "k8s.io/api/core/v1"
@@ -35,10 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	pvdr "github.com/konveyor/mig-controller/pkg/cloudprovider"
-	migref "github.com/konveyor/mig-controller/pkg/reference"
-	"github.com/konveyor/mig-controller/pkg/settings"
 )
 
 var Settings = &settings.Settings
@@ -674,11 +673,12 @@ func (r *MigPlan) IsResourceExcluded(resource string) bool {
 	return false
 }
 
-// IsImageMigrationDisabled returns whether this MigPlan has disabled Image Migration
-// Currently this is only implemented site-wide via the ExcludedResources list. This
+// IsImageMigrationDisabled returns whether this MigPlan has disable_image_copy or disabled_image_migration
+// disable_image_copy is a flag available as a controller boolean env var.
+// disabled_image_migration is currently implemented site-wide via the ExcludedResources list. This
 // This will change to an explicit controller boolean env var at some point.
 func (r *MigPlan) IsImageMigrationDisabled() bool {
-	return r.IsResourceExcluded(settings.ISResource)
+	return r.IsResourceExcluded(settings.ISResource) || Settings.DisImgCopy
 }
 
 // IsVolumeMigrationDisabled returns whether this MigPlan has disabled Volume Migration

--- a/pkg/controller/miganalytic/miganalytics_controller.go
+++ b/pkg/controller/miganalytic/miganalytics_controller.go
@@ -24,12 +24,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/konveyor/mig-controller/pkg/errorutil"
-
 	"github.com/konveyor/controller/pkg/logging"
 	"github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/konveyor/mig-controller/pkg/compat"
+	"github.com/konveyor/mig-controller/pkg/errorutil"
 	"github.com/konveyor/mig-controller/pkg/gvk"
+	"github.com/konveyor/mig-controller/pkg/settings"
 	"github.com/openshift/api/image/docker10"
 	"github.com/openshift/library-go/pkg/image/reference"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -62,6 +62,7 @@ const (
 )
 
 var log = logging.WithName("analytics")
+var Settings = &settings.Settings
 
 // Add creates a new MigAnalytic Controller and adds it to the Manager with default RBAC.
 // The Manager will set fields on the Controller and Start it when the Manager is Started.
@@ -263,7 +264,7 @@ func (r *ReconcileMigAnalytic) analyze(analytic *migapi.MigAnalytic) error {
 				return liberr.Wrap(err)
 			}
 		}
-		if analytic.Spec.AnalyzeImageCount && !isExcluded("imagestreams", excludedResources) {
+		if analytic.Spec.AnalyzeImageCount && !isExcluded("imagestreams", excludedResources) && !Settings.DisImgCopy {
 			err := r.analyzeImages(client, &ns, analytic.Spec.ListImages, analytic.Spec.ListImagesLimit)
 			if err != nil {
 				return liberr.Wrap(err)

--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -3,6 +3,8 @@ package migmigration
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	liberr "github.com/konveyor/controller/pkg/error"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/konveyor/mig-controller/pkg/compat"
@@ -10,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 )
 
 // Velero Plugin Annotations
@@ -34,6 +35,11 @@ const (
 const (
 	ResticPvBackupAnnotation = "backup.velero.io/backup-volumes" // comma-separated list of volume names
 	ResticPvVerifyAnnotation = "backup.velero.io/verify-volumes" // comma-separated list of volume names
+)
+
+// Disables the internal image copy
+const (
+	DisableImageCopy = "migration.openshift.io/disable-image-copy"
 )
 
 // Labels.

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -20,9 +20,10 @@ const (
 	// Only the discovery should be loaded.
 	DiscoveryRole = "discovery"
 	// Proxy environment variables
-	HttpProxy  = "HTTP_PROXY"
-	HttpsProxy = "HTTPS_PROXY"
-	NoProxy    = "NO_PROXY"
+	HttpProxy        = "HTTP_PROXY"
+	HttpsProxy       = "HTTPS_PROXY"
+	NoProxy          = "NO_PROXY"
+	DisableImageCopy = "DISABLE_IMAGE_COPY"
 )
 
 // Global
@@ -34,8 +35,9 @@ type _Settings struct {
 	Discovery
 	Plan
 	DvmOpts
-	Roles     map[string]bool
-	ProxyVars map[string]string
+	Roles      map[string]bool
+	ProxyVars  map[string]string
+	DisImgCopy bool
 }
 
 // Load settings.
@@ -60,6 +62,8 @@ func (r *_Settings) Load() error {
 	if err != nil {
 		return err
 	}
+
+	r.DisImgCopy = getEnvBool(DisableImageCopy, false)
 
 	return nil
 }


### PR DESCRIPTION
This PR is part of a three-part fix. Other two PRs are listed below:
1. [velero-plugin fix](https://github.com/konveyor/openshift-velero-plugin/pull/69)
2. [mig-operator fix](https://github.com/konveyor/mig-operator/pull/554)

### Description of changes: 
**disable_image_copy** flag is read from the environment variable and used to:
1. Annotate the backup based on whether the image copy is required or not. [Indirect migration case]
2. Ensure mig-analytics does not include images in the count when `disable_image_copy=true`. 
3. Inhibit image copy [direct image migration case].

Since, `disable_image_copy` is related to `disable_image_migration`, following discussion with team, sanity test was performed for following tests:
<img width="616" alt="image" src="https://user-images.githubusercontent.com/67090431/106500343-b57ca580-64e7-11eb-88ef-5eddbdbfb346.png">

As per the bug 1859998, the buggy output is:
```$ oc get builds
NAME        TYPE     FROM      STATUS                         STARTED   DURATION
jws-app-1   Source   Git@1.2   New (InvalidOutputReference)   
```
Above output is avoided by setting `disable_image_copy=true` and `disable_image_migration=false` and we now get the following expected output is obtained by avoiding only image copy, but migrating image-stream and image-stream-tags, 
```$ oc get builds
NAME        TYPE     FROM          STATUS    STARTED          DURATION
jws-app-1   Source   Git@caec202   Running   48 seconds ago   
```
Signed-off-by: Padmanabha Venkatagiri Seshadri <seshapad@in.ibm.com>