### PR TITLE
resticting capabilities in pod scc field

### DIFF
--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -600,6 +600,9 @@ func (t *Task) createRsyncTransferPods() error {
 							Privileged:             &isRsyncPrivileged,
 							RunAsUser:              &runAsUser,
 							ReadOnlyRootFilesystem: &trueBool,
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"MKNOD", "SETPCAP"},
+							},
 						},
 						Resources: corev1.ResourceRequirements{
 							Limits:   limits,
@@ -632,6 +635,9 @@ func (t *Task) createRsyncTransferPods() error {
 							Privileged:             &isRsyncPrivileged,
 							RunAsUser:              &runAsUser,
 							ReadOnlyRootFilesystem: &trueBool,
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"MKNOD", "SETPCAP"},
+							},
 						},
 					},
 				},
@@ -1113,6 +1119,9 @@ func (t *Task) createRsyncClientPods() error {
 					Privileged:             &isPrivileged,
 					RunAsUser:              &runAsUser,
 					ReadOnlyRootFilesystem: &trueBool,
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{"MKNOD", "SETPCAP"},
+					},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits:   limits,

--- a/pkg/controller/directvolumemigration/stunnel.go
+++ b/pkg/controller/directvolumemigration/stunnel.go
@@ -525,6 +525,9 @@ func (t *Task) createStunnelClientPods() error {
 				Privileged:             &isRsyncPrivileged,
 				RunAsUser:              &runAsUser,
 				ReadOnlyRootFilesystem: &trueBool,
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"MKNOD", "SETPCAP"},
+				},
 			},
 			Resources: corev1.ResourceRequirements{
 				Limits:   limits,


### PR DESCRIPTION
Adding in drop capabilities list of `pod.container.SCC` to make sure openshift always picks `rsync-anyuid`

Below is the result of file permissions after migration with modified `rsync-anyuid`

```
destination 

$ ls -la /data/db1
total 364
drwxrwxrwx. 5 root       root  8192 Mar 24 15:06 .
drwxr-xr-x. 3 root       root    17 Mar 24 15:06 ..
-rw-r--r--. 1 1000990002 root 18502 Mar 24 15:03 1.html
-rw-r--r--. 1 1000990004 root 18473 Mar 24 15:03 2.html
-


source 

$ ls -l data/db1
total 340
-rw-r--r--. 1 1000990002 root 25984 Mar 24 15:07 1.html
-rw-r--r--. 1 1000990004 root 25955 Mar 24 15:07 2.html
```

The uids on the files are getting preserved along with permissions.