### PR TITLE
Check for resource staleness, requeue if stale

### DIFF
--- a/pkg/cache/stale.go
+++ b/pkg/cache/stale.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2021 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Functions in this file solve the problem of duplicate reconciles when the cached
+// client hasn't received the latest resource and feeds a stale resource to controller.
+// We will reject reconciling a resource if its generation is older than one we've
+// successfully reconciled.
+
+// UIDToGenerationMap keeps track of highest observed generation of a particular resource UID
+type UIDToGenerationMap struct {
+	mutex                   sync.RWMutex
+	resourceUIDtoGeneration map[types.UID]int64
+}
+
+// CreateUIDToGenerationMap creates a new UID => generation map
+func CreateUIDToGenerationMap() *UIDToGenerationMap {
+	uidGenMap := UIDToGenerationMap{}
+	uidGenMap.resourceUIDtoGeneration = make(map[types.UID]int64)
+	return &uidGenMap
+}
+
+// getGenerationForUID returns the latest successfully reconciled resource generation
+// returns -1 if not found.
+func (u *UIDToGenerationMap) getGenerationForUID(resourceUID types.UID) int64 {
+	u.mutex.Lock()
+	defer u.mutex.Unlock()
+	generation, ok := u.resourceUIDtoGeneration[resourceUID]
+	if !ok {
+		return -1
+	}
+	return generation
+}
+
+// setGenerationForUID returns the latest successfully reconciled resource generation
+func (u *UIDToGenerationMap) setGenerationForUID(resourceUID types.UID, generation int64) {
+	u.mutex.Lock()
+	defer u.mutex.Unlock()
+	u.resourceUIDtoGeneration[resourceUID] = generation
+}
+
+// IsCacheStale checks if the cached client is providing a resource we've successfully reconciled.
+func (u *UIDToGenerationMap) IsCacheStale(resourceUID types.UID, generation int64) bool {
+	reconciledGeneration := u.getGenerationForUID(resourceUID)
+	// Resource should be reconciled if we've never seen it
+	if generation == -1 {
+		return false
+	}
+	// Resource is stale if we've reconciled a newer generation
+	if generation < reconciledGeneration {
+		return true
+	}
+	return false
+}
+
+// RecordReconciledGeneration records that a resource UID generation was pushed back to the APIserver
+func (u *UIDToGenerationMap) RecordReconciledGeneration(resourceUID types.UID, generation int64) {
+	u.setGenerationForUID(resourceUID, generation)
+}

--- a/pkg/controller/directimagemigration/directimagemigration_controller.go
+++ b/pkg/controller/directimagemigration/directimagemigration_controller.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/konveyor/controller/pkg/logging"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/cache"
 	migref "github.com/konveyor/mig-controller/pkg/reference"
 	"github.com/opentracing/opentracing-go"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -46,9 +47,10 @@ func Add(mgr manager.Manager) error {
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileDirectImageMigration{
-		Client:        mgr.GetClient(),
-		scheme:        mgr.GetScheme(),
-		EventRecorder: mgr.GetRecorder("directimagemigration_controller"),
+		Client:           mgr.GetClient(),
+		scheme:           mgr.GetScheme(),
+		EventRecorder:    mgr.GetRecorder("directimagemigration_controller"),
+		uidGenerationMap: cache.CreateUIDToGenerationMap(),
 	}
 }
 
@@ -99,8 +101,9 @@ var _ reconcile.Reconciler = &ReconcileDirectImageMigration{}
 type ReconcileDirectImageMigration struct {
 	client.Client
 	record.EventRecorder
-	scheme *runtime.Scheme
-	tracer opentracing.Tracer
+	scheme           *runtime.Scheme
+	tracer           opentracing.Tracer
+	uidGenerationMap *cache.UIDToGenerationMap
 }
 
 // Reconcile reads that state of the cluster for a DirectImageMigration object and makes changes based on the state read
@@ -125,6 +128,13 @@ func (r *ReconcileDirectImageMigration) Reconcile(request reconcile.Request) (re
 		// Error reading the object - requeue the request.
 		return reconcile.Result{Requeue: true}, err
 	}
+
+	// Check if cache is still catching up
+	if r.uidGenerationMap.IsCacheStale(imageMigration.UID, imageMigration.Generation) {
+		return reconcile.Result{Requeue: true}, nil
+	}
+	// Record reconciled generation
+	defer r.uidGenerationMap.RecordReconciledGeneration(imageMigration.UID, imageMigration.Generation)
 
 	// Set up jaeger tracing
 	reconcileSpan := r.initTracer(imageMigration)

--- a/pkg/controller/directimagestreammigration/directimagestreammigration_controller.go
+++ b/pkg/controller/directimagestreammigration/directimagestreammigration_controller.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/konveyor/controller/pkg/logging"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/cache"
 	migref "github.com/konveyor/mig-controller/pkg/reference"
 	"github.com/opentracing/opentracing-go"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -46,9 +47,10 @@ func Add(mgr manager.Manager) error {
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileDirectImageStreamMigration{
-		Client:        mgr.GetClient(),
-		scheme:        mgr.GetScheme(),
-		EventRecorder: mgr.GetRecorder("directimagestreammigration_controller"),
+		Client:           mgr.GetClient(),
+		scheme:           mgr.GetScheme(),
+		EventRecorder:    mgr.GetRecorder("directimagestreammigration_controller"),
+		uidGenerationMap: cache.CreateUIDToGenerationMap(),
 	}
 }
 
@@ -90,8 +92,9 @@ var _ reconcile.Reconciler = &ReconcileDirectImageStreamMigration{}
 type ReconcileDirectImageStreamMigration struct {
 	client.Client
 	record.EventRecorder
-	scheme *runtime.Scheme
-	tracer opentracing.Tracer
+	scheme           *runtime.Scheme
+	tracer           opentracing.Tracer
+	uidGenerationMap *cache.UIDToGenerationMap
 }
 
 // Reconcile reads that state of the cluster for a DirectImageStreamMigration object and makes changes based on the state read
@@ -116,6 +119,14 @@ func (r *ReconcileDirectImageStreamMigration) Reconcile(request reconcile.Reques
 		// Error reading the object - requeue the request.
 		return reconcile.Result{Requeue: true}, err
 	}
+
+	// Check if cache is still catching up
+	if r.uidGenerationMap.IsCacheStale(imageStreamMigration.UID, imageStreamMigration.Generation) {
+		return reconcile.Result{Requeue: true}, nil
+	}
+	// Record reconciled generation
+	defer r.uidGenerationMap.RecordReconciledGeneration(
+		imageStreamMigration.UID, imageStreamMigration.Generation)
 
 	// Set up jaeger tracing
 	reconcileSpan, err := r.initTracer(*imageStreamMigration)

--- a/pkg/controller/directvolumemigration/directvolumemigration_controller.go
+++ b/pkg/controller/directvolumemigration/directvolumemigration_controller.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/konveyor/controller/pkg/logging"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/cache"
 	"github.com/opentracing/opentracing-go"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,7 +44,11 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileDirectVolumeMigration{Client: mgr.GetClient(), scheme: mgr.GetScheme()}
+	return &ReconcileDirectVolumeMigration{
+		Client:           mgr.GetClient(),
+		scheme:           mgr.GetScheme(),
+		uidGenerationMap: cache.CreateUIDToGenerationMap(),
+	}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -79,8 +84,9 @@ var _ reconcile.Reconciler = &ReconcileDirectVolumeMigration{}
 // ReconcileDirectVolumeMigration reconciles a DirectVolumeMigration object
 type ReconcileDirectVolumeMigration struct {
 	client.Client
-	scheme *runtime.Scheme
-	tracer opentracing.Tracer
+	scheme           *runtime.Scheme
+	tracer           opentracing.Tracer
+	uidGenerationMap *cache.UIDToGenerationMap
 }
 
 // Reconcile reads that state of the cluster for a DirectVolumeMigration object and makes changes based on the state read
@@ -106,6 +112,13 @@ func (r *ReconcileDirectVolumeMigration) Reconcile(request reconcile.Request) (r
 		// Error reading the object - requeue the request.
 		return reconcile.Result{Requeue: true}, err
 	}
+
+	// Check if cache is still catching up
+	if r.uidGenerationMap.IsCacheStale(direct.UID, direct.Generation) {
+		return reconcile.Result{Requeue: true}, nil
+	}
+	// Record reconciled generation
+	defer r.uidGenerationMap.RecordReconciledGeneration(direct.UID, direct.Generation)
 
 	// Set up jaeger tracing
 	reconcileSpan := r.initTracer(direct)


### PR DESCRIPTION
Resolves #1026 by keeping track of the latest generation of each resource UID we've reconciled. We will requeue if the cached client feeds us a resource generation < what we've already reconciled.


### Illustration of problem from #1026 
![image](https://user-images.githubusercontent.com/7576968/112673382-07cca980-8e3b-11eb-8548-bf07996adc67.png)


