### PR TITLE
Introduce cached client behind feature flag

### DIFF
--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -148,7 +148,8 @@ func (t *Task) areRsyncTransferPodsRunning() (arePodsRunning bool, nonRunningPod
 				migevent.LogAbnormalEventsForResource(
 					destClient, t.Log,
 					"Found abnormal event for Rsync transfer Pod on destination cluster",
-					types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, "Pod")
+					types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
+					pod.UID, "Pod")
 
 				isUnschedulable := false
 				for _, podCond := range pod.Status.Conditions {
@@ -815,7 +816,8 @@ func (t *Task) areRsyncRoutesAdmitted() (bool, []string, error) {
 		migevent.LogAbnormalEventsForResource(
 			destClient, t.Log,
 			"Found abnormal event for Rsync Route on destination cluster",
-			types.NamespacedName{Namespace: route.Namespace, Name: route.Name}, "Route")
+			types.NamespacedName{Namespace: route.Namespace, Name: route.Name},
+			route.UID, "Route")
 
 		admitted := false
 		message := "no status condition available for the route"

--- a/pkg/controller/migcluster/remote_watch.go
+++ b/pkg/controller/migcluster/remote_watch.go
@@ -36,7 +36,6 @@ func StartRemoteWatch(r *ReconcileMigCluster, config remote.ManagerConfig) error
 		return liberr.Wrap(err)
 	}
 
-	// sigStopChan := make(chan struct{})
 	ctx := context.TODO()
 	ctx, stopFunc := context.WithCancel(ctx)
 	log.Info("Remote cache: Starting manager for MigCluster",
@@ -133,7 +132,6 @@ func StopRemoteWatch(nsName types.NamespacedName) {
 	remoteWatchMap := remote.GetWatchMap()
 	remoteWatchCluster := remoteWatchMap.Get(nsName)
 	if remoteWatchCluster != nil {
-		// close(remoteWatchCluster.StopChannel)
 		remoteWatchCluster.StopFunc()
 		remoteWatchMap.Delete(nsName)
 	}

--- a/pkg/controller/migcluster/remote_watch.go
+++ b/pkg/controller/migcluster/remote_watch.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2021 Red Hat Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migcluster
+
+import (
+	"context"
+	"strconv"
+
+	liberr "github.com/konveyor/controller/pkg/error"
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/remote"
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// StartRemoteWatch will configure a new RemoteWatcher manager that provides a cached client
+func StartRemoteWatch(r *ReconcileMigCluster, config remote.ManagerConfig) error {
+	remoteWatchMap := remote.GetWatchMap()
+
+	mgr, err := manager.New(config.RemoteRestConfig, manager.Options{Scheme: config.Scheme, MetricsBindAddress: "0"})
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+
+	// sigStopChan := make(chan struct{})
+	ctx := context.TODO()
+	ctx, stopFunc := context.WithCancel(ctx)
+	log.Info("Remote cache: Starting manager for MigCluster",
+		"migCluster", config.ParentNsName)
+	go mgr.Start(ctx)
+
+	// Indexes
+	indexer := mgr.GetFieldIndexer()
+
+	// Plan
+	err = indexer.IndexField(
+		context.TODO(),
+		&migapi.MigPlan{},
+		migapi.ClosedIndexField,
+		func(rawObj k8sclient.Object) []string {
+			p, cast := rawObj.(*migapi.MigPlan)
+			if !cast {
+				return nil
+			}
+			return []string{
+				strconv.FormatBool(p.Spec.Closed),
+			}
+		})
+	if err != nil {
+		stopFunc()
+		return err
+	}
+	// Pod
+	err = indexer.IndexField(
+		context.TODO(),
+		&kapi.Pod{},
+		"status.phase",
+		func(rawObj k8sclient.Object) []string {
+			p, cast := rawObj.(*kapi.Pod)
+			if !cast {
+				return nil
+			}
+			return []string{
+				string(p.Status.Phase),
+			}
+		})
+	if err != nil {
+		stopFunc()
+		return err
+	}
+	// Event
+	err = indexer.IndexField(
+		context.TODO(),
+		&kapi.Event{},
+		"involvedObject.uid",
+		func(rawObj k8sclient.Object) []string {
+			e, cast := rawObj.(*kapi.Event)
+			if !cast {
+				return nil
+			}
+			return []string{
+				string(e.InvolvedObject.UID),
+			}
+		})
+	if err != nil {
+		stopFunc()
+		return err
+	}
+
+	log.Info("Remote cache: Manager started for MigCluster",
+		"migCluster", config.ParentNsName)
+
+	// Create remoteWatchCluster tracking obj and attach reference to parent object so we don't create extra
+	remoteWatchCluster := &remote.WatchCluster{RemoteManager: mgr, StopFunc: stopFunc}
+
+	// MigClusters have a 1:1 association with a RemoteWatchCluster, so we will store the mapping
+	// to avoid creating duplicate remote managers in the future.
+	remoteWatchMap.Set(config.ParentNsName, remoteWatchCluster)
+
+	return nil
+}
+
+// IsRemoteWatchConsistent checks whether remote watch in-memory is consistent with given new config
+func IsRemoteWatchConsistent(nsName types.NamespacedName, config *rest.Config) bool {
+	inMemoryWatch := remote.GetWatchMap().Get(types.NamespacedName{
+		Name:      nsName.Name,
+		Namespace: nsName.Namespace,
+	})
+	if inMemoryWatch == nil {
+		return false
+	}
+	inMemoryConfig := inMemoryWatch.RemoteManager.GetConfig()
+	return migapi.AreRestConfigsEqual(inMemoryConfig, config)
+}
+
+// StopRemoteWatch will run the remote manager stopFunc
+// and delete it from the remote watch map.
+func StopRemoteWatch(nsName types.NamespacedName) {
+	remoteWatchMap := remote.GetWatchMap()
+	remoteWatchCluster := remoteWatchMap.Get(nsName)
+	if remoteWatchCluster != nil {
+		// close(remoteWatchCluster.StopChannel)
+		remoteWatchCluster.StopFunc()
+		remoteWatchMap.Delete(nsName)
+	}
+}

--- a/pkg/controller/migmigration/hooks.go
+++ b/pkg/controller/migmigration/hooks.go
@@ -159,7 +159,8 @@ func (t *Task) ensureJob(job *batchv1.Job, hook migapi.MigPlanHook, migHook miga
 		migevent.LogAbnormalEventsForResource(
 			client, t.Log,
 			"Found abnormal event for Hook Job",
-			types.NamespacedName{Namespace: runningJob.Namespace, Name: runningJob.Name}, "Job")
+			types.NamespacedName{Namespace: runningJob.Namespace, Name: runningJob.Name},
+			runningJob.UID, "Job")
 	}
 
 	if runningJob == nil && err == nil {

--- a/pkg/controller/migmigration/pod.go
+++ b/pkg/controller/migmigration/pod.go
@@ -152,7 +152,8 @@ func (t *Task) haveResticPodsStarted() (bool, error) {
 		migevent.LogAbnormalEventsForResource(
 			client, t.Log,
 			"Found abnormal event for Restic Pod",
-			types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, "Pod")
+			types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
+			pod.UID, "Pod")
 
 		if pod.DeletionTimestamp != nil {
 			t.Log.Info("Deletion timestamp found on Restic Pod, "+
@@ -221,7 +222,7 @@ func (t *Task) deleteVeleroPodsForCluster(cluster *migapi.MigCluster) error {
 		}
 		t.Log.Info("Deleting running Velero Pod on MigCluster",
 			"pod", path.Join(pod.Namespace, pod.Name),
-			"migCluster", cluster.Namespace, cluster.Name)
+			"migCluster", path.Join(cluster.Namespace, cluster.Name))
 		err = clusterClient.Delete(
 			context.TODO(),
 			&pod)
@@ -276,7 +277,8 @@ func (t *Task) haveVeleroPodsStarted() (bool, error) {
 			migevent.LogAbnormalEventsForResource(
 				client, t.Log,
 				"Found abnormal event for Velero Pod",
-				types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, "Pod")
+				types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
+				pod.UID, "Pod")
 
 			if pod.DeletionTimestamp != nil {
 				t.Log.Info("Found Velero Pod with deletion timestamp."+

--- a/pkg/controller/migmigration/stage.go
+++ b/pkg/controller/migmigration/stage.go
@@ -523,7 +523,8 @@ func (t *Task) stagePodReport(client k8sclient.Client) (report PodStartReport, e
 		migevent.LogAbnormalEventsForResource(
 			client, t.Log,
 			"Found abnormal event for Stage Pod",
-			types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, "Pod")
+			types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
+			pod.UID, "Pod")
 
 		initReady := true
 		for _, c := range pod.Status.InitContainerStatuses {

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -323,7 +323,8 @@ func ensureRegistryHealth(c k8sclient.Client, migration *migapi.MigMigration) (i
 			migevent.LogAbnormalEventsForResource(
 				client, log,
 				"Found abnormal event for Registry Pod",
-				types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, "Pod")
+				types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
+				pod.UID, "Pod")
 		}
 
 		registryPodCount := len(registryPods.Items)

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -2,7 +2,6 @@ package event
 
 import (
 	"context"
-	"fmt"
 	"path"
 
 	"github.com/go-logr/logr"
@@ -18,25 +17,28 @@ import (
 // related to a resource we're waiting on.
 // Make sure to pass in the kind exactly as it is capitalized on the event, e.g. "Pod"
 func GetAbnormalEventsForResource(client client.Client,
-	nsName types.NamespacedName, resourceKind string) ([]corev1.Event, error) {
+	resourceNsName types.NamespacedName, resourceUID types.UID) ([]corev1.Event, error) {
 	uniqueEventMap := make(map[string]corev1.Event)
 
 	eList := corev1.EventList{}
-	options := k8sclient.ListOptions{}
-	k8sclient.InNamespace(nsName.Namespace).ApplyToList(&options)
-	fieldSelector := fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=%s,type!=Normal",
-		nsName.Name, resourceKind)
-	selector, err := fields.ParseSelector(fieldSelector)
-	if err != nil {
-		return nil, fmt.Errorf("field selector construction failed: fieldSelector=[%v]", fieldSelector)
+
+	options := &k8sclient.ListOptions{
+		Namespace: resourceNsName.Namespace,
+		FieldSelector: fields.SelectorFromSet(
+			fields.Set{
+				"involvedObject.uid": string(resourceUID),
+			}),
 	}
-	matchingFields := k8sclient.MatchingFieldsSelector{Selector: selector}
-	matchingFields.ApplyToList(&options)
-	err = client.List(context.TODO(), &eList, &options)
+	k8sclient.InNamespace(resourceNsName.Namespace).ApplyToList(options)
+	err := client.List(context.TODO(), &eList, options)
 	if err != nil {
 		return nil, err
 	}
 	for _, event := range eList.Items {
+		// Check if event is a warning
+		if event.Type != corev1.EventTypeWarning {
+			continue
+		}
 		// Check if same event reason has already been seen
 		eventFromMap, ok := uniqueEventMap[event.Reason]
 		if !ok {
@@ -63,20 +65,21 @@ func GetAbnormalEventsForResource(client client.Client,
 // related to a resource we're waiting on.
 // The message logged will match what is provided in 'message'
 func LogAbnormalEventsForResource(
-	client client.Client, log logr.Logger, message string, nsName types.NamespacedName, resourceKind string) {
+	client client.Client, log logr.Logger, message string,
+	resourceNsName types.NamespacedName, resourceUID types.UID, resourceKind string) {
 
 	relevantEvents, err := GetAbnormalEventsForResource(client,
-		types.NamespacedName{Name: nsName.Name, Namespace: nsName.Namespace}, resourceKind)
+		types.NamespacedName{Name: resourceNsName.Name, Namespace: resourceNsName.Namespace}, resourceUID)
 	if err != nil {
 		log.Info("Error getting events",
 			"kind", resourceKind,
-			"resource", path.Join(nsName.Namespace, nsName.Name),
+			"resource", path.Join(resourceNsName.Namespace, resourceNsName.Name),
 			"error", err)
 		return
 	}
 	for _, rEvent := range relevantEvents {
 		log.Info(message,
-			resourceKind, path.Join(nsName.Namespace, nsName.Name),
+			resourceKind, path.Join(resourceNsName.Namespace, resourceNsName.Name),
 			"eventType", rEvent.Type,
 			"eventReason", rEvent.Reason,
 			"eventMessage", rEvent.Message,

--- a/pkg/remote/watch.go
+++ b/pkg/remote/watch.go
@@ -17,13 +17,13 @@ limitations under the License.
 package remote
 
 import (
+	"context"
 	"sync"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -39,16 +39,13 @@ type ManagerConfig struct {
 	// MigMigration v1.Object and runtime.Object needed for remote cluster to properly forward events
 	ParentMeta   v1.Object
 	ParentObject runtime.Object
+	Scheme       *runtime.Scheme
 }
-
-// TODO: add support for forwarding events to multiple channels so that MigStage and
-// MigMigration controllers can also be notified of Velero events on remote clusters.
 
 // WatchCluster tracks Remote Managers and Event Forward Channels
 type WatchCluster struct {
-	ForwardChannel chan event.GenericEvent
-	RemoteManager  manager.Manager
-	StopChannel    chan<- struct{}
+	RemoteManager manager.Manager
+	StopFunc      context.CancelFunc
 }
 
 // WatchMap provides a map between MigCluster nsNames and RemoteWatchClusters

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -20,10 +20,13 @@ const (
 	// Only the discovery should be loaded.
 	DiscoveryRole = "discovery"
 	// Proxy environment variables
-	HttpProxy        = "HTTP_PROXY"
-	HttpsProxy       = "HTTPS_PROXY"
-	NoProxy          = "NO_PROXY"
+	HttpProxy  = "HTTP_PROXY"
+	HttpsProxy = "HTTPS_PROXY"
+	NoProxy    = "NO_PROXY"
+	// Disable image copy
 	DisableImageCopy = "DISABLE_IMAGE_COPY"
+	// Enable cached remote client
+	EnableCachedClient = "ENABLE_CACHED_CLIENT"
 )
 
 // Global
@@ -35,7 +38,8 @@ type _Settings struct {
 	Discovery
 	Plan
 	DvmOpts
-	DisImgCopy bool
+	DisImgCopy         bool
+	EnableCachedClient bool
 	JaegerOpts
 	Roles     map[string]bool
 	ProxyVars map[string]string
@@ -69,6 +73,7 @@ func (r *_Settings) Load() error {
 	}
 
 	r.DisImgCopy = getEnvBool(DisableImageCopy, false)
+	r.EnableCachedClient = getEnvBool(EnableCachedClient, false)
 
 	return nil
 }


### PR DESCRIPTION
**Summary**

- Makes mig-controller go _BRRR_
- Reintroduces remote cluster cache behind feature flag `ENABLE_CACHED_CLIENT`
  - Each remote cluster gets its own manager with cache 
  - On `Create` and `Update`, blocks until the cache catches up 


Complement to operator PR: https://github.com/konveyor/mig-operator/pull/675

**To test**

```
# Local
ENABLE_CACHED_CLIENT=true make run-fast
```

**Open (Potential) Problems:**

* [x] Need to add safe map access to the stored list of clients. 

* [x] Need to properly handle teardown and recreation of client in shared map when a migcluster credential set changes
  - Need a graceful strategy for dealing with bad creds being given to the cache `manager` due to bad MigCluster creds (this may be handled by current logic)

* [x] Need to properly destroy manager which holds the cache when a migcluster is removed. 
  - This removal must be safe such that we don't crash due to someone else using the manager client as we destroy it

* [x] Need to make sure that `update` calls are blocking until receipt of update is present in our cache (e.g. a GET shows the expected resourceVersion)

* [x] Need to add a while polling for cache to populate after a `create` or `update` (for a rare race condition I'm imagining where we create something but something else deletes, we wouldn't want to hang forever waiting, maybe 10 second max)

