### PR TITLE
Bug 1925065: raise a warning when rsync pod fails and fail dvmp

### DIFF
--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -1170,6 +1170,7 @@ func (t *Task) haveRsyncClientPodsCompletedOrFailed() (bool, bool, error) {
 	t.Owner.Status.RunningPods = []*migapi.PodProgress{}
 	t.Owner.Status.FailedPods = []*migapi.PodProgress{}
 	t.Owner.Status.SuccessfulPods = []*migapi.PodProgress{}
+	t.Owner.Status.PendingPods = []*migapi.PodProgress{}
 	var pendingPods []string
 	pvcMap := t.getPVCNamespaceMap()
 	for ns, vols := range pvcMap {
@@ -1245,6 +1246,7 @@ func hasAllRsyncClientPodsTimedOut(pvcMap map[string][]pvcMapElement, client k8s
 				return false, err
 			}
 			if dvmp.Status.PodPhase != corev1.PodFailed ||
+				dvmp.Status.ContainerElapsedTime == nil ||
 				(dvmp.Status.ContainerElapsedTime != nil &&
 					dvmp.Status.ContainerElapsedTime.Duration.Round(time.Second).Seconds() != float64(DefaultStunnelTimeout)) {
 				return false, nil
@@ -1267,6 +1269,7 @@ func isAllRsyncClientPodsNoRouteToHost(pvcMap map[string][]pvcMapElement, client
 			}
 
 			if dvmp.Status.PodPhase != corev1.PodFailed ||
+				dvmp.Status.ContainerElapsedTime == nil ||
 				(dvmp.Status.ContainerElapsedTime != nil &&
 					dvmp.Status.ContainerElapsedTime.Duration.Seconds() > float64(5)) || *dvmp.Status.ExitCode != int32(10) || !strings.Contains(dvmp.Status.LogMessage, "No route to host") {
 				return false, nil

--- a/pkg/controller/directvolumemigration/rsync_test.go
+++ b/pkg/controller/directvolumemigration/rsync_test.go
@@ -173,6 +173,36 @@ func Test_hasAllRsyncClientPodsTimedOut(t *testing.T) {
 			want:    true,
 			wantErr: false,
 		},
+		{
+			name: "both rsync client pods failed with nil elapsad time",
+			args: args{
+				pvcMap: map[string][]pvcMapElement{"foo": {{
+					Name:   "pvc-0",
+					Verify: false,
+				}, {
+					Name:   "pvc-1",
+					Verify: false,
+				}}},
+				client: fake.NewFakeClient(&migapi.DirectVolumeMigrationProgress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      getMD5Hash("test" + "pvc-0" + "foo"),
+						Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec:   migapi.DirectVolumeMigrationProgressSpec{},
+					Status: migapi.DirectVolumeMigrationProgressStatus{PodPhase: corev1.PodFailed},
+				}, &migapi.DirectVolumeMigrationProgress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      getMD5Hash("test" + "pvc-1" + "foo"),
+						Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec:   migapi.DirectVolumeMigrationProgressSpec{},
+					Status: migapi.DirectVolumeMigrationProgressStatus{PodPhase: corev1.PodFailed},
+				}),
+				dvmName: "test",
+			},
+			want:    false,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -340,6 +370,36 @@ func Test_isAllRsyncClientPodsNoRouteToHost(t *testing.T) {
 							"      rsync: failed to connect to 172.30.12.121 (172.30.12.121): No route to host (113)",
 							"rsync, error: error in socket IO (code 10) at clientserver.c(127) [sender = 3.1.3]"}, "\n"),
 					},
+				}),
+				dvmName: "test",
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "both rsync client pods failed with nil elapsad time",
+			args: args{
+				pvcMap: map[string][]pvcMapElement{"foo": {{
+					Name:   "pvc-0",
+					Verify: false,
+				}, {
+					Name:   "pvc-1",
+					Verify: false,
+				}}},
+				client: fake.NewFakeClient(&migapi.DirectVolumeMigrationProgress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      getMD5Hash("test" + "pvc-0" + "foo"),
+						Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec:   migapi.DirectVolumeMigrationProgressSpec{},
+					Status: migapi.DirectVolumeMigrationProgressStatus{PodPhase: corev1.PodFailed},
+				}, &migapi.DirectVolumeMigrationProgress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      getMD5Hash("test" + "pvc-1" + "foo"),
+						Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec:   migapi.DirectVolumeMigrationProgressSpec{},
+					Status: migapi.DirectVolumeMigrationProgressStatus{PodPhase: corev1.PodFailed},
 				}),
 				dvmName: "test",
 			},


### PR DESCRIPTION
This PR raises a warning if rsync client pod are in failed state with no `containerStatus`.