### PR TITLE
Bug 1916554: failing if rsync client pods are stuck 

### DIFF
--- a/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
+++ b/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
@@ -31,17 +31,17 @@ type PVCToMigrate struct {
 
 // DirectVolumeMigrationSpec defines the desired state of DirectVolumeMigration
 type DirectVolumeMigrationSpec struct {
-	SrcMigClusterRef            *kapi.ObjectReference `json:"srcMigClusterRef,omitempty"`
-	DestMigClusterRef           *kapi.ObjectReference `json:"destMigClusterRef,omitempty"`
+	SrcMigClusterRef  *kapi.ObjectReference `json:"srcMigClusterRef,omitempty"`
+	DestMigClusterRef *kapi.ObjectReference `json:"destMigClusterRef,omitempty"`
 
 	//  Holds all the PVCs that are to be migrated with direct volume migration
-	PersistentVolumeClaims      []PVCToMigrate        `json:"persistentVolumeClaims,omitempty"`
+	PersistentVolumeClaims []PVCToMigrate `json:"persistentVolumeClaims,omitempty"`
 
 	// Set true to create namespaces in destination cluster
-	CreateDestinationNamespaces bool                  `json:"createDestinationNamespaces,omitempty"`
+	CreateDestinationNamespaces bool `json:"createDestinationNamespaces,omitempty"`
 
 	// Specifies if progress reporting CRs needs to be deleted or not
-	DeleteProgressReportingCRs  bool                  `json:"deleteProgressReportingCRs,omitempty"`
+	DeleteProgressReportingCRs bool `json:"deleteProgressReportingCRs,omitempty"`
 }
 
 // DirectVolumeMigrationStatus defines the observed state of DirectVolumeMigration
@@ -56,6 +56,7 @@ type DirectVolumeMigrationStatus struct {
 	SuccessfulPods   []*PodProgress `json:"successfulPods,omitempty"`
 	FailedPods       []*PodProgress `json:"failedPods,omitempty"`
 	RunningPods      []*PodProgress `json:"runningPods,omitempty"`
+	PendingPods      []*PodProgress `json:"pendingPods,omitempty"`
 }
 
 // TODO: Explore how to reliably get stunnel+rsync logs/status reported back to

--- a/pkg/controller/directvolumemigration/validation.go
+++ b/pkg/controller/directvolumemigration/validation.go
@@ -26,6 +26,7 @@ const (
 	RsyncRouteNotAdmitted           = "RsyncRouteNotAdmitted"
 	Running                         = "Running"
 	Failed                          = "Failed"
+	RsyncClientPodsPending          = "RsyncClientPodsPending"
 	Succeeded                       = "Succeeded"
 	SourceToDestinationNetworkError = "SourceToDestinationNetworkError"
 )


### PR DESCRIPTION
Failing the migration if Rsync client pods are stuck in "container creating" phase for more than 10 mins.