### PR TITLE
Fix typo from structured logging PR

### DIFF
--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -184,7 +184,7 @@ func (t *Task) init() error {
 }
 
 func (t *Task) Run() error {
-	t.Log = t.Log.WithValues("Phase", t.Phase)
+	t.Log = t.Log.WithValues("phase", t.Phase)
 	// Init
 	err := t.init()
 	if err != nil {


### PR DESCRIPTION
Going to go ahead and merge this, one char change. Breaks phase timing table.