### PR TITLE
Bug 1929853: Don't exit annotatePVs prematurely

### DIFF
--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -293,10 +293,6 @@ func (t *Task) annotatePods(client k8sclient.Client, itemsUpdated int) (int, Ser
 // The PvAccessModeAnnotation annotation is added to PVC as needed by the velero plugin.
 // The PvCopyMethodAnnotation annotation is added to PV and PVC as needed by the velero plugin.
 func (t *Task) annotatePVs(client k8sclient.Client, itemsUpdated int) (int, error) {
-	hasPVs, hasStagePVs := t.hasPVs()
-	if !hasPVs || !hasStagePVs {
-		return 0, nil
-	}
 	pvs := t.getStagePVs()
 	total := len(pvs.List)
 	for i, pv := range pvs.List {


### PR DESCRIPTION
This commit removes some logic which incorrectly tries to determine
when we don't need to annotate any PVs or PVCs. Instead, rely on
the returned pvs list. If there aren't any returned, then the
for loop won't iterate, and exit naturally.

This fixes a regression introduced in https://github.com/konveyor/mig-controller/pull/937