### PR TITLE
Add mig-log-reader labels to Pods created by DVM

### DIFF
--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -63,7 +63,7 @@ const (
 	DirectVolumeMigrationStunnel            = "stunnel"
 	MigratedByPlanLabel                     = "migration.openshift.io/migrated-by-migplan"      // (migplan UID)
 	MigratedByMigrationLabel                = "migration.openshift.io/migrated-by-migmigration" // (migmigration UID)
-
+	PartOfLabel                             = "openshift-migration"
 )
 
 // Flags
@@ -603,6 +603,7 @@ func (t *Task) buildDVMLabels() map[string]string {
 
 	dvmLabels["app"] = DirectVolumeMigrationRsyncTransfer
 	dvmLabels["owner"] = DirectVolumeMigration
+	dvmLabels["app.kubernetes.io/part-of"] = PartOfLabel
 
 	return dvmLabels
 }


### PR DESCRIPTION
Related to https://github.com/konveyor/mig-log-reader/issues/3

Merge at same time with 

- https://github.com/konveyor/mig-controller/pull/1003
- https://github.com/konveyor/mig-operator/pull/613
- https://github.com/konveyor/mig-log-reader/pull/8