### PR TITLE
Add demo video link / screenshot to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ mig-controller is installed by [mig-operator](https://github.com/konveyor/mig-op
 
 ## Demo Video 
 
-This [video](https://www.youtube.com/watch?v=OaRp4_j9F_A) shows a CLI driven migration of a [rocket-chat](https://github.com/konveyor/mig-demo-apps/tree/master/apps/rocket-chat) demo app and associated PersistentVolume data.
+This [video](https://www.youtube.com/watch?v=OaRp4_j9F_A) shows a CLI driven migration of a [rocket-chat](https://github.com/konveyor/mig-demo-apps/tree/master/apps/rocket-chat) demo app and associated PersistentVolume data from OpenShift 3.11 to OpenShift 4.6.
 
 [![Watch the demo](https://user-images.githubusercontent.com/7576968/111339370-16061300-864e-11eb-8ae5-37a250c65f08.png)](https://www.youtube.com/watch?v=OaRp4_j9F_A)
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 ## Installing
 mig-controller is installed by [mig-operator](https://github.com/konveyor/mig-operator).
 
+## Demo Video
+[![Watch the demo](https://user-images.githubusercontent.com/7576968/111339370-16061300-864e-11eb-8ae5-37a250c65f08.png)](https://www.youtube.com/watch?v=d6w25kvQd3o)
+
 ## Development
 
 [HACKING.md](./HACKING.md) has instructions for:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ mig-controller is installed by [mig-operator](https://github.com/konveyor/mig-op
 
 ## Demo Video 
 
-The linked video shows a CLI driven migration of a [rocket-chat](https://github.com/konveyor/mig-demo-apps/tree/master/apps/rocket-chat) demo app and associated PersistentVolume data.
+This [video](https://www.youtube.com/watch?v=OaRp4_j9F_A) shows a CLI driven migration of a [rocket-chat](https://github.com/konveyor/mig-demo-apps/tree/master/apps/rocket-chat) demo app and associated PersistentVolume data.
 
 [![Watch the demo](https://user-images.githubusercontent.com/7576968/111339370-16061300-864e-11eb-8ae5-37a250c65f08.png)](https://www.youtube.com/watch?v=OaRp4_j9F_A)
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 ## Installing
 mig-controller is installed by [mig-operator](https://github.com/konveyor/mig-operator).
 
-## Demo Video
-[![Watch the demo](https://user-images.githubusercontent.com/7576968/111339370-16061300-864e-11eb-8ae5-37a250c65f08.png)](https://www.youtube.com/watch?v=d6w25kvQd3o)
+## Demo Video 
+
+The linked video shows a CLI driven migration of a [rocket-chat](https://github.com/konveyor/mig-demo-apps/tree/master/apps/rocket-chat) demo app and associated PersistentVolume data.
+
+[![Watch the demo](https://user-images.githubusercontent.com/7576968/111339370-16061300-864e-11eb-8ae5-37a250c65f08.png)](https://www.youtube.com/watch?v=OaRp4_j9F_A)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ mig-controller is installed by [mig-operator](https://github.com/konveyor/mig-op
 
 ## Demo Video 
 
-This [video](https://www.youtube.com/watch?v=OaRp4_j9F_A) shows a CLI driven migration of a [rocket-chat](https://github.com/konveyor/mig-demo-apps/tree/master/apps/rocket-chat) demo app and associated PersistentVolume data from OpenShift 3.11 to OpenShift 4.6.
+[This video](https://www.youtube.com/watch?v=OaRp4_j9F_A) shows a CLI driven migration of a [rocket-chat](https://github.com/konveyor/mig-demo-apps/tree/master/apps/rocket-chat) app and associated PersistentVolume data from OpenShift 3.11 => OpenShift 4.6.
 
 [![Watch the demo](https://user-images.githubusercontent.com/7576968/111339370-16061300-864e-11eb-8ae5-37a250c65f08.png)](https://www.youtube.com/watch?v=OaRp4_j9F_A)
 


### PR DESCRIPTION
I recorded a 1 minute demo video of a CLI migration to show the gist of the role mig-controller plays in OpenShift migrations. I think this could be cool to have something visual on our frontpage README.

![image](https://user-images.githubusercontent.com/7576968/111358187-743bf180-8660-11eb-91c5-08982a31e110.png)
