### PR TITLE
Make MigPlan PV field optional to prevent breaking on upgrades

### DIFF
--- a/config/crds/migration.openshift.io_migplans.yaml
+++ b/config/crds/migration.openshift.io_migplans.yaml
@@ -282,7 +282,6 @@ spec:
                     - copyMethods
                     type: object
                 required:
-                - capacityConfirmed
                 - selection
                 - supported
                 type: object

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -724,7 +724,7 @@ type PV struct {
 	PVC               PVC                   `json:"pvc,omitempty"`
 	NFS               *kapi.NFSVolumeSource `json:"-"`
 	staged            bool                  `json:"-"`
-	CapacityConfirmed bool                  `json:"capacityConfirmed"`
+	CapacityConfirmed bool                  `json:"capacityConfirmed,omitempty"`
 	ProposedCapacity  resource.Quantity     `json:"proposedCapacity,omitempty"`
 }
 


### PR DESCRIPTION
The `CapacityConfirmed` field introduced in PV resize work broke upgrade path when existing _MigPlan_ CRs with Persistent Volumes existed in a cluster. This PR marks the CapacityConfirmed field as optional. 