### PR TITLE
Add plan check before PV resize 

### DIFF
--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -107,10 +107,12 @@ func (t *Task) getDestinationPVCs() error {
 }
 
 func (t *Task) findMatchingPV(plan *migapi.MigPlan, pvcName string, pvcNamespace string) *migapi.PV {
-	for i := range plan.Spec.PersistentVolumes.List {
-		planVol := &plan.Spec.PersistentVolumes.List[i]
-		if planVol.PVC.Name == pvcName && planVol.PVC.Namespace == pvcNamespace {
-			return planVol
+	if plan != nil {
+		for i := range plan.Spec.PersistentVolumes.List {
+			planVol := &plan.Spec.PersistentVolumes.List[i]
+			if planVol.PVC.Name == pvcName && planVol.PVC.Namespace == pvcNamespace {
+				return planVol
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR adds a `nil`  check for `MigPlan` before performing PV resize during the creation of destination PVs