### PR TITLE
Fix panic during "validateOperatorVersions" and "validateNamespaceLengthForDVM" from running controller with bad destClusterRef on MigPlan

### DIFF
--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -281,7 +281,8 @@ func (r ReconcileMigPlan) validateNamespaces(plan *migapi.MigPlan) error {
 func (r ReconcileMigPlan) validateNamespaceLengthForDVM(plan *migapi.MigPlan) []string {
 	items := []string{}
 	// If validation for destination cluster ref failed, we can't check this
-	if plan.Status.HasAnyCondition(InvalidDestinationClusterRef) {
+	if plan.Status.HasAnyCondition(
+		InvalidDestinationClusterRef, InvalidDestinationCluster) {
 		return items
 	}
 	// This is not relevant if the plan is not running DVM

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -526,8 +526,7 @@ func (r ReconcileMigPlan) validateDestinationCluster(plan *migapi.MigPlan) error
 func (r ReconcileMigPlan) validateOperatorVersions(plan *migapi.MigPlan) error {
 	if plan.Status.HasAnyCondition(
 		InvalidDestinationClusterRef, InvalidDestinationCluster,
-		InvalidSourceClusterRef, InvalidSourceClusterRef,
-	) {
+		InvalidSourceClusterRef, InvalidSourceClusterRef) {
 		return nil
 	}
 	destRef := plan.Spec.DestMigClusterRef

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -280,6 +280,10 @@ func (r ReconcileMigPlan) validateNamespaces(plan *migapi.MigPlan) error {
 
 func (r ReconcileMigPlan) validateNamespaceLengthForDVM(plan *migapi.MigPlan) []string {
 	items := []string{}
+	// If validation for destination cluster ref failed, we can't check this
+	if plan.Status.HasAnyCondition(InvalidDestinationClusterRef) {
+		return items
+	}
 	// This is not relevant if the plan is not running DVM
 	// This validation is also not needed if the user has supplied the route
 	// subdomain for the destination cluster
@@ -519,6 +523,12 @@ func (r ReconcileMigPlan) validateDestinationCluster(plan *migapi.MigPlan) error
 }
 
 func (r ReconcileMigPlan) validateOperatorVersions(plan *migapi.MigPlan) error {
+	if plan.Status.HasAnyCondition(
+		InvalidDestinationClusterRef, InvalidDestinationCluster,
+		InvalidSourceClusterRef, InvalidSourceClusterRef,
+	) {
+		return nil
+	}
 	destRef := plan.Spec.DestMigClusterRef
 	srcRef := plan.Spec.SrcMigClusterRef
 


### PR DESCRIPTION
Fixes #999 