### PR TITLE
Discovery and Grouping of PVs for Intelligent PV resizing

### DIFF
--- a/pkg/controller/miganalytic/miganalytics_controller.go
+++ b/pkg/controller/miganalytic/miganalytics_controller.go
@@ -50,7 +50,6 @@ import (
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	imagev1 "github.com/openshift/api/image/v1"
 	corev1 "k8s.io/api/core/v1"
-	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -320,7 +319,7 @@ func (r *ReconcileMigAnalytic) getNodeToPVMapForNS(ns *migapi.MigAnalyticNamespa
 		if pod.Status.Phase == migapi.Running {
 			for _, vol := range pod.Spec.Volumes {
 				if vol.PersistentVolumeClaim != nil {
-					pvcObject := kapi.PersistentVolumeClaim{}
+					pvcObject := corev1.PersistentVolumeClaim{}
 					err := client.Get(
 						context.TODO(),
 						types.NamespacedName{

--- a/pkg/controller/miganalytic/miganalytics_controller.go
+++ b/pkg/controller/miganalytic/miganalytics_controller.go
@@ -332,20 +332,12 @@ func (r *ReconcileMigAnalytic) getNodeToPVMapForNS(ns *migapi.MigAnalyticNamespa
 						return nodeToPVDetails, liberr.Wrap(err)
 					}
 
-					if volDetailList, exists := nodeToPVDetails[pod.Spec.NodeName]; exists {
-						volDetailList = append(volDetailList,
-							MigAnalyticPersistentVolumeDetails{
-								Name:                vol.PersistentVolumeClaim.ClaimName,
-								Namespace:           pvcObject.Namespace,
-								RequestedCapacity:   pvcObject.Spec.Resources.Requests.StorageEphemeral(),
-								PodUID:              pod.UID,
-								ProvisionedCapacity: pvcObject.Status.Capacity.StorageEphemeral(),
-								StorageClass:        pvcObject.Spec.StorageClassName,
-								VolumeName:          pvcObject.Spec.VolumeName,
-							})
-						nodeToPVDetails[pod.Spec.NodeName] = volDetailList
-					} else {
-						nodeToPVDetails[pod.Spec.NodeName] = []MigAnalyticPersistentVolumeDetails{{
+					if _, exists := nodeToPVDetails[pod.Spec.NodeName]; !exists {
+						nodeToPVDetails[pod.Spec.NodeName] = make([]MigAnalyticPersistentVolumeDetails, 0)
+					}
+
+					nodeToPVDetails[pod.Spec.NodeName] = append(nodeToPVDetails[pod.Spec.NodeName],
+						MigAnalyticPersistentVolumeDetails{
 							Name:                vol.PersistentVolumeClaim.ClaimName,
 							Namespace:           pvcObject.Namespace,
 							RequestedCapacity:   pvcObject.Spec.Resources.Requests.StorageEphemeral(),
@@ -353,9 +345,7 @@ func (r *ReconcileMigAnalytic) getNodeToPVMapForNS(ns *migapi.MigAnalyticNamespa
 							ProvisionedCapacity: pvcObject.Status.Capacity.StorageEphemeral(),
 							StorageClass:        pvcObject.Spec.StorageClassName,
 							VolumeName:          pvcObject.Spec.VolumeName,
-						}}
-					}
-
+						})
 				}
 			}
 		}

--- a/pkg/controller/miganalytic/miganalytics_controller.go
+++ b/pkg/controller/miganalytic/miganalytics_controller.go
@@ -50,8 +50,8 @@ import (
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	imagev1 "github.com/openshift/api/image/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -314,7 +314,7 @@ func (r *ReconcileMigAnalytic) getNodeToPVMapForNS(ns *migapi.MigAnalyticNamespa
 						err := r.Client.Get(
 							context.TODO(),
 							types.NamespacedName{
-								Name: vol.PersistentVolumeClaim.ClaimName,
+								Name:      vol.PersistentVolumeClaim.ClaimName,
 								Namespace: pod.Namespace,
 							}, &pvcObject)
 
@@ -325,24 +325,24 @@ func (r *ReconcileMigAnalytic) getNodeToPVMapForNS(ns *migapi.MigAnalyticNamespa
 						if volDetailList, exists := nodeToPVDetails[pod.Spec.NodeName]; exists {
 							volDetailList = append(volDetailList,
 								persistentVolumeDetails{
-								Name: vol.PersistentVolumeClaim.ClaimName,
-								Namespace: pvcObject.Namespace,
-								RequestedCapacity: pvcObject.Spec.Resources.Requests.StorageEphemeral(),
-								PodUID: pod.UID,
-								ProvisionedCapacity: pvcObject.Status.Capacity.StorageEphemeral(),
-								StorageClass: pvcObject.Spec.StorageClassName,
-								VolumeName: pvcObject.Spec.VolumeName,
+									Name:                vol.PersistentVolumeClaim.ClaimName,
+									Namespace:           pvcObject.Namespace,
+									RequestedCapacity:   pvcObject.Spec.Resources.Requests.StorageEphemeral(),
+									PodUID:              pod.UID,
+									ProvisionedCapacity: pvcObject.Status.Capacity.StorageEphemeral(),
+									StorageClass:        pvcObject.Spec.StorageClassName,
+									VolumeName:          pvcObject.Spec.VolumeName,
 								})
 							nodeToPVDetails[pod.Spec.NodeName] = volDetailList
 						} else {
 							nodeToPVDetails[pod.Spec.NodeName] = []persistentVolumeDetails{{
-								Name: vol.PersistentVolumeClaim.ClaimName,
-								Namespace: pvcObject.Namespace,
-								RequestedCapacity: pvcObject.Spec.Resources.Requests.StorageEphemeral(),
-								PodUID: pod.UID,
+								Name:                vol.PersistentVolumeClaim.ClaimName,
+								Namespace:           pvcObject.Namespace,
+								RequestedCapacity:   pvcObject.Spec.Resources.Requests.StorageEphemeral(),
+								PodUID:              pod.UID,
 								ProvisionedCapacity: pvcObject.Status.Capacity.StorageEphemeral(),
-								StorageClass: pvcObject.Spec.StorageClassName,
-								VolumeName: pvcObject.Spec.VolumeName,
+								StorageClass:        pvcObject.Spec.StorageClassName,
+								VolumeName:          pvcObject.Spec.VolumeName,
 							}}
 						}
 
@@ -355,7 +355,6 @@ func (r *ReconcileMigAnalytic) getNodeToPVMapForNS(ns *migapi.MigAnalyticNamespa
 
 	return nil, nil
 }
-
 
 func (r *ReconcileMigAnalytic) analyzeK8SResources(dynamic dynamic.Interface,
 	resources []*metav1.APIResourceList,


### PR DESCRIPTION
This PR does the following:
- Introduces a new struct `MigAnalyticPersistentVolumeDetails` to hold the PV details needed for resizing 
- Adds a new function `getNodeToPVMapForNS` which builds a map of `NodeName : []MigAnalyticPersistentVolumeDetails`which will be later consumed by `analyzeExtendedPVCapacity`  for PV resizing