### PR TITLE
Delete stale restores instead of backups

### DIFF
--- a/pkg/controller/migmigration/backup.go
+++ b/pkg/controller/migmigration/backup.go
@@ -493,7 +493,7 @@ func (t *Task) deleteStaleVeleroCRs() error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-	nRestoresDeleted, nInProgressRestoresDeleted, err := t.deleteStaleBackupsOnCluster(srcCluster)
+	nRestoresDeleted, nInProgressRestoresDeleted, err := t.deleteStaleRestoresOnCluster(srcCluster)
 	if err != nil {
 		return liberr.Wrap(err)
 	}


### PR DESCRIPTION
I committed a typo in the Velero cleanup routine. This fixes it.

Original PR: https://github.com/konveyor/mig-controller/pull/743