### PR TITLE
Structured log conversion

### DIFF
--- a/pkg/controller/directimagemigration/directimagemigration_controller.go
+++ b/pkg/controller/directimagemigration/directimagemigration_controller.go
@@ -113,7 +113,7 @@ type ReconcileDirectImageMigration struct {
 func (r *ReconcileDirectImageMigration) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the DirectImageMigration instance
 	log.Reset()
-	log.SetValues("DirectImageMigration", request.Name)
+	log.SetValues("dim", request.Name)
 	imageMigration := &migapi.DirectImageMigration{}
 	err := r.Get(context.TODO(), request.NamespacedName, imageMigration)
 	if err != nil {

--- a/pkg/controller/directimagemigration/migrate.go
+++ b/pkg/controller/directimagemigration/migrate.go
@@ -51,8 +51,10 @@ func (r *ReconcileDirectImageMigration) migrate(imageMigration *migapi.DirectIma
 			log.V(4).Info("Conflict error during task.Run, requeueing.")
 			return FastReQ, nil
 		}
-		log.Info(fmt.Sprintf("Phase [%v] execution FAILED with Error=[%v], Phase.Description=[%v]",
-			task.Phase, errorutil.Unwrap(err).Error(), task.getPhaseDescription(task.Phase)))
+		log.Info("Phase execution failed.",
+			"phase", task.Phase,
+			"phaseDescription", task.getPhaseDescription(task.Phase),
+			"error", errorutil.Unwrap(err).Error())
 		log.Trace(err)
 		task.fail(MigrationFailed, []string{err.Error()})
 		return task.Requeue, nil

--- a/pkg/controller/directimagestreammigration/directimagestreammigration_controller.go
+++ b/pkg/controller/directimagestreammigration/directimagestreammigration_controller.go
@@ -103,7 +103,7 @@ type ReconcileDirectImageStreamMigration struct {
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=directimagestreammigrations/status,verbs=get;update;patch
 func (r *ReconcileDirectImageStreamMigration) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	log.Reset()
-	log.SetValues("DirectImageStreamMigration", request.Name)
+	log.SetValues("dism", request.Name)
 	// Fetch the DirectImageStreamMigration instance
 	imageStreamMigration := &migapi.DirectImageStreamMigration{}
 	err := r.Get(context.TODO(), request.NamespacedName, imageStreamMigration)

--- a/pkg/controller/directimagestreammigration/migrate.go
+++ b/pkg/controller/directimagestreammigration/migrate.go
@@ -50,8 +50,10 @@ func (r *ReconcileDirectImageStreamMigration) migrate(imageStreamMigration *miga
 		if errors.IsConflict(errorutil.Unwrap(err)) {
 			return FastReQ, nil
 		}
-		log.Info(fmt.Sprintf("Phase [%v] execution FAILED with Error=[%v], Phase.Description=[%v]",
-			task.Phase, errorutil.Unwrap(err).Error(), task.getPhaseDescription(task.Phase)))
+		log.Info("Phase execution failed.",
+			"phase", task.Phase,
+			"phaseDescription", task.getPhaseDescription(task.Phase),
+			"error", errorutil.Unwrap(err).Error())
 		log.Trace(err)
 		task.fail(MigrationFailed, []string{err.Error()})
 		return task.Requeue, nil

--- a/pkg/controller/directvolumemigration/directvolumemigration_controller.go
+++ b/pkg/controller/directvolumemigration/directvolumemigration_controller.go
@@ -114,7 +114,7 @@ func (r *ReconcileDirectVolumeMigration) Reconcile(request reconcile.Request) (r
 	}
 
 	// Set values
-	log.SetValues("DVM", request.Name)
+	log.SetValues("dvm", request.Name)
 
 	// Check if completed
 	if direct.Status.Phase == Completed {

--- a/pkg/controller/directvolumemigration/migrate.go
+++ b/pkg/controller/directvolumemigration/migrate.go
@@ -49,8 +49,10 @@ func (r *ReconcileDirectVolumeMigration) migrate(direct *migapi.DirectVolumeMigr
 			log.V(4).Info("Conflict error during task.Run, requeueing.")
 			return FastReQ, nil
 		}
-		log.Info(fmt.Sprintf("Phase [%v] execution FAILED with Error=[%v], Phase.Description=[%v]",
-			task.Phase, errorutil.Unwrap(err).Error(), task.getPhaseDescription(task.Phase)))
+		log.Info("Phase execution failed.",
+			"phase", task.Phase,
+			"phaseDescription", task.getPhaseDescription(task.Phase),
+			"error", errorutil.Unwrap(err).Error())
 		log.Trace(err)
 		task.fail(MigrationFailed, []string{err.Error()})
 		return task.Requeue, nil

--- a/pkg/controller/directvolumemigration/namespace.go
+++ b/pkg/controller/directvolumemigration/namespace.go
@@ -2,7 +2,6 @@ package directvolumemigration
 
 import (
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,8 +41,8 @@ func (t *Task) ensureDestinationNamespaces() error {
 				Annotations: srcNS.Annotations,
 			},
 		}
-		t.Log.Info(fmt.Sprintf("Creating namespace [%v] on destination MigCluster",
-			destNs.Name))
+		t.Log.Info("Creating namespace on destination MigCluster",
+			"namespace", destNs.Name)
 		err = destClient.Create(context.TODO(), &destNs)
 		if err != nil {
 			return err

--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -2,7 +2,7 @@ package directvolumemigration
 
 import (
 	"context"
-	"fmt"
+	"path"
 
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/konveyor/mig-controller/pkg/settings"
@@ -86,11 +86,11 @@ func (t *Task) createDestinationPVCs() error {
 			},
 			Spec: newSpec,
 		}
-		t.Log.Info(fmt.Sprintf("Creating PVC [%v/%v] with StorageClassName=[%v] "+
-			"AccessModes=[%v] Requests=[%v] on destination MigCluster",
-			pvc.Namespace, pvc.Name,
-			destPVC.Spec.StorageClassName, destPVC.Spec.AccessModes,
-			destPVC.Spec.Resources.Requests))
+		t.Log.Info("Creating PVC on destination MigCluster",
+			"persistentVolumeClaim", path.Join(pvc.Namespace, pvc.Name),
+			"pvcStorageClassName", destPVC.Spec.StorageClassName,
+			"pvcAccessModes", destPVC.Spec.AccessModes,
+			"pvcRequests", destPVC.Spec.Resources.Requests)
 		err = destClient.Create(context.TODO(), &destPVC)
 		if k8serror.IsAlreadyExists(err) {
 			t.Log.Info("PVC already exists on destination", "name", pvc.Name)

--- a/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller.go
+++ b/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller.go
@@ -126,7 +126,7 @@ type ReconcileDirectVolumeMigrationProgress struct {
 func (r *ReconcileDirectVolumeMigrationProgress) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	var err error
 	log.Reset()
-	log.SetValues("DVMP", request.Name)
+	log.SetValues("dvmp", request.Name)
 	// Fetch the DirectVolumeMigrationProgress instance
 	pvProgress := &migapi.DirectVolumeMigrationProgress{}
 	err = r.Get(context.TODO(), request.NamespacedName, pvProgress)

--- a/pkg/controller/miganalytic/miganalytics_controller.go
+++ b/pkg/controller/miganalytic/miganalytics_controller.go
@@ -124,7 +124,7 @@ type MigAnalyticPersistentVolumeDetails struct {
 func (r *ReconcileMigAnalytic) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	var err error
 	log.Reset()
-	log.SetValues("analytic", request)
+	log.SetValues("migAnalytic", request.Name)
 
 	// Fetch the MigAnalytic instance
 	analytic := &migapi.MigAnalytic{}

--- a/pkg/controller/miganalytic/restic_executor.go
+++ b/pkg/controller/miganalytic/restic_executor.go
@@ -18,7 +18,7 @@ package miganalytic
 
 import (
 	"context"
-	"fmt"
+	"path"
 	"sync"
 
 	liberr "github.com/konveyor/controller/pkg/error"
@@ -64,8 +64,9 @@ func (r *ResticDFCommandExecutor) DF(podRef *corev1.Pod, persistentVolumes []Mig
 	}
 	err := podCommand.Run()
 	if err != nil {
-		log.Error(err,
-			fmt.Sprintf("Failed running df command inside pod %s", podRef.Name))
+		log.Error(err, "Failed running df command inside Restic Pod",
+			"pod", path.Join(podRef.Namespace, podRef.Name),
+			"command", cmdString)
 	}
 	dfCmd.StdErr = podCommand.Err.String()
 	dfCmd.StdOut = podCommand.Out.String()

--- a/pkg/controller/miganalytic/volume_adjustment.go
+++ b/pkg/controller/miganalytic/volume_adjustment.go
@@ -199,12 +199,14 @@ func (pva *PersistentVolumeAdjuster) generateWarningForErroredPVs(erroredPVs []*
 		}
 	}
 	if len(pvNames) > 0 {
+		msg := fmt.Sprintf(warningString, strings.Join(pvNames, " "))
+		log.Info(msg)
 		pva.Owner.Status.Conditions.SetCondition(migapi.Condition{
 			Category: migapi.Warn,
 			Status:   True,
 			Type:     ExtendedPVAnalysisFailed,
 			Reason:   FailedRunningDf,
-			Message:  fmt.Sprintf(warningString, strings.Join(pvNames, " ")),
+			Message:  msg,
 		})
 	}
 }

--- a/pkg/controller/migcluster/migcluster_controller.go
+++ b/pkg/controller/migcluster/migcluster_controller.go
@@ -108,7 +108,7 @@ type ReconcileMigCluster struct {
 func (r *ReconcileMigCluster) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	var err error
 	log.Reset()
-	log.SetValues("cluster", request)
+	log.SetValues("migCluster", request.Name)
 
 	// Fetch the MigCluster
 	cluster := &migapi.MigCluster{}

--- a/pkg/controller/mighook/mighook_controller.go
+++ b/pkg/controller/mighook/mighook_controller.go
@@ -80,7 +80,7 @@ type ReconcileMigHook struct {
 func (r *ReconcileMigHook) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	var err error
 	log.Reset()
-	log.SetValues("hook", request)
+	log.SetValues("migHook", request.Name)
 
 	// Fetch the MigHook instance
 	hook := &migapi.MigHook{}

--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -3,6 +3,7 @@ package migmigration
 import (
 	"context"
 	"fmt"
+	"path"
 	"strings"
 
 	liberr "github.com/konveyor/controller/pkg/error"
@@ -212,9 +213,8 @@ func (t *Task) labelNamespaces(client k8sclient.Client, itemsUpdated int) (int, 
 			continue
 		}
 		namespace.Labels[IncludedInStageBackupLabel] = t.UID()
-		log.Info(
-			fmt.Sprintf("Adding migration annotations/labels to source cluster namespace [%v].",
-				namespace.Name))
+		log.Info("Adding migration annotations/labels to source cluster namespace.",
+			"namespace", namespace.Name)
 		err = client.Update(context.TODO(), &namespace)
 		if err != nil {
 			return itemsUpdated, liberr.Wrap(err)
@@ -266,9 +266,8 @@ func (t *Task) annotatePods(client k8sclient.Client, itemsUpdated int) (int, Ser
 		pod.Annotations[ResticPvVerifyAnnotation] = strings.Join(verifyVolumes, ",")
 
 		// Update
-		log.Info(
-			fmt.Sprintf("Adding annotations/labels to source cluster Pod [%v/%v].",
-				pod.Namespace, pod.Name))
+		log.Info("Adding annotations/labels to source cluster Pod.",
+			"pod", path.Join(pod.Namespace, pod.Name))
 		err = client.Update(context.TODO(), &pod)
 		if err != nil {
 			return itemsUpdated, nil, liberr.Wrap(err)
@@ -332,8 +331,8 @@ func (t *Task) annotatePVs(client k8sclient.Client, itemsUpdated int) (int, erro
 		pvResource.Labels[IncludedInStageBackupLabel] = t.UID()
 
 		// Update
-		log.Info(fmt.Sprintf("Adding annotations/labels to source cluster "+
-			"PersistentVolume [%v].", pv.Name))
+		log.Info("Adding annotations/labels to source cluster PersistentVolume.",
+			"persistentVolume", pv.Name)
 		err = client.Update(context.TODO(), &pvResource)
 		if err != nil {
 			return itemsUpdated, liberr.Wrap(err)
@@ -374,9 +373,8 @@ func (t *Task) annotatePVs(client k8sclient.Client, itemsUpdated int) (int, erro
 			}
 		}
 		// Update
-		log.Info(
-			fmt.Sprintf("Adding annotations/labels to source cluster PersistentVolumeClaim [%v/%v].",
-				pv.PVC.Namespace, pv.PVC.Name))
+		log.Info("Adding annotations/labels to source cluster PersistentVolumeClaim.",
+			"persistentVolumeClaim", path.Join(pv.PVC.Namespace, pv.PVC.Name))
 		err = client.Update(context.TODO(), &pvcResource)
 		if err != nil {
 			return itemsUpdated, liberr.Wrap(err)
@@ -421,9 +419,8 @@ func (t *Task) labelServiceAccounts(client k8sclient.Client, serviceAccounts Ser
 			if err != nil {
 				return itemsUpdated, liberr.Wrap(err)
 			}
-			log.Info(
-				fmt.Sprintf("Added annotations/labels to source cluster Service Account [%v/%v].",
-					sa.Namespace, sa.Name))
+			log.Info("Added annotations/labels to source cluster Service Account.",
+				"serviceAccount", path.Join(sa.Namespace, sa.Name))
 			itemsUpdated++
 			if itemsUpdated > AnnotationsPerReconcile {
 				t.setProgress([]string{fmt.Sprintf("%v/%v SA annotations/labels added in the namespace: %s", i, total, sa.Namespace)})
@@ -454,8 +451,8 @@ func (t *Task) labelImageStreams(client compat.Client, itemsUpdated int) (int, e
 			}
 			is.Labels[IncludedInStageBackupLabel] = t.UID()
 
-			log.Info(fmt.Sprintf("Adding labels to source cluster ImageStream [%v/%v].",
-				is.Namespace, is.Name))
+			log.Info("Adding labels to source cluster ImageStream.",
+				"imageStream", path.Join(is.Namespace, is.Name))
 			err = client.Update(context.Background(), &is)
 			if err != nil {
 				return itemsUpdated, liberr.Wrap(err)
@@ -545,8 +542,8 @@ func (t *Task) deletePodAnnotations(client k8sclient.Client, namespaceList []str
 			if err != nil {
 				return liberr.Wrap(err)
 			}
-			log.Info(fmt.Sprintf("Velero Annotations/Labels removed on Pod [%v/%v].",
-				pod.Namespace, pod.Name))
+			log.Info("Velero Annotations/Labels removed on Pod.",
+				"pod", path.Join(pod.Namespace, pod.Name))
 		}
 	}
 
@@ -621,8 +618,8 @@ func (t *Task) deletePVCAnnotations(client k8sclient.Client, namespaceList []str
 			if err != nil {
 				return liberr.Wrap(err)
 			}
-			log.Info(fmt.Sprintf("Velero Annotations/Labels removed on PersistentVolumeClaim [%v/%v].",
-				pvc.Namespace, pvc.Name))
+			log.Info("Velero Annotations/Labels removed on PersistentVolumeClaim.",
+				"persistentVolumeClaim", path.Join(pvc.Namespace, pvc.Name))
 		}
 	}
 
@@ -648,8 +645,8 @@ func (t *Task) deletePVAnnotations(client k8sclient.Client) error {
 		if err != nil {
 			return liberr.Wrap(err)
 		}
-		log.Info(fmt.Sprintf("Velero Annotations/Labels removed on PersistentVolume [%v/%v].",
-			pv.Namespace, pv.Name))
+		log.Info("Velero Annotations/Labels removed on PersistentVolume.",
+			"persistentVolume", path.Join(pv.Namespace, pv.Name))
 	}
 
 	return nil
@@ -672,8 +669,8 @@ func (t *Task) deleteServiceAccountLabels(client k8sclient.Client) error {
 		if err != nil {
 			return liberr.Wrap(err)
 		}
-		log.Info(fmt.Sprintf("Velero Annotations/Labels removed on ServiceAccount [%v/%v].",
-			sa.Namespace, sa.Name))
+		log.Info("Velero Annotations/Labels removed on ServiceAccount.",
+			"serviceAccount", path.Join(sa.Namespace, sa.Name))
 	}
 	return nil
 }
@@ -695,8 +692,8 @@ func (t *Task) deleteImageStreamLabels(client k8sclient.Client, namespaceList []
 		if err != nil {
 			return liberr.Wrap(err)
 		}
-		log.Info(fmt.Sprintf("Velero Annotations/Labels removed on ImageStream [%v/%v].",
-			is.Namespace, is.Name))
+		log.Info("Velero Annotations/Labels removed on ImageStream.",
+			"imageStream", path.Join(is.Namespace, is.Name))
 	}
 	return nil
 }

--- a/pkg/controller/migmigration/description.go
+++ b/pkg/controller/migmigration/description.go
@@ -18,6 +18,7 @@ package migmigration
 
 // PhaseDescriptions are human readable strings that describe a phase
 var PhaseDescriptions = map[string]string{
+	Created:                                "Migration created.",
 	Started:                                "Migration started.",
 	StartRefresh:                           "Starting refresh on MigPlan, MigStorage and MigCluster resources",
 	WaitForRefresh:                         "Waiting for refresh of MigPlan, MigStorage and MigCluster resources to complete",

--- a/pkg/controller/migmigration/directimagemigration.go
+++ b/pkg/controller/migmigration/directimagemigration.go
@@ -19,6 +19,7 @@ package migmigration
 import (
 	"context"
 	"fmt"
+	"path"
 
 	liberr "github.com/konveyor/controller/pkg/error"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
@@ -50,8 +51,8 @@ func (t *Task) createDirectImageMigration() error {
 		return nil
 	}
 	dim = t.buildDirectImageMigration()
-	t.Log.Info(fmt.Sprintf("Creating directimagemigration resource %v/%v.",
-		dim.Namespace, dim.Name))
+	t.Log.Info("Creating DirectImageMigration resource.",
+		"directImageMigration", path.Join(dim.Namespace, dim.Name))
 	err = t.Client.Create(context.TODO(), dim)
 	if err != nil {
 		return liberr.Wrap(err)
@@ -101,8 +102,9 @@ func (t *Task) deleteDirectImageMigrationResources() error {
 
 	if dim != nil {
 		// delete the DIM instance
-		t.Log.Info(fmt.Sprintf("Deleting DirectImageMigration [%v/%v] on host cluster "+
-			"due to correlation with MigPlan", dim.Namespace, dim.Name))
+		t.Log.Info("Deleting DirectImageMigration on host cluster "+
+			"due to correlation with MigPlan",
+			"directImageMigration", path.Join(dim.Namespace, dim.Name))
 		err = t.Client.Delete(context.TODO(), dim)
 		if err != nil {
 			return liberr.Wrap(err)

--- a/pkg/controller/migmigration/dvm.go
+++ b/pkg/controller/migmigration/dvm.go
@@ -30,8 +30,8 @@ func (t *Task) createDirectVolumeMigration() error {
 	if dvm == nil {
 		return errors.New("failed to build directvolumeclaim list")
 	}
-	t.Log.Info(fmt.Sprintf("Creating DirectVolumeMigration [%v/%v] on host cluster",
-		dvm.Namespace, dvm.Name))
+	t.Log.Info("Creating DirectVolumeMigration on host cluster",
+		"directVolumeMigration", path.Join(dvm.Namespace, dvm.Name))
 	err = t.Client.Create(context.TODO(), dvm)
 	return err
 
@@ -213,8 +213,9 @@ func (t *Task) deleteDirectVolumeMigrationResources() error {
 
 	if dvm != nil {
 		// delete the DVM instance
-		t.Log.Info(fmt.Sprintf("Deleting DirectVolumeMigration [%v/%v] on host cluster "+
-			"due to correlation with MigPlan", dvm.Namespace, dvm.Name))
+		t.Log.Info("Deleting DirectVolumeMigration on host cluster "+
+			"due to correlation with MigPlan",
+			"directVolumeMigration", path.Join(dvm.Namespace, dvm.Name))
 		err = t.Client.Delete(context.TODO(), dvm)
 		if err != nil {
 			return liberr.Wrap(err)

--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -148,7 +148,7 @@ func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.
 	var err error
 	log.Reset()
 	// Set values.
-	log.SetValues("MigMigration", request.Name)
+	log.SetValues("migMigration", request.Name)
 
 	// Retrieve the MigMigration being reconciled
 	migration := &migapi.MigMigration{}

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -74,8 +74,10 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration, reconcil
 			log.V(4).Info("Conflict error during task.Run, requeueing.")
 			return FastReQ, nil
 		}
-		log.Info(fmt.Sprintf("Phase [%v] execution FAILED with Error=[%v], Phase.Description=[%v]",
-			task.Phase, errorutil.Unwrap(err).Error(), task.getPhaseDescription(task.Phase)))
+		log.Info("Phase execution failed.",
+			"phase", task.Phase,
+			"phaseDescription", task.getPhaseDescription(task.Phase),
+			"error", errorutil.Unwrap(err).Error())
 		log.Trace(err)
 		task.fail(MigrationFailed, []string{err.Error()})
 		return task.Requeue, nil

--- a/pkg/controller/migmigration/registry.go
+++ b/pkg/controller/migmigration/registry.go
@@ -3,6 +3,7 @@ package migmigration
 import (
 	"errors"
 	"fmt"
+	"path"
 
 	liberr "github.com/konveyor/controller/pkg/error"
 
@@ -93,32 +94,32 @@ func (t *Task) ensureMigRegistries() (int, error) {
 		}
 
 		// Migration Registry Secret
-		t.Log.Info(fmt.Sprintf("Creating migration registry secret on MigCluster %v/%v",
-			cluster.Namespace, cluster.Name))
+		t.Log.Info("Creating migration registry secret on MigCluster",
+			"migCluster", path.Join(cluster.Namespace, cluster.Name))
 		secret, err := t.ensureRegistrySecret(client)
 		if err != nil {
 			return nEnsured, liberr.Wrap(err)
 		}
 
 		// Get cluster specific registry image
-		t.Log.Info(fmt.Sprintf("Retreiving migration registry image name for MigCluster %v/%v",
-			cluster.Namespace, cluster.Name))
+		t.Log.Info("Retreiving migration registry image name for MigCluster",
+			"migCluster", path.Join(cluster.Namespace, cluster.Name))
 		registryImage, err := cluster.GetRegistryImage(client)
 		if err != nil {
 			return nEnsured, liberr.Wrap(err)
 		}
 
 		// Migration Registry DeploymentConfig
-		t.Log.Info(fmt.Sprintf("Creating migration registry deployment for MigCluster %v/%v",
-			cluster.Namespace, cluster.Name))
+		t.Log.Info("Creating migration registry deployment for MigCluster",
+			"migCluster", path.Join(cluster.Namespace, cluster.Name))
 		err = t.ensureRegistryDeployment(client, secret, registryImage)
 		if err != nil {
 			return nEnsured, liberr.Wrap(err)
 		}
 
 		// Migration Registry Service
-		t.Log.Info(fmt.Sprintf("Creating migration registry service on MigCluster %v/%v",
-			cluster.Namespace, cluster.Name))
+		t.Log.Info("Creating migration registry service on MigCluster",
+			"migCluster", path.Join(cluster.Namespace, cluster.Name))
 		err = t.ensureRegistryService(client, secret)
 		if err != nil {
 			return nEnsured, liberr.Wrap(err)
@@ -189,8 +190,8 @@ func (t *Task) deleteImageRegistryResourcesForClient(client k8sclient.Client, pl
 		return liberr.Wrap(err)
 	}
 	if secret != nil {
-		t.Log.Info(fmt.Sprintf("Deleting registry secret [%v/%v] created for migration.",
-			secret.Namespace, secret.Name))
+		t.Log.Info("Deleting registry secret created for migration.",
+			"secret", path.Join(secret.Namespace, secret.Name))
 		err := client.Delete(context.Background(), secret)
 		if err != nil {
 			return liberr.Wrap(err)
@@ -206,8 +207,8 @@ func (t *Task) deleteImageRegistryResourcesForClient(client k8sclient.Client, pl
 		return liberr.Wrap(err)
 	}
 	if foundService != nil {
-		t.Log.Info(fmt.Sprintf("Deleting registry service [%v/%v] created for migration.",
-			secret.Namespace, secret.Name))
+		t.Log.Info("Deleting registry service created for migration.",
+			"secret", path.Join(secret.Namespace, secret.Name))
 		err := client.Delete(context.Background(), foundService)
 		if err != nil {
 			return liberr.Wrap(err)
@@ -223,8 +224,8 @@ func (t *Task) deleteImageRegistryDeploymentForClient(client k8sclient.Client, p
 		return liberr.Wrap(err)
 	}
 	if foundDeployment != nil {
-		t.Log.Info(fmt.Sprintf("Deleting registry deployment [%v/%v] created for migration.",
-			foundDeployment.Namespace, foundDeployment.Name))
+		t.Log.Info("Deleting registry deployment created for migration.",
+			"deployment", path.Join(foundDeployment.Namespace, foundDeployment.Name))
 		err := client.Delete(context.Background(), foundDeployment, k8sclient.PropagationPolicy(metav1.DeletePropagationForeground))
 		if err != nil {
 			return liberr.Wrap(err)
@@ -325,8 +326,8 @@ func (t *Task) deleteImageRegistryResources() error {
 	}
 	clusters := t.getBothClusters()
 	for _, cluster := range clusters {
-		t.Log.Info(fmt.Sprintf("Deleting image registry for MigCluster [%v/%v]",
-			cluster.Namespace, cluster.Name))
+		t.Log.Info("Deleting image registry for MigCluster",
+			"migCluster", path.Join(cluster.Namespace, cluster.Name))
 		clusterClient, err := cluster.GetClient(t.Client)
 		if err != nil {
 			return liberr.Wrap(err)

--- a/pkg/controller/migmigration/verify.go
+++ b/pkg/controller/migmigration/verify.go
@@ -3,6 +3,7 @@ package migmigration
 import (
 	"context"
 	"fmt"
+	"path"
 
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -57,8 +58,9 @@ func (t *Task) updateResourcesHealth(client k8sclient.Client) error {
 func (t *Task) getAppState(client k8sclient.Client) error {
 	// Scan namespaces
 	for _, namespace := range t.PlanResources.MigPlan.Spec.Namespaces {
-		t.Log.Info(fmt.Sprintf("Checking migrated app health in destination"+
-			"cluster namespace [%v]", namespace))
+		t.Log.Info("Checking migrated app health in destination"+
+			"cluster namespace.",
+			"namespace", namespace)
 		options := k8sclient.InNamespace(namespace)
 
 		unhealthyPods, err := health.PodsUnhealthy(client, options)
@@ -68,8 +70,10 @@ func (t *Task) getAppState(client k8sclient.Client) error {
 
 		unhealthyPodCount := len(*unhealthyPods)
 		if unhealthyPodCount > 0 {
-			t.Log.Info(fmt.Sprintf("Found [%v] unhealthy Pods in destination "+
-				"cluster namespace [%v]", unhealthyPodCount, namespace))
+			t.Log.Info("Found unhealthy Pods in destination "+
+				"cluster namespace",
+				"unhealthyPodCount", unhealthyPodCount,
+				"namespace", namespace)
 		}
 		destinationNamespaces := &t.Owner.Status.UnhealthyResources.Namespaces
 		t.Owner.Status.UnhealthyResources.AddResources(
@@ -141,10 +145,9 @@ func (t *Task) startRefresh() (bool, error) {
 // Verify plan finished with refresh before migrating
 func (t *Task) waitForRefresh() bool {
 	if t.PlanResources.MigPlan.Spec.Refresh == true {
-		t.Log.Info(fmt.Sprintf("Refresh of associated MigPlan [%v/%v] "+
-			"not yet finished (Spec.Refresh=[%v]) waiting...",
-			t.PlanResources.MigPlan.Namespace, t.PlanResources.MigPlan.Name,
-			t.PlanResources.MigPlan.Spec.Refresh))
+		t.Log.Info("Refresh of associated MigPlan not yet finished. Waiting.",
+			"migPlan", path.Join(t.PlanResources.MigPlan.Namespace, t.PlanResources.MigPlan.Name),
+			"migPlan.Spec.Refresh", t.PlanResources.MigPlan.Spec.Refresh)
 		return false
 	}
 	return true

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -180,7 +180,7 @@ type ReconcileMigPlan struct {
 func (r *ReconcileMigPlan) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	var err error
 	log.Reset()
-	log.SetValues("plan", request)
+	log.SetValues("migPlan", request.Name)
 
 	// Fetch the MigPlan instance
 	plan := &migapi.MigPlan{}

--- a/pkg/controller/migplan/pvlist.go
+++ b/pkg/controller/migplan/pvlist.go
@@ -3,6 +3,7 @@ package migplan
 import (
 	"context"
 	"fmt"
+	"path"
 	"strings"
 
 	liberr "github.com/konveyor/controller/pkg/error"
@@ -39,8 +40,9 @@ func (r *ReconcileMigPlan) updatePvs(plan *migapi.MigPlan) error {
 		return nil
 	}
 
-	log.Info(fmt.Sprintf("PV Discovery: Starting for for MigPlan [%v/%v] in namespaces [%v]",
-		plan.Namespace, plan.Name, plan.Spec.Namespaces))
+	log.Info("PV Discovery: Starting for Migration Plan",
+		"migPlan", path.Join(plan.Namespace, plan.Name),
+		"migPlanNamespaces", plan.Spec.Namespaces)
 
 	// Get srcMigCluster
 	srcMigCluster, err := plan.GetSourceCluster(r.Client)
@@ -85,9 +87,9 @@ func (r *ReconcileMigPlan) updatePvs(plan *migapi.MigPlan) error {
 
 	plan.Spec.BeginPvStaging()
 	if plan.IsResourceExcluded("persistentvolumeclaims") {
-		log.Info(fmt.Sprintf("PV Discovery: 'persistentvolumeclaims' found in MigPlan [%v/%v] "+
+		log.Info("PV Discovery: 'persistentvolumeclaims' found in MigPlan "+
 			"Status.ExcludedResources, ending PV discovery",
-			plan.Namespace, plan.Name))
+			"migPlan", path.Join(plan.Namespace, plan.Name))
 		plan.Spec.ResetPvs()
 		plan.Status.SetCondition(migapi.Condition{
 			Type:     PvsDiscovered,
@@ -178,8 +180,9 @@ func (r *ReconcileMigPlan) updatePvs(plan *migapi.MigPlan) error {
 		})
 	}
 
-	log.Info(fmt.Sprintf("PV Discovery: Finished for MigPlan [%v/%v] in namespaces [%v]",
-		plan.Namespace, plan.Name, plan.Spec.Namespaces))
+	log.Info("PV Discovery: Finished for Migration Plan",
+		"migPlan", path.Join(plan.Namespace, plan.Name),
+		"migPlanNamespaces", plan.Spec.Namespaces)
 	return nil
 }
 
@@ -328,10 +331,11 @@ func (r *ReconcileMigPlan) getDefaultSelection(pv core.PersistentVolume,
 			}
 		}
 	}
-	log.Info(fmt.Sprintf("PV Discovery: Setting default selections for PV [%v]: "+
-		"Action=[%v], StorageClass=[%v], CopyMethod=[%v]",
-		pv.Name, selectedAction,
-		selectedStorageClass, migapi.PvFilesystemCopyMethod))
+	log.Info("PV Discovery: Setting default selections for discovered PV.",
+		"persistentVolume", pv.Name,
+		"pvSelectedAction", selectedAction,
+		"pvSelectedStorageClass", selectedStorageClass,
+		"pvCopyMethod", migapi.PvFilesystemCopyMethod)
 	return migapi.Selection{
 		Action:       selectedAction,
 		StorageClass: selectedStorageClass,

--- a/pkg/controller/migstorage/migstorage_controller.go
+++ b/pkg/controller/migstorage/migstorage_controller.go
@@ -106,7 +106,7 @@ type ReconcileMigStorage struct {
 func (r *ReconcileMigStorage) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	var err error
 	log.Reset()
-	log.SetValues("storage", request)
+	log.SetValues("migStorage", request.Name)
 
 	// Fetch the MigStorage instance
 	storage := &migapi.MigStorage{}


### PR DESCRIPTION
This PR is a continuation of work done on the [Debug 2.0 Enhancement](https://github.com/konveyor/enhancements/tree/master/enhancements/logs-events-debugging) and follows up on [the original logs enhancement PR](https://github.com/konveyor/mig-controller/pull/992)

- Adds structured logs throughout controller
- Adopts `camelCase` structured logging keys
- Adds "phase skipped due to flags" log.

Logs samples attached.
[direct-structured-log-sample.txt](https://github.com/konveyor/mig-controller/files/6206515/direct-structured-log-sample.txt)
[indirect-structured-log-sample.txt](https://github.com/konveyor/mig-controller/files/6206516/indirect-structured-log-sample.txt)

### Example of unstructured -> structured conversion

```go
# Unstructured
		log.Info(fmt.Sprintf("Phase [%v] execution FAILED with Error=[%v], Phase.Description=[%v]",
			task.Phase, errorutil.Unwrap(err).Error(), task.getPhaseDescription(task.Phase)))
# Structured
		log.Info("Phase execution failed.",
			"phase", task.Phase,
			"phaseDescription", task.getPhaseDescription(task.Phase),
			"error", errorutil.Unwrap(err).Error())
```

### Example of "skipped phase" message
```
{"level":"info","ts":1616690995787,"logger":"migration|46d8t","msg":"Velero Backup progress report","migMigration":"f969f980-8d89-11eb-be8b-6b964d3a5d1d","phase":"InitialBackupCreated","backup":"openshift-migration/f969f980-8d89-11eb-be8b-6b964d3a5d1d-7bfs4","backupProgress":["Backup openshift-migration/f969f980-8d89-11eb-be8b-6b964d3a5d1d-7bfs4: 92 out of estimated total of 92 objects backed up (18s)"]}
{"level":"info","ts":1616690995787,"logger":"migration|46d8t","msg":"Skipped phase due to flag evaluation.","migMigration":"f969f980-8d89-11eb-be8b-6b964d3a5d1d","phase":"InitialBackupCreated","skippedPhase":"EnsureStagePodsFromRunning"}
{"level":"info","ts":1616690995787,"logger":"migration|46d8t","msg":"Skipped phase due to flag evaluation.","migMigration":"f969f980-8d89-11eb-be8b-6b964d3a5d1d","phase":"InitialBackupCreated","skippedPhase":"EnsureStagePodsFromTemplates"}
{"level":"info","ts":1616690995787,"logger":"migration|46d8t","msg":"Skipped phase due to flag evaluation.","migMigration":"f969f980-8d89-11eb-be8b-6b964d3a5d1d","phase":"InitialBackupCreated","skippedPhase":"EnsureStagePodsFromOrphanedPVCs"}
{"level":"info","ts":1616690995787,"logger":"migration|46d8t","msg":"Skipped phase due to flag evaluation.","migMigration":"f969f980-8d89-11eb-be8b-6b964d3a5d1d","phase":"InitialBackupCreated","skippedPhase":"StagePodsCreated"}
{"level":"info","ts":1616690995787,"logger":"migration|46d8t","msg":"Skipped phase due to flag evaluation.","migMigration":"f969f980-8d89-11eb-be8b-6b964d3a5d1d","phase":"InitialBackupCreated","skippedPhase":"RestartRestic"}
{"level":"info","ts":1616690996338,"logger":"migration|46d8t","msg":"Skipped phase due to flag evaluation.","migMigration":"f969f980-8d89-11eb-be8b-6b964d3a5d1d","phase":"InitialBackupCreated","skippedPhase":"AnnotateResources"}
{"level":"info","ts":1616690996460,"logger":"migration|xwt5s","msg":"[RUN] (Step 25/48) Waiting for Restic Pods to restart, ensuring latest PVC mounts are available for PVC backups.","migMigration":"f969f980-8d89-11eb-be8b-6b964d3a5d1d","phase":"WaitForResticReady"}
{"level":"info","ts":1616690997061,"logger":"migration|sjm48","msg":"[RUN] (Step 26/48) Quiescing (Scaling to 0 replicas): Deployments, DeploymentConfigs, StatefulSets, ReplicaSets, DaemonSets, CronJobs and Jobs.","migMigration":"f969f980-8d89-11eb-be8b-6b964d3a5d1d","phase":"QuiesceApplications"}
```
