### PR TITLE
Bug 1936549: Fix problem with dest cluster configmap missing not triggering version warning

### DIFF
--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -534,7 +534,7 @@ func (r ReconcileMigPlan) validateOperatorVersions(plan *migapi.MigPlan) error {
 	srcHasMismatch := srcCluster.Status.HasAnyCondition(
 		migcluster.OperatorVersionMismatch,
 		migcluster.ClusterOperatorVersionNotFound)
-	destHasMismatch := destCluster.Status.HasCondition(
+	destHasMismatch := destCluster.Status.HasAnyCondition(
 		migcluster.OperatorVersionMismatch,
 		migcluster.ClusterOperatorVersionNotFound)
 	if srcHasMismatch || destHasMismatch {


### PR DESCRIPTION
Reported by Sergio, migplan wasn't showing warning when host cluster was 3.x