### PR TITLE
Fix missing comment in some of the volumes

### DIFF
--- a/pkg/controller/miganalytic/volume_adjustment.go
+++ b/pkg/controller/miganalytic/volume_adjustment.go
@@ -244,6 +244,7 @@ func (pva *PersistentVolumeAdjuster) Run(pvNodeMap map[string][]MigAnalyticPersi
 		statusFieldUpdate := migapi.MigAnalyticPersistentVolumeClaim{
 			Name:              originalData.Name,
 			RequestedCapacity: originalData.RequestedCapacity,
+			Comment:           VolumeAdjustmentNoOp,
 		}
 		if pvDfOutput.IsError {
 			erroredPVs = append(erroredPVs, &pvDfOutputs[i])

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -597,7 +597,7 @@ func (r ReconcileMigPlan) generatePVResizeConditions(pvResizingRequiredVolumes [
 	// remove pv analysis related conditions as we are here processing pvs
 	plan.Status.DeleteCondition(PvUsageAnalysisFailed)
 	if len(pvResizingRequiredVolumes) > 0 {
-		if !Settings.DvmOpts.EnablePVResizing || plan.Spec.IndirectVolumeMigration {
+		if !Settings.DvmOpts.EnablePVResizing {
 			plan.Status.SetCondition(migapi.Condition{
 				Type:     PvCapacityAdjustmentRequired,
 				Status:   True,


### PR DESCRIPTION
I found out a glitch when recording demo. This fix ensures that all volumes (failed & succeeded) have PV comment. Also, theres a bug in how UI determines indirect image migration flag which is making wrong warning displayed in validation page sometimes. This fix also solves that temporarily until the actual UI bug is fixed. 