### PR TITLE
Bug 1926128: Dvm proxy support

### DIFF
--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -336,7 +336,7 @@ func (r *MigPlan) BuildRegistryDeployment(storage *MigStorage, proxySecret *kapi
 
 // Get registry proxy secret for registry DC
 // Returns nil if secret isn't found or no configuration exists
-func (r *MigPlan) GetRegistryProxySecret(client k8sclient.Client) (*kapi.Secret, error) {
+func (r *MigPlan) GetProxySecret(client k8sclient.Client) (*kapi.Secret, error) {
 	list := kapi.SecretList{}
 	selector := k8sLabels.SelectorFromSet(map[string]string{
 		"migration-proxy-config": "true",

--- a/pkg/controller/directvolumemigration/stunnel_test.go
+++ b/pkg/controller/directvolumemigration/stunnel_test.go
@@ -1,0 +1,120 @@
+package directvolumemigration
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/settings"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var justHostProxy = "https://just-host"
+
+var mangledHostProxy = "https://@valid"
+
+var validProxySecret = "https://user:pass@ip:1111"
+
+var basicAuthWithSpecialChars = "https://user:!:pass@ip:1111"
+
+var invalidProxy = "https://220.22.23.265.253.255:err"
+
+func TestTask_generateStunnelProxyConfig(t *testing.T) {
+	type fields struct {
+		Log              logr.Logger
+		Client           k8sclient.Client
+		Owner            *migapi.DirectVolumeMigration
+		SSHKeys          *sshKeys
+		RsyncRoutes      map[string]string
+		Phase            string
+		PhaseDescription string
+		PlanResources    *migapi.PlanResources
+		MigrationUID     string
+		Requeue          time.Duration
+		Itinerary        Itinerary
+		Errors           []string
+	}
+	tests := []struct {
+		name        string
+		fields      fields
+		proxyString string
+		want        stunnelProxyConfig
+		wantErr     bool
+	}{
+		{
+			name:        "when given a proxy without username/pass, should return proxy config with host without username/pass",
+			proxyString: justHostProxy,
+			want: stunnelProxyConfig{
+				ProxyHost: "just-host",
+			},
+			fields: fields{
+				Log: log,
+			},
+			wantErr: false,
+		},
+		{
+			name:        "when given a proxy with mangled host string, should return proxy config with host without username/pass",
+			proxyString: mangledHostProxy,
+			want: stunnelProxyConfig{
+				ProxyHost: "valid",
+			},
+			fields: fields{
+				Log: log,
+			},
+			wantErr: false,
+		},
+		{
+			name: "when given a valid proxy with username/pass, should proxy config with username/pass",
+			want: stunnelProxyConfig{
+				ProxyHost:     "ip:1111",
+				ProxyUsername: "user",
+				ProxyPassword: "pass",
+			},
+			fields: fields{
+				Log: log,
+			},
+			proxyString: validProxySecret,
+			wantErr:     false,
+		},
+		{
+			name: "when given a proxy with username/pass containing special chars, should proxy config with username/pass",
+			want: stunnelProxyConfig{
+				ProxyHost:     "ip:1111",
+				ProxyUsername: "user",
+				ProxyPassword: "!:pass",
+			},
+			fields: fields{
+				Log: log,
+			},
+			proxyString: basicAuthWithSpecialChars,
+			wantErr:     false,
+		},
+		{
+			name: "when given a proxy with invalid host/port, should return err",
+			want: stunnelProxyConfig{},
+			fields: fields{
+				Log: log,
+			},
+			proxyString: invalidProxy,
+			wantErr:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &Task{
+				Log: tt.fields.Log,
+			}
+			settings.Settings.StunnelTCPProxy = tt.proxyString
+			got, err := task.generateStunnelProxyConfig()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Task.generateStunnelProxyConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Task.generateStunnelProxyConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/migmigration/registry.go
+++ b/pkg/controller/migmigration/registry.go
@@ -233,7 +233,7 @@ func (t *Task) ensureRegistryDeployment(client k8sclient.Client, secret *kapi.Se
 	dirName := storage.GetName() + "-registry-" + string(storage.UID)
 
 	// Get Proxy Env Vars for DC
-	proxySecret, err := plan.GetRegistryProxySecret(client)
+	proxySecret, err := plan.GetProxySecret(client)
 	if err != nil {
 		return liberr.Wrap(err)
 	}

--- a/pkg/settings/dvm.go
+++ b/pkg/settings/dvm.go
@@ -7,14 +7,17 @@ import (
 
 // DVM options
 const (
-	RsyncOptBwLimit   = "RSYNC_OPT_BWLIMIT"
-	RsyncOptPartial   = "RSYNC_OPT_PARTIAL"
-	RsyncOptArchive   = "RSYNC_OPT_ARCHIVE"
-	RsyncOptDelete    = "RSYNC_OPT_DELETE"
-	RsyncOptHardLinks = "RSYNC_OPT_HARDLINKS"
-	RsyncOptInfo      = "RSYNC_OPT_INFO"
-	RsyncOptExtras    = "RSYNC_OPT_EXTRAS"
-	EnablePVResizing  = "ENABLE_DVM_PV_RESIZING"
+	RsyncOptBwLimit         = "RSYNC_OPT_BWLIMIT"
+	RsyncOptPartial         = "RSYNC_OPT_PARTIAL"
+	RsyncOptArchive         = "RSYNC_OPT_ARCHIVE"
+	RsyncOptDelete          = "RSYNC_OPT_DELETE"
+	RsyncOptHardLinks       = "RSYNC_OPT_HARDLINKS"
+	RsyncOptInfo            = "RSYNC_OPT_INFO"
+	RsyncOptExtras          = "RSYNC_OPT_EXTRAS"
+	EnablePVResizing        = "ENABLE_DVM_PV_RESIZING"
+	TCPProxyKey             = "STUNNEL_TCP_PROXY"
+	StunnelVerifyCAKey      = "STUNNEL_VERIFY_CA"
+	StunnelVerifyCALevelKey = "STUNNEL_VERIFY_CA_LEVEL"
 )
 
 // RsyncOpts Rsync Options
@@ -37,7 +40,10 @@ type RsyncOpts struct {
 // DvmOpts DVM settings
 type DvmOpts struct {
 	RsyncOpts
-	EnablePVResizing bool
+	EnablePVResizing     bool
+	StunnelTCPProxy      string
+	StunnelVerifyCA      bool
+	StunnelVerifyCALevel string
 }
 
 // Load load rsync options
@@ -66,6 +72,12 @@ func (r *RsyncOpts) Load() error {
 func (r *DvmOpts) Load() error {
 	var err error
 	r.EnablePVResizing = getEnvBool(EnablePVResizing, false)
+	r.StunnelTCPProxy = os.Getenv(TCPProxyKey)
+	r.StunnelVerifyCA = getEnvBool(StunnelVerifyCAKey, true)
+	r.StunnelVerifyCALevel = os.Getenv(StunnelVerifyCALevelKey)
+	if r.StunnelVerifyCALevel == "" {
+		r.StunnelVerifyCALevel = "2"
+	}
 	err = r.RsyncOpts.Load()
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR adds support for using TCP_PROXY in Stunnel enabling Rsync work behind a TCP proxy.

It also adds new variables to allow configuring CA verification in Stunnel. 

Please also review: https://github.com/konveyor/mig-operator/pull/599