### PR TITLE
Add explicit error message on DirectVolumeMigration network misconfiguration

### DIFF
--- a/pkg/controller/directvolumemigration/rsync_test.go
+++ b/pkg/controller/directvolumemigration/rsync_test.go
@@ -1,0 +1,188 @@
+package directvolumemigration
+
+import (
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+	"time"
+)
+
+func Test_hasAllRsyncClientPodsTimedOut(t *testing.T) {
+	type args struct {
+		pvcMap  map[string][]pvcMapElement
+		client  client.Client
+		dvmName string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "both rsync clients pods succeeded",
+			args: args{
+				pvcMap: map[string][]pvcMapElement{"foo": {{
+					Name:   "pvc-0",
+					Verify: false,
+				}, {
+					Name:   "pvc-1",
+					Verify: false,
+				}}},
+				client: fake.NewFakeClient(&migapi.DirectVolumeMigrationProgress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      getMD5Hash("test" + "pvc-0" + "foo"),
+						Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec:   migapi.DirectVolumeMigrationProgressSpec{},
+					Status: migapi.DirectVolumeMigrationProgressStatus{PodPhase: corev1.PodSucceeded, ContainerElapsedTime: &metav1.Duration{Duration: time.Second * 20}},
+				}, &migapi.DirectVolumeMigrationProgress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      getMD5Hash("test" + "pvc-1" + "foo"),
+						Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec:   migapi.DirectVolumeMigrationProgressSpec{},
+					Status: migapi.DirectVolumeMigrationProgressStatus{PodPhase: corev1.PodSucceeded, ContainerElapsedTime: &metav1.Duration{Duration: time.Second * 20}},
+				}),
+				dvmName: "test",
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "both rsync clients failed with 20 seconds",
+			args: args{
+				pvcMap: map[string][]pvcMapElement{"foo": {{
+					Name:   "pvc-0",
+					Verify: false,
+				}, {
+					Name:   "pvc-1",
+					Verify: false,
+				}}},
+				client: fake.NewFakeClient(&migapi.DirectVolumeMigrationProgress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      getMD5Hash("test" + "pvc-0" + "foo"),
+						Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec:   migapi.DirectVolumeMigrationProgressSpec{},
+					Status: migapi.DirectVolumeMigrationProgressStatus{PodPhase: corev1.PodFailed, ContainerElapsedTime: &metav1.Duration{Duration: time.Second * 20}},
+				}, &migapi.DirectVolumeMigrationProgress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      getMD5Hash("test" + "pvc-1" + "foo"),
+						Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec:   migapi.DirectVolumeMigrationProgressSpec{},
+					Status: migapi.DirectVolumeMigrationProgressStatus{PodPhase: corev1.PodFailed, ContainerElapsedTime: &metav1.Duration{Duration: time.Second * 20}},
+				}),
+				dvmName: "test",
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "one rsync client pod failed with 20 second timeout other succeeded",
+			args: args{
+				pvcMap: map[string][]pvcMapElement{"foo": {{
+					Name:   "pvc-0",
+					Verify: false,
+				}, {
+					Name:   "pvc-1",
+					Verify: false,
+				}}},
+				client: fake.NewFakeClient(&migapi.DirectVolumeMigrationProgress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      getMD5Hash("test" + "pvc-0" + "foo"),
+						Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec:   migapi.DirectVolumeMigrationProgressSpec{},
+					Status: migapi.DirectVolumeMigrationProgressStatus{PodPhase: corev1.PodSucceeded, ContainerElapsedTime: &metav1.Duration{Duration: time.Second * 20}},
+				}, &migapi.DirectVolumeMigrationProgress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      getMD5Hash("test" + "pvc-1" + "foo"),
+						Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec:   migapi.DirectVolumeMigrationProgressSpec{},
+					Status: migapi.DirectVolumeMigrationProgressStatus{PodPhase: corev1.PodFailed, ContainerElapsedTime: &metav1.Duration{Duration: time.Second * 20}},
+				}),
+				dvmName: "test",
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "one rsync client pod failed with 20.49 and other with 20.50 second, expect false",
+			args: args{
+				pvcMap: map[string][]pvcMapElement{"foo": {{
+					Name:   "pvc-0",
+					Verify: false,
+				}, {
+					Name:   "pvc-1",
+					Verify: false,
+				}}},
+				client: fake.NewFakeClient(&migapi.DirectVolumeMigrationProgress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      getMD5Hash("test" + "pvc-0" + "foo"),
+						Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec:   migapi.DirectVolumeMigrationProgressSpec{},
+					Status: migapi.DirectVolumeMigrationProgressStatus{PodPhase: corev1.PodFailed, ContainerElapsedTime: &metav1.Duration{Duration: time.Millisecond * 20490}},
+				}, &migapi.DirectVolumeMigrationProgress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      getMD5Hash("test" + "pvc-1" + "foo"),
+						Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec:   migapi.DirectVolumeMigrationProgressSpec{},
+					Status: migapi.DirectVolumeMigrationProgressStatus{PodPhase: corev1.PodFailed, ContainerElapsedTime: &metav1.Duration{Duration: time.Millisecond * 20500}},
+				}),
+				dvmName: "test",
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "one rsync client pod failed with 20.49 and other with 20.45 second, expect true",
+			args: args{
+				pvcMap: map[string][]pvcMapElement{"foo": {{
+					Name:   "pvc-0",
+					Verify: false,
+				}, {
+					Name:   "pvc-1",
+					Verify: false,
+				}}},
+				client: fake.NewFakeClient(&migapi.DirectVolumeMigrationProgress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      getMD5Hash("test" + "pvc-0" + "foo"),
+						Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec:   migapi.DirectVolumeMigrationProgressSpec{},
+					Status: migapi.DirectVolumeMigrationProgressStatus{PodPhase: corev1.PodFailed, ContainerElapsedTime: &metav1.Duration{Duration: time.Millisecond * 20490}},
+				}, &migapi.DirectVolumeMigrationProgress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      getMD5Hash("test" + "pvc-1" + "foo"),
+						Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec:   migapi.DirectVolumeMigrationProgressSpec{},
+					Status: migapi.DirectVolumeMigrationProgressStatus{PodPhase: corev1.PodFailed, ContainerElapsedTime: &metav1.Duration{Duration: time.Millisecond * 20450}},
+				}),
+				dvmName: "test",
+			},
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := hasAllRsyncClientPodsTimedOut(tt.args.pvcMap, tt.args.client, tt.args.dvmName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("hasAllRsyncClientPodsTimedOut() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("hasAllRsyncClientPodsTimedOut() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -436,11 +436,12 @@ func (t *Task) Run() error {
 					Reason:   SourceToDestinationNetworkError,
 					Category: migapi.Error,
 					Message: "All the rsync client pods on source are timing out at 20 seconds, " +
-						"please check your network configuration (like egressnetwork) that would block traffic from " +
+						"please check your network configuration (like egressnetworkpolicy) that would block traffic from " +
 						"source namespace to destination",
 					Durable: true,
 				})
 				t.fail(MigrationFailed, []string{"all the source rsync pods have timed out, look at error condition for more details"})
+				t.Requeue = NoReQ
 				return nil
 			}
 			if failed {

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -425,6 +425,24 @@ func (t *Task) Run() error {
 			return liberr.Wrap(err)
 		}
 		if completed {
+			isEgressNetworkSetup, err := hasAllRsyncClientPodsTimedOut(t.getPVCNamespaceMap(), t.Client, t.Owner.Name)
+			if err != nil {
+				return err
+			}
+			if isEgressNetworkSetup {
+				t.Owner.Status.SetCondition(migapi.Condition{
+					Type:     migapi.ReconcileFailed,
+					Status:   True,
+					Reason:   SourceToDestinationNetworkError,
+					Category: migapi.Error,
+					Message: "All the rsync client pods on source are timing out at 20 seconds, " +
+						"please check your network configuration (like egressnetwork) that would block traffic from " +
+						"source namespace to destination",
+					Durable: true,
+				})
+				t.fail(MigrationFailed, []string{"all the source rsync pods have timed out, look at error condition for more details"})
+				return nil
+			}
 			if failed {
 				t.fail(MigrationFailed, []string{"One or more pods are in error state"})
 			}

--- a/pkg/controller/directvolumemigration/validation.go
+++ b/pkg/controller/directvolumemigration/validation.go
@@ -13,20 +13,21 @@ import (
 
 // Types
 const (
-	InvalidSourceClusterRef      = "InvalidSourceClusterRef"
-	InvalidDestinationClusterRef = "InvalidDestinationClusterRef"
-	InvalidSourceCluster         = "InvalidSourceCluster"
-	InvalidDestinationCluster    = "InvalidDestinationCluster"
-	InvalidPVCs                  = "InvalidPVCs"
-	SourceClusterNotReady        = "SourceClusterNotReady"
-	DestinationClusterNotReady   = "DestinationClusterNotReady"
-	PVCsNotFoundOnSourceCluster  = "PodsNotFoundOnSourceCluster"
-	StunnelClientPodsPending     = "StunnelClientPodsPending"
-	RsyncTransferPodsPending     = "RsyncTransferPodsPending"
-	RsyncRouteNotAdmitted        = "RsyncRouteNotAdmitted"
-	Running                      = "Running"
-	Failed                       = "Failed"
-	Succeeded                    = "Succeeded"
+	InvalidSourceClusterRef         = "InvalidSourceClusterRef"
+	InvalidDestinationClusterRef    = "InvalidDestinationClusterRef"
+	InvalidSourceCluster            = "InvalidSourceCluster"
+	InvalidDestinationCluster       = "InvalidDestinationCluster"
+	InvalidPVCs                     = "InvalidPVCs"
+	SourceClusterNotReady           = "SourceClusterNotReady"
+	DestinationClusterNotReady      = "DestinationClusterNotReady"
+	PVCsNotFoundOnSourceCluster     = "PodsNotFoundOnSourceCluster"
+	StunnelClientPodsPending        = "StunnelClientPodsPending"
+	RsyncTransferPodsPending        = "RsyncTransferPodsPending"
+	RsyncRouteNotAdmitted           = "RsyncRouteNotAdmitted"
+	Running                         = "Running"
+	Failed                          = "Failed"
+	Succeeded                       = "Succeeded"
+	SourceToDestinationNetworkError = "SourceToDestinationNetworkError"
 )
 
 // Reasons

--- a/pkg/controller/migmigration/dvm.go
+++ b/pkg/controller/migmigration/dvm.go
@@ -98,8 +98,8 @@ func (t *Task) hasDirectVolumeMigrationCompleted(dvm *migapi.DirectVolumeMigrati
 
 	volumeProgress := fmt.Sprintf("%v total volumes; %v successful; %v running; %v failed", totalVolumes, successfulPods, runningPods, failedPods)
 	switch {
-	case dvm.Status.Phase != "" && dvm.Status.Phase != dvmc.Completed:
-		// TODO: Update this to check on the associated dvmp resources and build up a progress indicator back to
+	//case dvm.Status.Phase != "" && dvm.Status.Phase != dvmc.Completed:
+	//	// TODO: Update this to check on the associated dvmp resources and build up a progress indicator back to
 	case dvm.Status.Phase == dvmc.Completed && dvm.Status.Itinerary == "VolumeMigration" && dvm.Status.HasCondition(dvmc.Succeeded):
 		// completed successfully
 		completed = true

--- a/pkg/controller/migmigration/dvm_test.go
+++ b/pkg/controller/migmigration/dvm_test.go
@@ -1,0 +1,114 @@
+package migmigration
+
+import (
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	dvmc "github.com/konveyor/mig-controller/pkg/controller/directvolumemigration"
+	v1 "k8s.io/api/core/v1"
+	"reflect"
+	"testing"
+)
+
+func TestTask_hasDirectVolumeMigrationCompleted(t1 *testing.T) {
+	type args struct {
+		dvm *migapi.DirectVolumeMigration
+	}
+	tests := []struct {
+		name               string
+		args               args
+		wantCompleted      bool
+		wantFailureReasons []string
+		wantProgress       []string
+	}{
+		{
+			name: "system wide network failure",
+			args: args{dvm: &migapi.DirectVolumeMigration{
+				Spec: migapi.DirectVolumeMigrationSpec{
+					PersistentVolumeClaims: []migapi.PVCToMigrate{
+						{
+							ObjectReference: &v1.ObjectReference{
+								Namespace: "pvc-0",
+								Name:      "foo",
+							},
+						},
+					},
+				},
+				Status: migapi.DirectVolumeMigrationStatus{
+					Conditions: migapi.Conditions{
+						List: []migapi.Condition{
+							{
+								Type:   dvmc.Failed,
+								Status: True,
+							},
+						},
+					},
+					Phase: dvmc.MigrationFailed,
+					FailedPods: []*migapi.PodProgress{
+						{
+							ObjectReference: &v1.ObjectReference{
+								Namespace: "pvc-0",
+								Name:      "foo",
+							},
+						},
+					},
+				},
+			}},
+			wantProgress:       []string{"Rsync Client Pod pvc-0/foo: Failed"},
+			wantFailureReasons: []string{"direct volume migration failed. 1 total volumes; 0 successful; 0 running; 1 failed"},
+			wantCompleted:      true,
+		},
+		{
+			name: "all client pods succeeded",
+			args: args{dvm: &migapi.DirectVolumeMigration{
+				Spec: migapi.DirectVolumeMigrationSpec{
+					PersistentVolumeClaims: []migapi.PVCToMigrate{
+						{
+							ObjectReference: &v1.ObjectReference{
+								Namespace: "pvc-0",
+								Name:      "foo",
+							},
+						},
+					},
+				},
+				Status: migapi.DirectVolumeMigrationStatus{
+					Conditions: migapi.Conditions{
+						List: []migapi.Condition{
+							{
+								Type:   dvmc.Succeeded,
+								Status: True,
+							},
+						},
+					},
+					Itinerary: dvmc.VolumeMigration.Name,
+					Phase:     dvmc.Completed,
+					SuccessfulPods: []*migapi.PodProgress{
+						{
+							ObjectReference: &v1.ObjectReference{
+								Namespace: "pvc-0",
+								Name:      "foo",
+							},
+							LastObservedProgressPercent: "100%",
+						},
+					},
+				},
+			}},
+			wantProgress:       []string{"Rsync Client Pod pvc-0/foo:  100% completed"},
+			wantFailureReasons: nil,
+			wantCompleted:      true,
+		},
+	}
+	for _, tt := range tests {
+		t1.Run(tt.name, func(t1 *testing.T) {
+			t := &Task{}
+			gotCompleted, gotFailureReasons, gotProgress := t.hasDirectVolumeMigrationCompleted(tt.args.dvm)
+			if gotCompleted != tt.wantCompleted {
+				t1.Errorf("hasDirectVolumeMigrationCompleted() gotCompleted = %v, want %v", gotCompleted, tt.wantCompleted)
+			}
+			if !reflect.DeepEqual(gotFailureReasons, tt.wantFailureReasons) {
+				t1.Errorf("hasDirectVolumeMigrationCompleted() gotFailureReasons = %v, want %v", gotFailureReasons, tt.wantFailureReasons)
+			}
+			if !reflect.DeepEqual(gotProgress, tt.wantProgress) {
+				t1.Errorf("hasDirectVolumeMigrationCompleted() gotProgress = %v, want %v", gotProgress, tt.wantProgress)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When running DVM with egressnetworkpolicy setup on the source side,
the client stunnel times out after 20 seconds, generating an error with
exit code 12 and connection reset by peer.

This PR checks if all the client pods have timed out in 20 seconds, and 
raises a network misconfiguraiton error condition on the dvm CR.

Closes #912 