### PR TITLE
Log phase completion times for perf profiling

### DIFF
--- a/pkg/controller/directimagemigration/description.go
+++ b/pkg/controller/directimagemigration/description.go
@@ -18,11 +18,12 @@ package directimagemigration
 
 // PhaseDescriptions are human readable strings that describe a phase
 var PhaseDescriptions = map[string]string{
-	Started:                           "Migration started.",
-	MigrationFailed:                   "Migration failed.",
+	Prepare:                           "Preparing for Direct Image Migration",
+	Started:                           "Direct Image Migration started.",
+	MigrationFailed:                   "Direct Image Migration failed.",
 	CreateDestinationNamespaces:       "Creating target cluster namespaces for ImageStreams to be migrated into.",
 	ListImageStreams:                  "Searching source cluster namespaces for ImageStreams to be migrated.",
 	CreateDirectImageStreamMigrations: "Launching DirectImageStreamMigrations for all discovered ImageStreams.",
 	WaitingForDirectImageStreamMigrationsToComplete: "Waiting for all DirectImageStreamMigrations to complete.",
-	Completed: "Migration completed.",
+	Completed: "Direct Image Migration completed.",
 }

--- a/pkg/controller/directimagemigration/task.go
+++ b/pkg/controller/directimagemigration/task.go
@@ -207,6 +207,15 @@ func (t *Task) Run() error {
 
 // Advance the task to the next phase.
 func (t *Task) next() error {
+	// Write time taken to complete phase
+	t.Owner.Status.StageCondition(migapi.Running)
+	cond := t.Owner.Status.FindCondition(migapi.Running)
+	if cond != nil {
+		now := time.Now().UTC()
+		elapsed := now.Sub(cond.LastTransitionTime.Time.UTC())
+		t.Log.Info("Phase completed", "Phase_Elapsed", elapsed)
+	}
+
 	current := -1
 	for i, step := range t.Itinerary.Steps {
 		if step.phase != t.Phase {

--- a/pkg/controller/directimagemigration/task.go
+++ b/pkg/controller/directimagemigration/task.go
@@ -215,7 +215,7 @@ func (t *Task) next() error {
 	if cond != nil {
 		now := time.Now().UTC()
 		elapsed := now.Sub(cond.LastTransitionTime.Time.UTC())
-		t.Log.Info("Phase completed", "Elapsed", elapsed)
+		t.Log.Info("[NEXT]", "Elapsed", elapsed)
 	}
 
 	current := -1

--- a/pkg/controller/directimagemigration/task.go
+++ b/pkg/controller/directimagemigration/task.go
@@ -214,7 +214,7 @@ func (t *Task) next() error {
 	cond := t.Owner.Status.FindCondition(migapi.Running)
 	if cond != nil {
 		elapsed := time.Since(cond.LastTransitionTime.Time)
-		t.Log.Info("Phase completed", "Elapsed", elapsed)
+		t.Log.Info("Phase completed", "phaseElapsed", elapsed)
 	}
 
 	current := -1

--- a/pkg/controller/directimagemigration/task.go
+++ b/pkg/controller/directimagemigration/task.go
@@ -127,6 +127,8 @@ func (t *Task) init() error {
 }
 
 func (t *Task) Run() error {
+	t.Log = t.Log.WithValues("Phase", t.Phase)
+
 	// Init
 	err := t.init()
 	if err != nil {
@@ -213,7 +215,7 @@ func (t *Task) next() error {
 	if cond != nil {
 		now := time.Now().UTC()
 		elapsed := now.Sub(cond.LastTransitionTime.Time.UTC())
-		t.Log.Info("Phase completed", "Phase_Elapsed", elapsed)
+		t.Log.Info("Phase completed", "Elapsed", elapsed)
 	}
 
 	current := -1

--- a/pkg/controller/directimagemigration/task.go
+++ b/pkg/controller/directimagemigration/task.go
@@ -213,9 +213,8 @@ func (t *Task) next() error {
 	t.Owner.Status.StageCondition(migapi.Running)
 	cond := t.Owner.Status.FindCondition(migapi.Running)
 	if cond != nil {
-		now := time.Now().UTC()
-		elapsed := now.Sub(cond.LastTransitionTime.Time.UTC())
-		t.Log.Info("[NEXT]", "Elapsed", elapsed)
+		elapsed := time.Since(cond.LastTransitionTime.Time)
+		t.Log.Info("Phase completed", "Elapsed", elapsed)
 	}
 
 	current := -1

--- a/pkg/controller/directimagestreammigration/task.go
+++ b/pkg/controller/directimagestreammigration/task.go
@@ -172,9 +172,8 @@ func (t *Task) next() error {
 	t.Owner.Status.Conditions.StageCondition(migapi.Running)
 	cond := t.Owner.Status.FindCondition(migapi.Running)
 	if cond != nil {
-		now := time.Now().UTC()
-		elapsed := now.Sub(cond.LastTransitionTime.Time.UTC())
-		t.Log.Info("[NEXT]", "Elapsed", elapsed)
+		elapsed := time.Since(cond.LastTransitionTime.Time)
+		t.Log.Info("Phase completed", "Elapsed", elapsed)
 	}
 	current := -1
 	for i, step := range t.Itinerary.Steps {

--- a/pkg/controller/directimagestreammigration/task.go
+++ b/pkg/controller/directimagestreammigration/task.go
@@ -167,6 +167,14 @@ func (t *Task) Run() error {
 
 // Advance the task to the next phase.
 func (t *Task) next() error {
+	// Write time taken to complete phase
+	t.Owner.Status.Conditions.StageCondition(migapi.Running)
+	cond := t.Owner.Status.FindCondition(migapi.Running)
+	if cond != nil {
+		now := time.Now().UTC()
+		elapsed := now.Sub(cond.LastTransitionTime.Time.UTC())
+		t.Log.Info("Phase completed", "Phase_Elapsed", elapsed)
+	}
 	current := -1
 	for i, step := range t.Itinerary.Steps {
 		if step.phase != t.Phase {

--- a/pkg/controller/directimagestreammigration/task.go
+++ b/pkg/controller/directimagestreammigration/task.go
@@ -121,6 +121,7 @@ func (t *Task) init() error {
 }
 
 func (t *Task) Run() error {
+	t.Log = t.Log.WithValues("Phase", t.Phase)
 	// Init
 	err := t.init()
 	if err != nil {
@@ -173,7 +174,7 @@ func (t *Task) next() error {
 	if cond != nil {
 		now := time.Now().UTC()
 		elapsed := now.Sub(cond.LastTransitionTime.Time.UTC())
-		t.Log.Info("Phase completed", "Phase_Elapsed", elapsed)
+		t.Log.Info("Phase complete.", "Elapsed", elapsed)
 	}
 	current := -1
 	for i, step := range t.Itinerary.Steps {

--- a/pkg/controller/directimagestreammigration/task.go
+++ b/pkg/controller/directimagestreammigration/task.go
@@ -174,7 +174,7 @@ func (t *Task) next() error {
 	if cond != nil {
 		now := time.Now().UTC()
 		elapsed := now.Sub(cond.LastTransitionTime.Time.UTC())
-		t.Log.Info("Phase complete.", "Elapsed", elapsed)
+		t.Log.Info("[NEXT]", "Elapsed", elapsed)
 	}
 	current := -1
 	for i, step := range t.Itinerary.Steps {

--- a/pkg/controller/directimagestreammigration/task.go
+++ b/pkg/controller/directimagestreammigration/task.go
@@ -173,7 +173,7 @@ func (t *Task) next() error {
 	cond := t.Owner.Status.FindCondition(migapi.Running)
 	if cond != nil {
 		elapsed := time.Since(cond.LastTransitionTime.Time)
-		t.Log.Info("Phase completed", "Elapsed", elapsed)
+		t.Log.Info("Phase completed", "phaseElapsed", elapsed)
 	}
 	current := -1
 	for i, step := range t.Itinerary.Steps {

--- a/pkg/controller/directvolumemigration/descriptions.go
+++ b/pkg/controller/directvolumemigration/descriptions.go
@@ -32,6 +32,7 @@ var phaseDescriptions = map[string]string{
 	CreatePVProgressCRs:                  "Creating a Direct Volume Migration Progress CR to get progress percentage and transfer rate",
 	CreateRsyncTransferPods:              "Creating Rsync daemon pods on the target cluster",
 	WaitForRsyncTransferPodsRunning:      "Waiting for the Rsync daemon pod to run",
+	EnsureRsyncRouteAdmitted:             "Waiting for Rsync route to be admitted.",
 	CreateStunnelClientPods:              "Creating Stunnel client pods on the source cluster",
 	WaitForStunnelClientPodsRunning:      "Waiting for the Stunnel client pods to run",
 	CreateRsyncClientPods:                "Creating Rsync client pods",

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -526,7 +526,7 @@ func (t *Task) next() error {
 	cond := t.Owner.Status.FindCondition(Running)
 	if cond != nil {
 		elapsed := time.Since(cond.LastTransitionTime.Time)
-		t.Log.Info("Phase completed", "Elapsed", elapsed)
+		t.Log.Info("Phase completed", "phaseElapsed", elapsed)
 	}
 
 	current := -1

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -180,6 +180,7 @@ func (t *Task) init() error {
 }
 
 func (t *Task) Run() error {
+	t.Log = t.Log.WithValues("Phase", t.Phase)
 	// Init
 	err := t.init()
 	if err != nil {
@@ -526,7 +527,7 @@ func (t *Task) next() error {
 	if cond != nil {
 		now := time.Now().UTC()
 		elapsed := now.Sub(cond.LastTransitionTime.Time.UTC())
-		t.Log.Info("Phase completed", "Phase_Elapsed", elapsed)
+		t.Log.Info("Phase completed", "Elapsed", elapsed)
 	}
 
 	current := -1

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -525,9 +525,8 @@ func (t *Task) next() error {
 	t.Owner.Status.Conditions.StageCondition(Running)
 	cond := t.Owner.Status.FindCondition(Running)
 	if cond != nil {
-		now := time.Now().UTC()
-		elapsed := now.Sub(cond.LastTransitionTime.Time.UTC())
-		t.Log.Info("[NEXT]", "Elapsed", elapsed)
+		elapsed := time.Since(cond.LastTransitionTime.Time)
+		t.Log.Info("Phase completed", "Elapsed", elapsed)
 	}
 
 	current := -1

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -520,6 +520,15 @@ func (t *Task) Run() error {
 
 // Advance the task to the next phase.
 func (t *Task) next() error {
+	// Write time taken to complete phase
+	t.Owner.Status.Conditions.StageCondition(Running)
+	cond := t.Owner.Status.FindCondition(Running)
+	if cond != nil {
+		now := time.Now().UTC()
+		elapsed := now.Sub(cond.LastTransitionTime.Time.UTC())
+		t.Log.Info("Phase completed", "Phase_Elapsed", elapsed)
+	}
+
 	current := -1
 	for i, step := range t.Itinerary.Steps {
 		if step.phase != t.Phase {

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -527,7 +527,7 @@ func (t *Task) next() error {
 	if cond != nil {
 		now := time.Now().UTC()
 		elapsed := now.Sub(cond.LastTransitionTime.Time.UTC())
-		t.Log.Info("Phase completed", "Elapsed", elapsed)
+		t.Log.Info("[NEXT]", "Elapsed", elapsed)
 	}
 
 	current := -1

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -1227,7 +1227,7 @@ func (t *Task) next() error {
 	if cond != nil {
 		now := time.Now().UTC()
 		elapsed := now.Sub(cond.LastTransitionTime.Time.UTC())
-		t.Log.Info("Phase completed", "Phase_Elapsed", elapsed)
+		t.Log.Info("Phase completed", "Elapsed", elapsed)
 	}
 
 	current := -1

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -1227,7 +1227,7 @@ func (t *Task) next() error {
 	if cond != nil {
 		now := time.Now().UTC()
 		elapsed := now.Sub(cond.LastTransitionTime.Time.UTC())
-		t.Log.Info("Phase completed", "Elapsed", elapsed)
+		t.Log.Info("[NEXT]", "Elapsed", elapsed)
 	}
 
 	current := -1

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -1221,6 +1221,15 @@ func (t *Task) setProgress(progress []string) {
 
 // Advance the task to the next phase.
 func (t *Task) next() error {
+	// Write time taken to complete phase
+	t.Owner.Status.StageCondition(Running)
+	cond := t.Owner.Status.FindCondition(Running)
+	if cond != nil {
+		now := time.Now().UTC()
+		elapsed := now.Sub(cond.LastTransitionTime.Time.UTC())
+		t.Log.Info("Phase completed", "Phase_Elapsed", elapsed)
+	}
+
 	current := -1
 	for i, phase := range t.Itinerary.Phases {
 		if phase.Name != t.Phase {

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -1225,9 +1225,8 @@ func (t *Task) next() error {
 	t.Owner.Status.StageCondition(Running)
 	cond := t.Owner.Status.FindCondition(Running)
 	if cond != nil {
-		now := time.Now().UTC()
-		elapsed := now.Sub(cond.LastTransitionTime.Time.UTC())
-		t.Log.Info("[NEXT]", "Elapsed", elapsed)
+		elapsed := time.Since(cond.LastTransitionTime.Time)
+		t.Log.Info("Phase completed", "Elapsed", elapsed)
 	}
 
 	current := -1

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -1226,7 +1226,7 @@ func (t *Task) next() error {
 	cond := t.Owner.Status.FindCondition(Running)
 	if cond != nil {
 		elapsed := time.Since(cond.LastTransitionTime.Time)
-		t.Log.Info("Phase completed", "Elapsed", elapsed)
+		t.Log.Info("Phase completed", "phaseElapsed", elapsed)
 	}
 
 	current := -1


### PR DESCRIPTION
```
{"level":"info","ts":[...],"logger":"[...]","msg":"[RUN] (Step 9/23) Checking whether the created PVCs are bound","DVM":[...]}
{"level":"info","ts":[...],"logger":"[...]","msg":"Phase completed",[...],"Phase": "StartRefresh", "phaseElapsed":0.522302}
```

Logs formatted in this way allows us to use a nasty bash one-liner to generate a performance report of which phases are taking the longest to run.

```
make run-fast 2>&1 | tee controller.log

echo "PhaseName ElapsedSeconds PercentOfTotal" > phase_timing.csv; total_time=$(cat controller.log | grep '\"Phase\ completed\"' | jq '([inputs | .phaseElapsed] | add)'); cat controller.log | grep '\"Phase\ completed\"' | jq -r --arg total_time "$total_time" '"\(.Phase) \(.phaseElapsed) \(.Elapsed / ($total_time|tonumber))"' >> phase_timing.csv
```

```
PhaseName ElapsedTime PercentOfTotal                
StartRefresh 49.691784 14.405797870070389    
WaitForRefresh 17.651623 5.117258680362241     
CleanStaleAnnotations 2.386096 0.6917364181286685
CleanStaleResticCRs 3.936635 1.1412423449768787    
CleanStaleResticCRs 7.816086 2.265906876096197     
CleanStaleVeleroCRs 7.983351 2.314397503454984                                                             
RestartVelero 1.007199 0.2919900241242501                                                                  
CleanStaleStagePods 1.669287 0.4839313297573738   
WaitForStaleStagePodsTerminated 2.195697 0.6365391744824445
WaitForVeleroReady 0.843389 0.24450101167309263                                                            
EnsureCloudSecretPropagated 5.634364 1.6334190962111823
PreBackupHooks 0.762824 0.2211449754840473       
CreateDirectImageMigration 0.912454 0.264523163220246      
EnsureInitialBackup 3.609576 1.0464269556644856 
Started 2.006556 0.5817066288257422            
EnsureInitialBackup 4.150545 1.2032554983461916                                                            
Prepare 1.541324 0.4468344705895118                                                                        
CreateDestinationNamespaces 3.497918 1.0140569651128017  
ListImageStreams 2.87607 0.8337813566961764              
```

And from this CSV we can easily create a Google Sheet with color formatting that highlights which phases are taking the longest.

![image](https://user-images.githubusercontent.com/7576968/111406259-57c3a780-86a8-11eb-9440-72f1512ecfdd.png)
