### PR TITLE
Add jaeger tracing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,9 +25,12 @@ require (
 	github.com/onsi/gomega v1.7.0
 	github.com/openshift/api v0.0.0-20200210091934-a0e53e94816b
 	github.com/openshift/library-go v0.0.0-20200521120150-e4959e210d3a
+	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.1.0
 	github.com/satori/go.uuid v1.2.0 // indirect
+	github.com/uber/jaeger-client-go v2.25.0+incompatible
+	github.com/uber/jaeger-lib v2.4.0+incompatible // indirect
 	github.com/vmware-tanzu/velero v1.4.2
 	go.opencensus.io v0.22.5 // indirect
 	go.uber.org/zap v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -557,6 +557,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mo
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240/go.mod h1:4riOwdj99Hd/q+iAcJZfNCsQQQMwURnZV6RL4WHYS5w=
 github.com/openshift/library-go v0.0.0-20200521120150-e4959e210d3a h1:gQ//Tpad7iV061CKTsouAE65aMgNArhuGqOeVgGqE+Q=
 github.com/openshift/library-go v0.0.0-20200521120150-e4959e210d3a/go.mod h1:HM1nXsKTup/9rYnmXdYbbN+8Ux8Xp39odoqZ4qvSyBo=
+github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
+github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913 h1:TnbXhKzrTOyuvWrjI8W6pcoI9XPbLHFXCdN2dtUw7Rw=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
@@ -657,6 +659,12 @@ github.com/tchap/go-patricia v2.3.0+incompatible h1:GkY4dP3cEfEASBPPkWd+AmjYxhmD
 github.com/tchap/go-patricia v2.3.0+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/uber/jaeger-client-go v1.6.0 h1:3+zLlq+4npI5fg8IsgAje3YsP7TcEdNzJScyqFIzxEQ=
+github.com/uber/jaeger-client-go v2.25.0+incompatible h1:IxcNZ7WRY1Y3G4poYlx24szfsn/3LvK9QHCq9oQw8+U=
+github.com/uber/jaeger-client-go v2.25.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
+github.com/uber/jaeger-lib v1.5.0 h1:OHbgr8l656Ub3Fw5k9SWnBfIEwvoHQ+W2y+Aa9D1Uyo=
+github.com/uber/jaeger-lib v2.4.0+incompatible h1:fY7QsGQWiCt8pajv4r7JEvmATdCVaWxXbjwyYwsNaLQ=
+github.com/uber/jaeger-lib v2.4.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=

--- a/pkg/apis/migration/v1alpha1/directimagemigration_types.go
+++ b/pkg/apis/migration/v1alpha1/directimagemigration_types.go
@@ -17,13 +17,16 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"strings"
 
+	liberr "github.com/konveyor/controller/pkg/error"
 	imagev1 "github.com/openshift/api/image/v1"
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -87,6 +90,20 @@ func (r *DirectImageMigration) GetSourceCluster(client k8sclient.Client) (*MigCl
 
 func (r *DirectImageMigration) GetDestinationCluster(client k8sclient.Client) (*MigCluster, error) {
 	return GetCluster(client, r.Spec.DestMigClusterRef)
+}
+
+// Get the MigMigration that owns this DirectImageMigration. If not owned, return nil.
+func (r *DirectImageMigration) GetOwner(client k8sclient.Client) (*MigMigration, error) {
+	owner := &MigMigration{}
+	ownerRefs := r.GetOwnerReferences()
+	if len(ownerRefs) > 0 {
+		ownerRef := types.NamespacedName{Name: ownerRefs[0].Name, Namespace: r.Namespace}
+		err := client.Get(context.TODO(), ownerRef, owner)
+		if err != nil {
+			return nil, liberr.Wrap(err)
+		}
+	}
+	return owner, nil
 }
 
 // GetSourceNamespaces get source namespaces without mapping

--- a/pkg/controller/directimagemigration/task.go
+++ b/pkg/controller/directimagemigration/task.go
@@ -24,6 +24,7 @@ import (
 	liberr "github.com/konveyor/controller/pkg/error"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/konveyor/mig-controller/pkg/compat"
+	"github.com/opentracing/opentracing-go"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -114,6 +115,9 @@ type Task struct {
 	Requeue   time.Duration
 	Itinerary Itinerary
 	Errors    []string
+
+	Tracer        opentracing.Tracer
+	ReconcileSpan opentracing.Span
 }
 
 func (t *Task) init() error {
@@ -135,6 +139,15 @@ func (t *Task) Run() error {
 
 	// Log "[RUN] <Phase Description>"
 	t.logRunHeader()
+
+	// Set up Jaeger span for task.Run
+	if t.ReconcileSpan != nil {
+		phaseSpan := t.Tracer.StartSpan(
+			"phase-"+t.Phase,
+			opentracing.ChildOf(t.ReconcileSpan.Context()),
+		)
+		defer phaseSpan.Finish()
+	}
 
 	// Run the current phase.
 	switch t.Phase {

--- a/pkg/controller/directimagemigration/task.go
+++ b/pkg/controller/directimagemigration/task.go
@@ -143,7 +143,7 @@ func (t *Task) Run() error {
 	// Set up Jaeger span for task.Run
 	if t.ReconcileSpan != nil {
 		phaseSpan := t.Tracer.StartSpan(
-			"phase-"+t.Phase,
+			"dim-phase-"+t.Phase,
 			opentracing.ChildOf(t.ReconcileSpan.Context()),
 		)
 		defer phaseSpan.Finish()

--- a/pkg/controller/directimagemigration/trace.go
+++ b/pkg/controller/directimagemigration/trace.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package directimagemigration
+
+import (
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/settings"
+	migtrace "github.com/konveyor/mig-controller/pkg/tracing"
+	"github.com/opentracing/opentracing-go"
+)
+
+func (r *ReconcileDirectImageMigration) initTracer(dim *migapi.DirectImageMigration) opentracing.Span {
+	// Exit if tracing disabled
+	if !settings.Settings.JaegerOpts.Enabled {
+		return nil
+	}
+	// Set tracer on reconciler if it's not already present.
+	// We will never close this, so the 'closer' is discarded.
+	if r.tracer == nil {
+		r.tracer, _ = migtrace.InitJaeger("DirectImageMigration")
+	}
+
+	// Get overall migration span
+	var migrationSpan opentracing.Span
+	ownerRefs := dim.GetOwnerReferences()
+	if len(ownerRefs) > 0 {
+		migrationUID := ownerRefs[0].UID
+		migrationSpan = migtrace.GetSpanForMigrationUID(string(migrationUID))
+		// Set up migrationSpan if doesn't exist yet
+		if migrationSpan == nil {
+			migrationSpan = r.tracer.StartSpan("migration-" + string(migrationUID))
+			migtrace.SetSpanForMigrationUID(string(migrationUID), migrationSpan)
+		}
+	}
+
+	// Get span for current reconcile
+	var reconcileSpan opentracing.Span
+	if migrationSpan != nil {
+		reconcileSpan = r.tracer.StartSpan(
+			"reconcile", opentracing.ChildOf(migrationSpan.Context()),
+		)
+	}
+
+	return reconcileSpan
+}

--- a/pkg/controller/directimagemigration/trace.go
+++ b/pkg/controller/directimagemigration/trace.go
@@ -43,11 +43,6 @@ func (r *ReconcileDirectImageMigration) initTracer(dim *migapi.DirectImageMigrat
 		}
 		migrationUID := string(ownerRef.UID)
 		migrationSpan = migtrace.GetSpanForMigrationUID(migrationUID)
-		// Set up migrationSpan if doesn't exist yet
-		if migrationSpan == nil {
-			migrationSpan = r.tracer.StartSpan("migration-" + migrationUID)
-			migtrace.SetSpanForMigrationUID(migrationUID, migrationSpan)
-		}
 	}
 	if migrationSpan == nil {
 		return nil
@@ -57,7 +52,7 @@ func (r *ReconcileDirectImageMigration) initTracer(dim *migapi.DirectImageMigrat
 	var reconcileSpan opentracing.Span
 	if migrationSpan != nil {
 		reconcileSpan = r.tracer.StartSpan(
-			"reconcile", opentracing.ChildOf(migrationSpan.Context()),
+			"dim-reconcile-"+dim.Name, opentracing.ChildOf(migrationSpan.Context()),
 		)
 	}
 

--- a/pkg/controller/directimagestreammigration/task.go
+++ b/pkg/controller/directimagestreammigration/task.go
@@ -134,7 +134,7 @@ func (t *Task) Run() error {
 	// Set up Jaeger span for task.Run
 	if t.ReconcileSpan != nil {
 		phaseSpan := t.Tracer.StartSpan(
-			"phase-"+t.Phase,
+			"dism-phase-"+t.Phase,
 			opentracing.ChildOf(t.ReconcileSpan.Context()),
 		)
 		defer phaseSpan.Finish()

--- a/pkg/controller/directimagestreammigration/trace.go
+++ b/pkg/controller/directimagestreammigration/trace.go
@@ -65,15 +65,14 @@ func (r *ReconcileDirectImageStreamMigration) initTracer(dism migapi.DirectImage
 	migrationUID := string(migration.GetUID())
 	migrationSpan := migtrace.GetSpanForMigrationUID(migrationUID)
 	if migrationSpan == nil {
-		migrationSpan = r.tracer.StartSpan("migration-" + migrationUID)
-		migtrace.SetSpanForMigrationUID(migrationUID, migrationSpan)
+		return nil, nil
 	}
 
 	// Get span for current reconcile
 	var reconcileSpan opentracing.Span
 	if migrationSpan != nil {
 		reconcileSpan = r.tracer.StartSpan(
-			"reconcile-"+dism.Name, opentracing.ChildOf(migrationSpan.Context()),
+			"dism-reconcile-"+dism.Name, opentracing.ChildOf(migrationSpan.Context()),
 		)
 	}
 

--- a/pkg/controller/directimagestreammigration/trace.go
+++ b/pkg/controller/directimagestreammigration/trace.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2020 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package directimagestreammigration
+
+import (
+	liberr "github.com/konveyor/controller/pkg/error"
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/errorutil"
+	"github.com/konveyor/mig-controller/pkg/settings"
+	migtrace "github.com/konveyor/mig-controller/pkg/tracing"
+	"github.com/opentracing/opentracing-go"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (r *ReconcileDirectImageStreamMigration) initTracer(dism migapi.DirectImageStreamMigration) (opentracing.Span, error) {
+	// Exit if tracing disabled
+	if !settings.Settings.JaegerOpts.Enabled {
+		return nil, nil
+	}
+
+	// Set tracer on reconciler if it's not already present.
+	// We will never close this, so the 'closer' is discarded.
+	if r.tracer == nil {
+		r.tracer, _ = migtrace.InitJaeger("DirectImageStreamMigration")
+	}
+
+	// Go from dism -> dim -> migration, use migration UID to get span
+	dim, err := dism.GetOwner(r)
+	if err != nil {
+		if errors.IsNotFound(errorutil.Unwrap(err)) {
+			return nil, nil
+		}
+		return nil, liberr.Wrap(err)
+	}
+	migration, err := dim.GetOwner(r)
+	if err != nil {
+		if errors.IsNotFound(errorutil.Unwrap(err)) {
+			return nil, nil
+		}
+		return nil, liberr.Wrap(err)
+	}
+
+	// Get overall migration span
+	migrationUID := string(migration.GetUID())
+	migrationSpan := migtrace.GetSpanForMigrationUID(migrationUID)
+	if migrationSpan == nil {
+		migrationSpan = r.tracer.StartSpan("migration-" + migrationUID)
+		migtrace.SetSpanForMigrationUID(migrationUID, migrationSpan)
+	}
+
+	// Get span for current reconcile
+	var reconcileSpan opentracing.Span
+	if migrationSpan != nil {
+		reconcileSpan = r.tracer.StartSpan(
+			"reconcile", opentracing.ChildOf(migrationSpan.Context()),
+		)
+	}
+
+	return reconcileSpan, nil
+}

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -196,7 +196,7 @@ func (t *Task) Run() error {
 	// Set up span for task.Run
 	if t.ReconcileSpan != nil {
 		phaseSpan := t.Tracer.StartSpan(
-			"phase-"+t.Phase,
+			"dvm-phase-"+t.Phase,
 			opentracing.ChildOf(t.ReconcileSpan.Context()),
 		)
 		defer phaseSpan.Finish()

--- a/pkg/controller/directvolumemigration/trace.go
+++ b/pkg/controller/directvolumemigration/trace.go
@@ -44,11 +44,6 @@ func (r *ReconcileDirectVolumeMigration) initTracer(direct *migapi.DirectVolumeM
 		}
 		migrationUID := ownerRef.UID
 		migrationSpan = migtrace.GetSpanForMigrationUID(string(migrationUID))
-		// Set up migrationSpan if doesn't exist yet
-		if migrationSpan == nil {
-			migrationSpan = r.tracer.StartSpan("migration-" + string(migrationUID))
-			migtrace.SetSpanForMigrationUID(string(migrationUID), migrationSpan)
-		}
 	}
 	if migrationSpan == nil {
 		return nil
@@ -58,7 +53,7 @@ func (r *ReconcileDirectVolumeMigration) initTracer(direct *migapi.DirectVolumeM
 	var reconcileSpan opentracing.Span
 	if migrationSpan != nil {
 		reconcileSpan = r.tracer.StartSpan(
-			"reconcile-"+direct.Name, opentracing.ChildOf(migrationSpan.Context()),
+			"dvm-reconcile-"+direct.Name, opentracing.ChildOf(migrationSpan.Context()),
 		)
 	}
 

--- a/pkg/controller/directvolumemigration/trace.go
+++ b/pkg/controller/directvolumemigration/trace.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package directvolumemigration
+
+import (
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/settings"
+	migtrace "github.com/konveyor/mig-controller/pkg/tracing"
+	"github.com/opentracing/opentracing-go"
+)
+
+func (r *ReconcileDirectVolumeMigration) initTracer(direct *migapi.DirectVolumeMigration) opentracing.Span {
+	// Exit if tracing disabled
+	if !settings.Settings.JaegerOpts.Enabled {
+		return nil
+	}
+
+	// Set tracer on reconciler if it's not already present.
+	// We will never close this, so the 'closer' is discarded.
+	if r.tracer == nil {
+		r.tracer, _ = migtrace.InitJaeger("DirectVolumeMigration")
+	}
+
+	// Get overall migration span
+	var migrationSpan opentracing.Span
+	ownerRefs := direct.GetOwnerReferences()
+	if len(ownerRefs) > 0 {
+		migrationUID := ownerRefs[0].UID
+		migrationSpan = migtrace.GetSpanForMigrationUID(string(migrationUID))
+		// Set up migrationSpan if doesn't exist yet
+		if migrationSpan == nil {
+			migrationSpan = r.tracer.StartSpan("migration-" + string(migrationUID))
+			migtrace.SetSpanForMigrationUID(string(migrationUID), migrationSpan)
+		}
+	}
+
+	// Get span for current reconcile
+	var reconcileSpan opentracing.Span
+	if migrationSpan != nil {
+		reconcileSpan = r.tracer.StartSpan(
+			"reconcile", opentracing.ChildOf(migrationSpan.Context()),
+		)
+	}
+
+	return reconcileSpan
+}

--- a/pkg/controller/directvolumemigrationprogress/trace.go
+++ b/pkg/controller/directvolumemigrationprogress/trace.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2020 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package directvolumemigrationprogress
+
+import (
+	"github.com/konveyor/mig-controller/pkg/errorutil"
+	"github.com/konveyor/mig-controller/pkg/settings"
+	migtrace "github.com/konveyor/mig-controller/pkg/tracing"
+	"github.com/opentracing/opentracing-go"
+
+	liberr "github.com/konveyor/controller/pkg/error"
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (r *ReconcileDirectVolumeMigrationProgress) initTracer(dvmp migapi.DirectVolumeMigrationProgress) (opentracing.Span, error) {
+	// Exit if tracing disabled
+	if !settings.Settings.JaegerOpts.Enabled {
+		return nil, nil
+	}
+
+	// Set tracer on reconciler if it's not already present.
+	// We will never close this, so the 'closer' is discarded.
+	if r.tracer == nil {
+		r.tracer, _ = migtrace.InitJaeger("DirectVolumeMigrationProgress")
+	}
+
+	// Go from dvmp -> dvm -> migration, use migration UID to get span
+	dvm, err := dvmp.GetOwner(r)
+	if err != nil {
+		if errors.IsNotFound(errorutil.Unwrap(err)) {
+			return nil, nil
+		}
+		return nil, liberr.Wrap(err)
+	}
+	migration, err := dvm.GetMigrationForDVM(r)
+	if err != nil {
+		if errors.IsNotFound(errorutil.Unwrap(err)) {
+			return nil, nil
+		}
+		return nil, liberr.Wrap(err)
+	}
+
+	// Get overall migration span
+	migrationUID := string(migration.GetUID())
+	migrationSpan := migtrace.GetSpanForMigrationUID(migrationUID)
+	if migrationSpan == nil {
+		migrationSpan = r.tracer.StartSpan("migration-" + migrationUID)
+		migtrace.SetSpanForMigrationUID(migrationUID, migrationSpan)
+	}
+
+	// Get span for current reconcile
+	var reconcileSpan opentracing.Span
+	if migrationSpan != nil {
+		reconcileSpan = r.tracer.StartSpan(
+			"reconcile", opentracing.ChildOf(migrationSpan.Context()),
+		)
+	}
+
+	return reconcileSpan, nil
+}

--- a/pkg/controller/directvolumemigrationprogress/trace.go
+++ b/pkg/controller/directvolumemigrationprogress/trace.go
@@ -65,15 +65,14 @@ func (r *ReconcileDirectVolumeMigrationProgress) initTracer(dvmp migapi.DirectVo
 	migrationUID := string(migration.GetUID())
 	migrationSpan := migtrace.GetSpanForMigrationUID(migrationUID)
 	if migrationSpan == nil {
-		migrationSpan = r.tracer.StartSpan("migration-" + migrationUID)
-		migtrace.SetSpanForMigrationUID(migrationUID, migrationSpan)
+		return nil, nil
 	}
 
 	// Get span for current reconcile
 	var reconcileSpan opentracing.Span
 	if migrationSpan != nil {
 		reconcileSpan = r.tracer.StartSpan(
-			"reconcile-"+dvmp.Name, opentracing.ChildOf(migrationSpan.Context()),
+			"dvmp-reconcile-"+dvmp.Name, opentracing.ChildOf(migrationSpan.Context()),
 		)
 	}
 

--- a/pkg/controller/directvolumemigrationprogress/trace.go
+++ b/pkg/controller/directvolumemigrationprogress/trace.go
@@ -73,7 +73,7 @@ func (r *ReconcileDirectVolumeMigrationProgress) initTracer(dvmp migapi.DirectVo
 	var reconcileSpan opentracing.Span
 	if migrationSpan != nil {
 		reconcileSpan = r.tracer.StartSpan(
-			"reconcile"+dvmp.Name, opentracing.ChildOf(migrationSpan.Context()),
+			"reconcile-"+dvmp.Name, opentracing.ChildOf(migrationSpan.Context()),
 		)
 	}
 

--- a/pkg/controller/migcluster/migcluster_controller.go
+++ b/pkg/controller/migcluster/migcluster_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Red Hat Inc.
+Copyright 2020 Red Hat Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@ package migcluster
 
 import (
 	"context"
-	"github.com/konveyor/mig-controller/pkg/errorutil"
 	"time"
+
+	"github.com/konveyor/mig-controller/pkg/errorutil"
 
 	"github.com/konveyor/controller/pkg/logging"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"

--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -238,7 +238,7 @@ func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.
 
 	// Migrate
 	if !migration.Status.HasBlockerCondition() {
-		requeueAfter, err = r.migrate(migration, migrationSpan)
+		requeueAfter, err = r.migrate(migration, reconcileSpan)
 		if err != nil {
 			log.Trace(err)
 			return reconcile.Result{Requeue: true}, nil

--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -164,7 +164,7 @@ func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.
 	}
 
 	// Get jaeger spans for migration and reconcile
-	migrationSpan, reconcileSpan := r.initTracer(migration)
+	_, reconcileSpan := r.initTracer(migration)
 	if reconcileSpan != nil {
 		defer reconcileSpan.Finish()
 	}

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -87,10 +87,8 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration, reconcil
 
 	// Completed
 	if task.Phase == Completed {
-		migrationSpan := migtrace.GetSpanForMigrationUID(string(migration.GetUID()))
-		if migrationSpan != nil {
-			migrationSpan.Finish()
-		}
+		// Close the Jaeger span for the migration
+		migtrace.CloseMigrationSpan(string(migration.GetUID()))
 
 		migration.Status.DeleteCondition(Running)
 		failed := task.Owner.Status.FindCondition(Failed)

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -329,7 +329,6 @@ type Task struct {
 
 	Tracer        opentracing.Tracer
 	ReconcileSpan opentracing.Span
-	MigrationSpan opentracing.Span
 }
 
 // Run the task.
@@ -346,7 +345,7 @@ func (t *Task) Run() error {
 	// Set up Jaeger span for task.Run
 	if t.ReconcileSpan != nil {
 		phaseSpan := t.Tracer.StartSpan(
-			"phase-"+t.Phase,
+			"migration-phase-"+t.Phase,
 			opentracing.ChildOf(t.ReconcileSpan.Context()),
 		)
 		defer phaseSpan.Finish()

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -12,6 +12,7 @@ import (
 	"github.com/konveyor/mig-controller/pkg/compat"
 	"github.com/konveyor/mig-controller/pkg/errorutil"
 	imagev1 "github.com/openshift/api/image/v1"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -325,6 +326,10 @@ type Task struct {
 	Itinerary       Itinerary
 	Errors          []string
 	Step            string
+
+	Tracer        opentracing.Tracer
+	ReconcileSpan opentracing.Span
+	MigrationSpan opentracing.Span
 }
 
 // Run the task.
@@ -334,9 +339,18 @@ type Task struct {
 //   3. Set the Requeue (as appropriate).
 //   4. Return.
 func (t *Task) Run() error {
-	// Set stage, phase, phase description, migplan name
+	// Set phase as logger K/V pair
 	t.Log = t.Log.WithValues("Phase", t.Phase)
 	t.Requeue = FastReQ
+
+	// Set up Jaeger span for task.Run
+	if t.ReconcileSpan != nil {
+		phaseSpan := t.Tracer.StartSpan(
+			"phase-"+t.Phase,
+			opentracing.ChildOf(t.ReconcileSpan.Context()),
+		)
+		defer phaseSpan.Finish()
+	}
 
 	err := t.init()
 	if err != nil {

--- a/pkg/controller/migmigration/trace.go
+++ b/pkg/controller/migmigration/trace.go
@@ -37,13 +37,11 @@ func (r *ReconcileMigMigration) initTracer(migration *migapi.MigMigration) (open
 		r.tracer, _ = migtrace.InitJaeger("MigMigration")
 	}
 	// Get migration span, add to global map if does not yet exist.
-	migrationSpan := migtrace.GetSpanForMigrationUID(string(migration.GetUID()))
+	migrationUID := string(migration.GetUID())
+	migrationSpan := migtrace.GetSpanForMigrationUID(migrationUID)
 	if migrationSpan == nil {
-		migrationSpan = r.tracer.StartSpan("migration-" + string(migration.UID))
-		migtrace.SetSpanForMigrationUID(string(migration.GetUID()), migrationSpan)
-	}
-	if migrationSpan == nil {
-		return nil, nil
+		migrationSpan = r.tracer.StartSpan("migration-" + migrationUID)
+		migtrace.SetSpanForMigrationUID(migrationUID, migrationSpan)
 	}
 	// Begin reconcile span
 	reconcileSpan := r.tracer.StartSpan(

--- a/pkg/controller/migmigration/trace.go
+++ b/pkg/controller/migmigration/trace.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migmigration
+
+import (
+	"github.com/opentracing/opentracing-go"
+
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/settings"
+	migtrace "github.com/konveyor/mig-controller/pkg/tracing"
+)
+
+func (r *ReconcileMigMigration) initTracer(migration *migapi.MigMigration) (opentracing.Span, opentracing.Span) {
+	// Exit if tracing disabled
+	if !settings.Settings.JaegerOpts.Enabled {
+		return nil, nil
+	}
+
+	// Set tracer on reconciler if it's not already present.
+	// We will never close this, so the 'closer' is discarded.
+	if r.tracer == nil {
+		r.tracer, _ = migtrace.InitJaeger("MigMigration")
+	}
+	// Get migration span, add to global map if does not yet exist.
+	migrationSpan := migtrace.GetSpanForMigrationUID(string(migration.GetUID()))
+	if migrationSpan == nil {
+		migrationSpan = r.tracer.StartSpan("migration-" + string(migration.UID))
+		migtrace.SetSpanForMigrationUID(string(migration.GetUID()), migrationSpan)
+	}
+	// Begin reconcile span
+	reconcileSpan := r.tracer.StartSpan(
+		"reconcile", opentracing.ChildOf(migrationSpan.Context()),
+	)
+
+	return migrationSpan, reconcileSpan
+}

--- a/pkg/controller/migmigration/trace.go
+++ b/pkg/controller/migmigration/trace.go
@@ -30,6 +30,10 @@ func (r *ReconcileMigMigration) initTracer(migration *migapi.MigMigration) (open
 	if !settings.Settings.JaegerOpts.Enabled {
 		return nil, nil
 	}
+	// Exit if migration is finished
+	if migration.Status.Phase == Completed {
+		return nil, nil
+	}
 
 	// Set tracer on reconciler if it's not already present.
 	// We will never close this, so the 'closer' is discarded.
@@ -45,7 +49,7 @@ func (r *ReconcileMigMigration) initTracer(migration *migapi.MigMigration) (open
 	}
 	// Begin reconcile span
 	reconcileSpan := r.tracer.StartSpan(
-		"reconcile-"+migration.Name, opentracing.ChildOf(migrationSpan.Context()),
+		"migration-reconcile-"+migration.Name, opentracing.ChildOf(migrationSpan.Context()),
 	)
 
 	return migrationSpan, reconcileSpan

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -35,9 +35,11 @@ type _Settings struct {
 	Discovery
 	Plan
 	DvmOpts
-	Roles      map[string]bool
-	ProxyVars  map[string]string
 	DisImgCopy bool
+	RsyncOpts
+	JaegerOpts
+	Roles     map[string]bool
+	ProxyVars map[string]string
 }
 
 // Load settings.
@@ -51,6 +53,10 @@ func (r *_Settings) Load() error {
 		return err
 	}
 	err = r.DvmOpts.Load()
+	if err != nil {
+		return err
+	}
+	err = r.JaegerOpts.Load()
 	if err != nil {
 		return err
 	}

--- a/pkg/settings/tracing.go
+++ b/pkg/settings/tracing.go
@@ -1,0 +1,19 @@
+package settings
+
+// Jaeger options
+const (
+	JaegerEnabled = "JAEGER_ENABLED"
+)
+
+// Jaeger Options
+//	Enabled: whether to emit jaeger spans from controller
+type JaegerOpts struct {
+	Enabled bool
+}
+
+// Load load rsync options
+func (r *JaegerOpts) Load() error {
+	var err error
+	r.Enabled = getEnvBool(JaegerEnabled, false)
+	return err
+}

--- a/pkg/tracing/trace.go
+++ b/pkg/tracing/trace.go
@@ -1,0 +1,72 @@
+package tracing
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	jaeger "github.com/uber/jaeger-client-go"
+	config "github.com/uber/jaeger-client-go/config"
+)
+
+var msmInstance MigrationSpanMap
+var createMsmMapOnce sync.Once
+
+// MigrationSpanMap provides a map between MigMigration UID and associated Jaeger span.
+// This is required so that all controllers can attach child spans to the correct
+// parent migmigration span for unified tracing of work done during migrations.
+type MigrationSpanMap struct {
+	mutex              sync.RWMutex
+	migrationUIDToSpan map[string]opentracing.Span
+}
+
+// InitJaeger returns an instance of Jaeger Tracer that samples 100% of traces and logs all spans to stdout.
+func InitJaeger(service string) (opentracing.Tracer, io.Closer) {
+	cfg := &config.Configuration{
+		ServiceName: service,
+		Sampler: &config.SamplerConfig{
+			Type:  "const",
+			Param: 1,
+		},
+		Reporter: &config.ReporterConfig{
+			LogSpans: true,
+		},
+	}
+	tracer, closer, err := cfg.NewTracer(config.Logger(jaeger.StdLogger))
+	if err != nil {
+		panic(fmt.Sprintf("ERROR: cannot init Jaeger: %v\n", err))
+	}
+	return tracer, closer
+}
+
+// SetSpanForMigrationUID sets the parent jaeger span for a migration
+func SetSpanForMigrationUID(migrationUID string, span opentracing.Span) {
+	// Init map if needed
+	createMsmMapOnce.Do(func() {
+		msmInstance = MigrationSpanMap{}
+		msmInstance.migrationUIDToSpan = make(map[string]opentracing.Span)
+	})
+	msmInstance.mutex.RLock()
+	defer msmInstance.mutex.RUnlock()
+
+	msmInstance.migrationUIDToSpan[migrationUID] = span
+	return
+}
+
+// GetSpanForMigrationUID returns the parent jaeger span for a migration
+func GetSpanForMigrationUID(migrationUID string) opentracing.Span {
+	// Init map if needed
+	createMsmMapOnce.Do(func() {
+		msmInstance = MigrationSpanMap{}
+		msmInstance.migrationUIDToSpan = make(map[string]opentracing.Span)
+	})
+	msmInstance.mutex.RLock()
+	defer msmInstance.mutex.RUnlock()
+
+	migrationSpan, ok := msmInstance.migrationUIDToSpan[migrationUID]
+	if !ok {
+		return nil
+	}
+	return migrationSpan
+}

--- a/pkg/tracing/trace.go
+++ b/pkg/tracing/trace.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package tracing
 
 import (


### PR DESCRIPTION
Todo

- [x] Add tracing to remaining controllers that are part of migration process (dim, dism, dvmp)
- [x] Hide tracing behind a env var flag since it's not needed all the time, and may have perf impact
- [x] Make sure that spans terminate when migration ends
- [x] Evaluate if sampling frequency is OK as-is (decided this isn't a problem for now since only use-case will be for dev perf evaluation, not enabling by default in user clusters)

Follow-on PR:
- [ ] Figure out how to deploy a jaeger collector inside OCP 4 cluster, see if there's an official way to do this without us needing to package

To test:

Start the jaeger collector:
```
docker run -d --name jaeger \
  -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
  -p 5775:5775/udp \
  -p 6831:6831/udp \
  -p 6832:6832/udp \
  -p 5778:5778 \
  -p 16686:16686 \
  -p 14268:14268 \
  -p 14250:14250 \
  -p 9411:9411 \
  jaegertracing/all-in-one:1.22
```
Navigate to http://localhost:16686

Run mig-controller with jaeger tracing enabled
```
JAEGER_ENABLED=true make run-fast
```


## Span hierarchy overview

```
- Parent MigMigration Span
  - Child MigMigration reconcile span
    - Child MigMigration phase execution span
  - Child DVM reconcile span
    - Child DVM phase execution span
  - Child DVMP reconcile span
  - Child DIM reconcile span
    - Child DIM phase execution span
  - Child DISM reconcile span
    - Child DISM phase execution span
```

![Jaeger ](https://user-images.githubusercontent.com/7576968/111396182-f0e8c300-8694-11eb-940e-a163090e61e7.png)

## Preview of Jaeger tracing showing interacting controllers
![image](https://user-images.githubusercontent.com/7576968/111397051-c0098d80-8696-11eb-8d74-436ea9e95639.png)


## Some useful phase timing statistics get for free by having Jaeger running while a migration runs

![image](https://user-images.githubusercontent.com/7576968/111813825-1867a780-88b0-11eb-867e-0ab8e8993238.png)
