### PR TITLE
Adjust destination PVC size based on Intelligent PV resizing for Direct Volume Migration

### DIFF
--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -49,14 +49,14 @@ func (t *Task) createDestinationPVCs() error {
 
 		// Adjusting destination PVC storage size request
 		if matchingPV != nil {
-			if srcPVCRequest.Cmp(matchingPV.Capacity) > 0 {
-				if srcPVCRequest.Cmp(matchingPV.ProposedCapacity) > 0 {
-					newSpec.Resources.Requests[corev1.ResourceStorage] = srcPVCRequest
-				} else {
-					newSpec.Resources.Requests[corev1.ResourceStorage] = matchingPV.ProposedCapacity
-				}
-			} else {
+			// update src PVC capacity if matching PV's capacity is the maximum
+			if matchingPV.Capacity.Cmp(srcPVCRequest) > 0 && matchingPV.Capacity.Cmp(matchingPV.ProposedCapacity) > 0 {
 				newSpec.Resources.Requests[corev1.ResourceStorage] = matchingPV.Capacity
+			}
+
+			// update src PVC capacity if matching PV's proposed capacity is the maximum
+			if matchingPV.ProposedCapacity.Cmp(srcPVCRequest) > 0 && matchingPV.ProposedCapacity.Cmp(matchingPV.Capacity) > 0 {
+				newSpec.Resources.Requests[corev1.ResourceStorage] = matchingPV.ProposedCapacity
 			}
 		}
 

--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -96,9 +96,11 @@ func (t *Task) getDestinationPVCs() error {
 }
 
 func (t *Task) findMatchingPV(plan *migapi.MigPlan, pvcName string, pvcNamespace string) *migapi.PV {
+	matchedPV := &migapi.PV{}
 	for _, planVol := range plan.Spec.PersistentVolumes.List {
 		if planVol.PVC.Name == pvcName && planVol.PVC.Namespace == pvcNamespace {
-			return &planVol
+			matchedPV = &planVol
+			return matchedPV
 		}
 	}
 	return nil

--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -96,11 +96,10 @@ func (t *Task) getDestinationPVCs() error {
 }
 
 func (t *Task) findMatchingPV(plan *migapi.MigPlan, pvcName string, pvcNamespace string) *migapi.PV {
-	matchedPV := &migapi.PV{}
-	for _, planVol := range plan.Spec.PersistentVolumes.List {
+	for i := range plan.Spec.PersistentVolumes.List {
+		planVol := &plan.Spec.PersistentVolumes.List[i]
 		if planVol.PVC.Name == pvcName && planVol.PVC.Namespace == pvcNamespace {
-			matchedPV = &planVol
-			return matchedPV
+			return planVol
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR does the following:
- Adds a new function `findMatchingPV` which matches the src PVCs with that of the present in `MigPlan` and returns the PV.
- Adjusts the size of destination PVC by comparing the src PVC request, PV capacity and the proposed PV size.