### PR TITLE
Proposed PV size processing and checking

### DIFF
--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -716,16 +716,16 @@ const (
 // NFS - NFS properties.
 // staged - A PV has been explicitly added/updated.
 type PV struct {
-	Name             string                `json:"name,omitempty"`
-	Capacity         resource.Quantity     `json:"capacity,omitempty"`
-	StorageClass     string                `json:"storageClass,omitempty"`
-	Supported        Supported             `json:"supported"`
-	Selection        Selection             `json:"selection"`
-	PVC              PVC                   `json:"pvc,omitempty"`
-	NFS              *kapi.NFSVolumeSource `json:"-"`
-	staged           bool                  `json:"-"`
-	Confirmed        bool                  `json:"capacityConfirmed"`
-	ProposedCapacity resource.Quantity     `json:"proposedCapacity,omitempty"`
+	Name              string                `json:"name,omitempty"`
+	Capacity          resource.Quantity     `json:"capacity,omitempty"`
+	StorageClass      string                `json:"storageClass,omitempty"`
+	Supported         Supported             `json:"supported"`
+	Selection         Selection             `json:"selection"`
+	PVC               PVC                   `json:"pvc,omitempty"`
+	NFS               *kapi.NFSVolumeSource `json:"-"`
+	staged            bool                  `json:"-"`
+	CapacityConfirmed bool                  `json:"capacityConfirmed"`
+	ProposedCapacity  resource.Quantity     `json:"proposedCapacity,omitempty"`
 }
 
 // PVC

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -724,8 +724,8 @@ type PV struct {
 	PVC              PVC                   `json:"pvc,omitempty"`
 	NFS              *kapi.NFSVolumeSource `json:"-"`
 	staged           bool                  `json:"-"`
-	Confirmed        bool                  `json:"_"`
-	ProposedCapacity resource.Quantity     `json:"capacity,omitempty"`
+	Confirmed        bool                  `json:"capacityConfirmed"`
+	ProposedCapacity resource.Quantity     `json:"proposedCapacity,omitempty"`
 }
 
 // PVC

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -50,47 +50,47 @@ const (
 
 // MigPlanHook hold a reference to a MigHook along with the desired phase to run it in
 type MigPlanHook struct {
-	Reference          *kapi.ObjectReference `json:"reference"`
+	Reference *kapi.ObjectReference `json:"reference"`
 
 	// Indicates the phase when the hooks will be executed. Acceptable values are: PreBackup, PostBackup, PreRestore, and PostRestore.
-	Phase              string                `json:"phase"`
+	Phase string `json:"phase"`
 
 	// Holds the name of the namespace where hooks should be implemented.
-	ExecutionNamespace string                `json:"executionNamespace"`
+	ExecutionNamespace string `json:"executionNamespace"`
 
 	// Holds the name of the service account to be used for running hooks.
-	ServiceAccount     string                `json:"serviceAccount"`
+	ServiceAccount string `json:"serviceAccount"`
 }
 
 // MigPlanSpec defines the desired state of MigPlan
 type MigPlanSpec struct {
 
 	// Holds all the persistent volumes found for the namespaces included in migplan. Each entry is a persistent volume with the information. Name - The PV name. Capacity - The PV storage capacity. StorageClass - The PV storage class name. Supported - Lists of what is supported. Selection - Choices made from supported. PVC - Associated PVC. NFS - NFS properties. staged - A PV has been explicitly added/updated.
-	PersistentVolumes       `json:",inline"`
+	PersistentVolumes `json:",inline"`
 
 	// Holds names of all the namespaces to be included in migration.
-	Namespaces              []string              `json:"namespaces,omitempty"`
+	Namespaces []string `json:"namespaces,omitempty"`
 
-	SrcMigClusterRef        *kapi.ObjectReference `json:"srcMigClusterRef,omitempty"`
+	SrcMigClusterRef *kapi.ObjectReference `json:"srcMigClusterRef,omitempty"`
 
-	DestMigClusterRef       *kapi.ObjectReference `json:"destMigClusterRef,omitempty"`
+	DestMigClusterRef *kapi.ObjectReference `json:"destMigClusterRef,omitempty"`
 
-	MigStorageRef           *kapi.ObjectReference `json:"migStorageRef,omitempty"`
+	MigStorageRef *kapi.ObjectReference `json:"migStorageRef,omitempty"`
 
 	// If the migration was successful for a migplan, this value can be set True indicating that after one successful migration no new migrations can be carried out for this migplan.
-	Closed                  bool                  `json:"closed,omitempty"`
+	Closed bool `json:"closed,omitempty"`
 
 	// Holds a reference to a MigHook along with the desired phase to run it in.
-	Hooks                   []MigPlanHook         `json:"hooks,omitempty"`
+	Hooks []MigPlanHook `json:"hooks,omitempty"`
 
 	// If set True, the controller is forced to check if the migplan is in Ready state or not.
-	Refresh                 bool                  `json:"refresh,omitempty"`
+	Refresh bool `json:"refresh,omitempty"`
 
 	// If set True, disables direct image migrations.
-	IndirectImageMigration  bool                  `json:"indirectImageMigration,omitempty"`
+	IndirectImageMigration bool `json:"indirectImageMigration,omitempty"`
 
 	// If set True, disables direct volume migrations.
-	IndirectVolumeMigration bool                  `json:"indirectVolumeMigration,omitempty"`
+	IndirectVolumeMigration bool `json:"indirectVolumeMigration,omitempty"`
 }
 
 // MigPlanStatus defines the observed state of MigPlan
@@ -716,14 +716,16 @@ const (
 // NFS - NFS properties.
 // staged - A PV has been explicitly added/updated.
 type PV struct {
-	Name         string                `json:"name,omitempty"`
-	Capacity     resource.Quantity     `json:"capacity,omitempty"`
-	StorageClass string                `json:"storageClass,omitempty"`
-	Supported    Supported             `json:"supported"`
-	Selection    Selection             `json:"selection"`
-	PVC          PVC                   `json:"pvc,omitempty"`
-	NFS          *kapi.NFSVolumeSource `json:"-"`
-	staged       bool                  `json:"-"`
+	Name             string                `json:"name,omitempty"`
+	Capacity         resource.Quantity     `json:"capacity,omitempty"`
+	StorageClass     string                `json:"storageClass,omitempty"`
+	Supported        Supported             `json:"supported"`
+	Selection        Selection             `json:"selection"`
+	PVC              PVC                   `json:"pvc,omitempty"`
+	NFS              *kapi.NFSVolumeSource `json:"-"`
+	staged           bool                  `json:"-"`
+	Confirmed        bool                  `json:"_"`
+	ProposedCapacity resource.Quantity     `json:"capacity,omitempty"`
 }
 
 // PVC

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -564,12 +564,12 @@ func (r ReconcileMigPlan) processExtendedPVCapacity(plan *migapi.MigPlan, analyt
 
 						// If plan volume capacity is less than analytic volume's proposed capacity, set confirmed to False
 						if planVol.Capacity.Cmp(analyticNSVol.ProposedCapacity) < 0 {
-							planVol.Confirmed = false
+							planVol.CapacityConfirmed = false
 						}
 
 						// If new proposed capacity is greater than original capacity, set confirmed to False
 						if planVol.ProposedCapacity.Cmp(analyticNSVol.ProposedCapacity) > 0 {
-							planVol.Confirmed = false
+							planVol.CapacityConfirmed = false
 						}
 						planVol.ProposedCapacity = analyticNSVol.ProposedCapacity
 						plan.Spec.AddPv(*planVol)
@@ -586,7 +586,7 @@ func (r ReconcileMigPlan) processExtendedPVCapacity(plan *migapi.MigPlan, analyt
 func (r ReconcileMigPlan) validatePVSizeConfirmation(plan *migapi.MigPlan, migAnalytic *migapi.MigAnalytic) {
 	unconfirmedVols := []string{}
 	for _, planVol := range plan.Spec.PersistentVolumes.List {
-		if planVol.Confirmed == false && planVol.ProposedCapacity.Cmp(planVol.Capacity) > 1 {
+		if planVol.CapacityConfirmed == false && planVol.ProposedCapacity.Cmp(planVol.Capacity) > 1 {
 			unconfirmedVols = append(unconfirmedVols, planVol.Name)
 		}
 	}

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -562,7 +562,7 @@ func (r ReconcileMigPlan) processExtendedPVCapacity(plan *migapi.MigPlan, analyt
 				for _, analyticNSVol := range analyticNS.PersistentVolumes {
 					if planVol.PVC.Name == analyticNSVol.Name {
 
-						// If old proposed capacity is smaller than new one, set confirmed to False
+						// If plan volume capacity is less than analytic volume's proposed capacity, set confirmed to False
 						if planVol.Capacity.Cmp(analyticNSVol.ProposedCapacity) < 0 {
 							planVol.Confirmed = false
 						}
@@ -606,9 +606,9 @@ func (r ReconcileMigPlan) validatePVSizeConfirmation(plan *migapi.MigPlan, migAn
 		plan.Status.SetCondition(migapi.Condition{
 			Type:     UnConfirmedPV,
 			Status:   True,
-			Category: Critical,
+			Category: migapi.Warn,
 			Reason:   UnConfirmedPV,
-			Message:  fmt.Sprintf("Adjusted capacity is not confirmed for PVs [%s]", strings.Join(unconfirmedVols, ",")),
+			Message:  fmt.Sprintf("Migrating data of following volumes may result in failure either due to mismatch in their apparent and actual capacities or disk usage being close to 100 %% :  [%s]", strings.Join(unconfirmedVols, ",")),
 			Durable:  true,
 		})
 	} else {

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -572,6 +572,7 @@ func (r ReconcileMigPlan) processExtendedPVCapacity(plan *migapi.MigPlan, analyt
 							planVol.Confirmed = false
 						}
 						planVol.ProposedCapacity = analyticNSVol.ProposedCapacity
+						plan.Spec.AddPv(*planVol)
 						log.Info(fmt.Sprintf("Setting proposed capacity of %s/%s to %s",
 							planVol.PVC.Namespace, planVol.PVC.Name, planVol.ProposedCapacity.String()))
 					}

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -608,7 +608,7 @@ func (r ReconcileMigPlan) validatePVSizeConfirmation(plan *migapi.MigPlan, migAn
 			Status:   True,
 			Category: migapi.Warn,
 			Reason:   UnConfirmedPV,
-			Message:  fmt.Sprintf("Migrating data of following volumes may result in failure either due to mismatch in their apparent and actual capacities or disk usage being close to 100 %% :  [%s]", strings.Join(unconfirmedVols, ",")),
+			Message:  fmt.Sprintf("Migrating data of following volumes may result in a failure either due to mismatch in their apparent and actual capacities or disk usage being close to 100%% :  [%s]", strings.Join(unconfirmedVols, ",")),
 			Durable:  true,
 		})
 	} else {

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -73,6 +73,7 @@ const (
 	InvalidHookSAName                          = "InvalidHookSAName"
 	HookPhaseUnknown                           = "HookPhaseUnknown"
 	HookPhaseDuplicate                         = "HookPhaseDuplicate"
+	UnConfirmedPV                              = "UnConfirmedPV"
 )
 
 // Categories


### PR DESCRIPTION
This PR does the following:
- Introduces two new fields in `Migplan.Spec.PV` - `Confirmed` and `ProposedSize`
- Adds a new function `processExtendedPVCapacity` which maps PV size data of the `MigPlan` volumes to that of the volumes in `MigAnalytic` , checks if the proposed size is updated and confirmed in the `MigPlan` or not.
- Adds a new function `validatePVSizeConfirmation` which sets or deletes `UnconfirmedPV` condition on `MigPlan` based on the value of `Confirmed` flag specified per PV.
- Relays `EnxtendedPVAnalysisFailed` condition from `MigAnalytic` to `Migplan`

Depends on #955 

Please review 955 first
