### PR TITLE
Add jaeger to remaining controllers, pass spans in ctx

### DIFF
--- a/pkg/controller/directimagestreammigration/migrate.go
+++ b/pkg/controller/directimagestreammigration/migrate.go
@@ -17,18 +17,18 @@ limitations under the License.
 package directimagestreammigration
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/konveyor/mig-controller/pkg/errorutil"
-	"github.com/opentracing/opentracing-go"
 
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (r *ReconcileDirectImageStreamMigration) migrate(imageStreamMigration *migapi.DirectImageStreamMigration, reconcileSpan opentracing.Span) (time.Duration, error) {
+func (r *ReconcileDirectImageStreamMigration) migrate(ctx context.Context, imageStreamMigration *migapi.DirectImageStreamMigration) (time.Duration, error) {
 	// Started
 	if imageStreamMigration.Status.StartTimestamp == nil {
 		log.Info("Marking DirectImageStreamMigration as started.")
@@ -42,10 +42,9 @@ func (r *ReconcileDirectImageStreamMigration) migrate(imageStreamMigration *miga
 		Owner:  imageStreamMigration,
 		Phase:  imageStreamMigration.Status.Phase,
 
-		Tracer:        r.tracer,
-		ReconcileSpan: reconcileSpan,
+		Tracer: r.tracer,
 	}
-	err := task.Run()
+	err := task.Run(ctx)
 	if err != nil {
 		if errors.IsConflict(errorutil.Unwrap(err)) {
 			return FastReQ, nil

--- a/pkg/controller/miganalytic/trace.go
+++ b/pkg/controller/miganalytic/trace.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package miganalytic
+
+import (
+	"github.com/opentracing/opentracing-go"
+
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/settings"
+	migtrace "github.com/konveyor/mig-controller/pkg/tracing"
+)
+
+// Given a MigStorage, return a reconcile-scoped Jaeger span.
+func (r *ReconcileMigAnalytic) initTracer(miganalytic *migapi.MigAnalytic) opentracing.Span {
+	// Exit if tracing disabled
+	if !settings.Settings.JaegerOpts.Enabled {
+		return nil
+	}
+	// Set tracer on reconciler if it's not already present.
+	// We will never close this, so the 'closer' is discarded.
+	if r.tracer == nil {
+		r.tracer, _ = migtrace.InitJaeger("MigAnalytic")
+	}
+	// Begin reconcile span
+	reconcileSpan := r.tracer.StartSpan("miganalytic-reconcile-" + miganalytic.Name)
+
+	return reconcileSpan
+}

--- a/pkg/controller/migcluster/trace.go
+++ b/pkg/controller/migcluster/trace.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migcluster
+
+import (
+	"github.com/opentracing/opentracing-go"
+
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/settings"
+	migtrace "github.com/konveyor/mig-controller/pkg/tracing"
+)
+
+// Given a MigCluster, return a reconcile-scoped Jaeger span.
+func (r *ReconcileMigCluster) initTracer(migcluster *migapi.MigCluster) opentracing.Span {
+	// Exit if tracing disabled
+	if !settings.Settings.JaegerOpts.Enabled {
+		return nil
+	}
+	// Set tracer on reconciler if it's not already present.
+	// We will never close this, so the 'closer' is discarded.
+	if r.tracer == nil {
+		r.tracer, _ = migtrace.InitJaeger("MigCluster")
+	}
+	// Begin reconcile span
+	reconcileSpan := r.tracer.StartSpan("migcluster-reconcile-" + migcluster.Name)
+
+	return reconcileSpan
+}

--- a/pkg/controller/migcluster/validation.go
+++ b/pkg/controller/migcluster/validation.go
@@ -15,6 +15,7 @@ import (
 	liberr "github.com/konveyor/controller/pkg/error"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/konveyor/mig-controller/pkg/reference"
+	"github.com/opentracing/opentracing-go"
 )
 
 // Types
@@ -56,39 +57,45 @@ const (
 
 // Validate the asset collection resource.
 // Returns error and the total error conditions set.
-func (r ReconcileMigCluster) validate(cluster *migapi.MigCluster) error {
+func (r ReconcileMigCluster) validate(ctx context.Context, cluster *migapi.MigCluster) error {
+	if opentracing.SpanFromContext(ctx) != nil {
+		var span opentracing.Span
+		span, ctx = opentracing.StartSpanFromContextWithTracer(ctx, r.tracer, "validate")
+		defer span.Finish()
+	}
+
 	// General settings
-	err := r.validateURL(cluster)
+	err := r.validateURL(ctx, cluster)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
 
 	// SA secret
-	err = r.validateSaSecret(cluster)
+	err = r.validateSaSecret(ctx, cluster)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
 
 	// Test Connection
-	err = r.testConnection(cluster)
+	err = r.testConnection(ctx, cluster)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
 
 	// Token privileges
-	err = r.validateSaTokenPrivileges(cluster)
+	err = r.validateSaTokenPrivileges(ctx, cluster)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
 
 	// Exposed registry route
-	err = r.validateRegistryRoute(cluster)
+	err = r.validateRegistryRoute(ctx, cluster)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
 
 	// cluster version
-	err = r.validateOperatorVersionMatchesHost(cluster)
+	err = r.validateOperatorVersionMatchesHost(ctx, cluster)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
@@ -96,7 +103,12 @@ func (r ReconcileMigCluster) validate(cluster *migapi.MigCluster) error {
 	return nil
 }
 
-func (r ReconcileMigCluster) validateURL(cluster *migapi.MigCluster) error {
+func (r ReconcileMigCluster) validateURL(ctx context.Context, cluster *migapi.MigCluster) error {
+	if opentracing.SpanFromContext(ctx) != nil {
+		span, _ := opentracing.StartSpanFromContextWithTracer(ctx, r.tracer, "validateURL")
+		defer span.Finish()
+	}
+
 	// Not needed.
 	if cluster.Spec.IsHostCluster {
 		return nil
@@ -136,7 +148,12 @@ func (r ReconcileMigCluster) validateURL(cluster *migapi.MigCluster) error {
 	return nil
 }
 
-func (r ReconcileMigCluster) validateSaSecret(cluster *migapi.MigCluster) error {
+func (r ReconcileMigCluster) validateSaSecret(ctx context.Context, cluster *migapi.MigCluster) error {
+	if opentracing.SpanFromContext(ctx) != nil {
+		span, _ := opentracing.StartSpanFromContextWithTracer(ctx, r.tracer, "validateSaSecret")
+		defer span.Finish()
+	}
+
 	ref := cluster.Spec.ServiceAccountSecretRef
 
 	// Not needed.
@@ -206,7 +223,12 @@ func (r ReconcileMigCluster) validateSaSecret(cluster *migapi.MigCluster) error 
 }
 
 // Test the connection.
-func (r ReconcileMigCluster) testConnection(cluster *migapi.MigCluster) error {
+func (r ReconcileMigCluster) testConnection(ctx context.Context, cluster *migapi.MigCluster) error {
+	if opentracing.SpanFromContext(ctx) != nil {
+		span, _ := opentracing.StartSpanFromContextWithTracer(ctx, r.tracer, "testConnection")
+		defer span.Finish()
+	}
+
 	if cluster.Spec.IsHostCluster {
 		return nil
 	}
@@ -238,7 +260,11 @@ func (r ReconcileMigCluster) testConnection(cluster *migapi.MigCluster) error {
 }
 
 // Validate the Exposed registry route
-func (r ReconcileMigCluster) validateRegistryRoute(cluster *migapi.MigCluster) error {
+func (r ReconcileMigCluster) validateRegistryRoute(ctx context.Context, cluster *migapi.MigCluster) error {
+	if opentracing.SpanFromContext(ctx) != nil {
+		span, _ := opentracing.StartSpanFromContextWithTracer(ctx, r.tracer, "validateRegistryRoute")
+		defer span.Finish()
+	}
 
 	if cluster.Status.HasCriticalCondition() {
 		return nil
@@ -300,7 +326,12 @@ func (r ReconcileMigCluster) validateRegistryRoute(cluster *migapi.MigCluster) e
 	return nil
 }
 
-func (r *ReconcileMigCluster) validateSaTokenPrivileges(cluster *migapi.MigCluster) error {
+func (r *ReconcileMigCluster) validateSaTokenPrivileges(ctx context.Context, cluster *migapi.MigCluster) error {
+	if opentracing.SpanFromContext(ctx) != nil {
+		span, _ := opentracing.StartSpanFromContextWithTracer(ctx, r.tracer, "validateSaTokenPrivileges")
+		defer span.Finish()
+	}
+
 	if cluster.Spec.IsHostCluster {
 		return nil
 	}
@@ -359,7 +390,12 @@ func (r *ReconcileMigCluster) validateSaTokenPrivileges(cluster *migapi.MigClust
 }
 
 // validate operator version.
-func (r ReconcileMigCluster) validateOperatorVersionMatchesHost(cluster *migapi.MigCluster) error {
+func (r ReconcileMigCluster) validateOperatorVersionMatchesHost(ctx context.Context, cluster *migapi.MigCluster) error {
+	if opentracing.SpanFromContext(ctx) != nil {
+		span, _ := opentracing.StartSpanFromContextWithTracer(ctx, r.tracer, "validateOperatorVersionMatchesHost")
+		defer span.Finish()
+	}
+
 	if cluster.Spec.IsHostCluster {
 		return nil
 	}

--- a/pkg/controller/mighook/trace.go
+++ b/pkg/controller/mighook/trace.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mighook
+
+import (
+	"github.com/opentracing/opentracing-go"
+
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/settings"
+	migtrace "github.com/konveyor/mig-controller/pkg/tracing"
+)
+
+// Given a MigHook, return a reconcile-scoped Jaeger span.
+func (r *ReconcileMigHook) initTracer(mighook *migapi.MigHook) opentracing.Span {
+	// Exit if tracing disabled
+	if !settings.Settings.JaegerOpts.Enabled {
+		return nil
+	}
+	// Set tracer on reconciler if it's not already present.
+	// We will never close this, so the 'closer' is discarded.
+	if r.tracer == nil {
+		r.tracer, _ = migtrace.InitJaeger("MigHook")
+	}
+	// Begin reconcile span
+	reconcileSpan := r.tracer.StartSpan("mighook-reconcile-" + mighook.Name)
+
+	return reconcileSpan
+}

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -17,12 +17,12 @@ limitations under the License.
 package migmigration
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/konveyor/mig-controller/pkg/errorutil"
 	migtrace "github.com/konveyor/mig-controller/pkg/tracing"
-	"github.com/opentracing/opentracing-go"
 
 	mapset "github.com/deckarep/golang-set"
 	liberr "github.com/konveyor/controller/pkg/error"
@@ -33,7 +33,7 @@ import (
 )
 
 // Perform the migration.
-func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration, reconcileSpan opentracing.Span) (time.Duration, error) {
+func (r *ReconcileMigMigration) migrate(ctx context.Context, migration *migapi.MigMigration) (time.Duration, error) {
 	// Ready
 	plan, err := migration.GetPlan(r)
 	if err != nil {
@@ -66,9 +66,8 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration, reconcil
 		Annotations:     r.getAnnotations(migration),
 		BackupResources: r.getBackupResources(migration),
 		Tracer:          r.tracer,
-		ReconcileSpan:   reconcileSpan,
 	}
-	err = task.Run()
+	err = task.Run(ctx)
 	if err != nil {
 		if errors.IsConflict(errorutil.Unwrap(err)) {
 			log.V(4).Info("Conflict error during task.Run, requeueing.")

--- a/pkg/controller/migplan/gvk.go
+++ b/pkg/controller/migplan/gvk.go
@@ -1,14 +1,22 @@
 package migplan
 
 import (
+	"context"
+
 	liberr "github.com/konveyor/controller/pkg/error"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/konveyor/mig-controller/pkg/gvk"
+	"github.com/opentracing/opentracing-go"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 )
 
-func (r ReconcileMigPlan) compareGVK(plan *migapi.MigPlan) error {
+func (r ReconcileMigPlan) compareGVK(ctx context.Context, plan *migapi.MigPlan) error {
+	if opentracing.SpanFromContext(ctx) != nil {
+		span, _ := opentracing.StartSpanFromContextWithTracer(ctx, r.tracer, "compareGVK")
+		defer span.Finish()
+	}
+
 	// No spec chage this time
 	if plan.HasReconciled() || !clustersReady(plan) {
 		plan.Status.StageCondition(GVKsIncompatible)

--- a/pkg/controller/migplan/migplan_controller_test.go
+++ b/pkg/controller/migplan/migplan_controller_test.go
@@ -366,7 +366,7 @@ func TestReconcileMigPlan_ensureMigAnalytics(t *testing.T) {
 				EventRecorder: tt.fields.EventRecorder,
 				scheme:        tt.fields.scheme,
 			}
-			if err := r.ensureMigAnalytics(tt.args.plan); (err != nil) != tt.wantErr {
+			if err := r.ensureMigAnalytics(context.TODO(), tt.args.plan); (err != nil) != tt.wantErr {
 				t.Errorf("ensureMigAnalytics() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			gotList := &migapi.MigAnalyticList{}
@@ -443,7 +443,7 @@ func TestReconcileMigPlan_waitForMigAnalyticsReady(t *testing.T) {
 				EventRecorder: tt.fields.EventRecorder,
 				scheme:        tt.fields.scheme,
 			}
-			got, err := r.checkIfMigAnalyticsReady(tt.args.plan)
+			got, err := r.checkIfMigAnalyticsReady(context.TODO(), tt.args.plan)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("checkIfMigAnalyticsReady() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/migplan/storage.go
+++ b/pkg/controller/migplan/storage.go
@@ -6,6 +6,7 @@ import (
 
 	liberr "github.com/konveyor/controller/pkg/error"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/opentracing/opentracing-go"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -16,7 +17,11 @@ import (
 // Create the velero BackupStorageLocation(s) and VolumeSnapshotLocation(s)
 // have been created on both the source and destination clusters associated
 // with the migration plan.
-func (r ReconcileMigPlan) ensureStorage(plan *migapi.MigPlan) error {
+func (r ReconcileMigPlan) ensureStorage(ctx context.Context, plan *migapi.MigPlan) error {
+	if opentracing.SpanFromContext(ctx) != nil {
+		span, _ := opentracing.StartSpanFromContextWithTracer(ctx, r.tracer, "ensureStorage")
+		defer span.Finish()
+	}
 	var client k8sclient.Client
 	nEnsured := 0
 

--- a/pkg/controller/migplan/trace.go
+++ b/pkg/controller/migplan/trace.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migplan
+
+import (
+	"github.com/opentracing/opentracing-go"
+
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/settings"
+	migtrace "github.com/konveyor/mig-controller/pkg/tracing"
+)
+
+// Given a MigPlan, return a reconcile-scoped Jaeger span.
+func (r *ReconcileMigPlan) initTracer(migplan *migapi.MigPlan) opentracing.Span {
+	// Exit if tracing disabled
+	if !settings.Settings.JaegerOpts.Enabled {
+		return nil
+	}
+	// Set tracer on reconciler if it's not already present.
+	// We will never close this, so the 'closer' is discarded.
+	if r.tracer == nil {
+		r.tracer, _ = migtrace.InitJaeger("MigPlan")
+	}
+	// Begin reconcile span
+	reconcileSpan := r.tracer.StartSpan("migplan-reconcile-" + migplan.Name)
+
+	return reconcileSpan
+}

--- a/pkg/controller/migstorage/trace.go
+++ b/pkg/controller/migstorage/trace.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migstorage
+
+import (
+	"github.com/opentracing/opentracing-go"
+
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/settings"
+	migtrace "github.com/konveyor/mig-controller/pkg/tracing"
+)
+
+// Given a MigStorage, return a reconcile-scoped Jaeger span.
+func (r *ReconcileMigStorage) initTracer(migstorage *migapi.MigStorage) opentracing.Span {
+	// Exit if tracing disabled
+	if !settings.Settings.JaegerOpts.Enabled {
+		return nil
+	}
+	// Set tracer on reconciler if it's not already present.
+	// We will never close this, so the 'closer' is discarded.
+	if r.tracer == nil {
+		r.tracer, _ = migtrace.InitJaeger("MigStorage")
+	}
+	// Begin reconcile span
+	reconcileSpan := r.tracer.StartSpan("migstorage-reconcile-" + migstorage.Name)
+
+	return reconcileSpan
+}


### PR DESCRIPTION
See example image. This adds a trace for validations on the controllers currently instrumented for Jaeger tracing.

- MigMigration
- DirectImageMigration
- DirectImageStreamMigration
- DirectVolumeMigration
- MigPlan

![image](https://user-images.githubusercontent.com/7576968/112690822-cfd16080-8e52-11eb-9e8e-931e2fe4d6f8.png)

### MigPlan validations

![image](https://user-images.githubusercontent.com/7576968/112695385-56d60700-8e5a-11eb-9306-5f30309eff89.png)

