### PR TITLE
No traces on DVMP validation fail

### DIFF
--- a/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller.go
+++ b/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller.go
@@ -143,8 +143,7 @@ func (r *ReconcileDirectVolumeMigrationProgress) Reconcile(request reconcile.Req
 	// Validate
 	cluster, srcClient, err := r.validate(pvProgress)
 	if err != nil {
-		log.Info("Validation failed, requeueing")
-		log.Trace(err)
+		log.V(4).Info("Validation failed, requeueing", "error", err)
 		return reconcile.Result{Requeue: true}, nil
 	}
 

--- a/pkg/controller/directvolumemigrationprogress/validation.go
+++ b/pkg/controller/directvolumemigrationprogress/validation.go
@@ -34,7 +34,7 @@ func (r *ReconcileDirectVolumeMigrationProgress) validate(pvProgress *migapi.Dir
 	cluster *migapi.MigCluster, client compat.Client, err error) {
 	cluster, err = r.validateCluster(pvProgress)
 	if err != nil {
-		log.V(4).Error(err, "Validation check for referenced MigCluster failed")
+		log.V(4).Info("Validation check for referenced MigCluster failed", err)
 		err = liberr.Wrap(err)
 		return
 	}
@@ -48,7 +48,7 @@ func (r *ReconcileDirectVolumeMigrationProgress) validate(pvProgress *migapi.Dir
 	}
 	err = r.validateSpec(client, pvProgress)
 	if err != nil {
-		log.V(4).Error(err, "Validation check for spec failed")
+		log.V(4).Info("Validation check for spec failed", "error", err)
 		err = liberr.Wrap(err)
 		return
 	}

--- a/pkg/controller/directvolumemigrationprogress/validation.go
+++ b/pkg/controller/directvolumemigrationprogress/validation.go
@@ -34,7 +34,7 @@ func (r *ReconcileDirectVolumeMigrationProgress) validate(pvProgress *migapi.Dir
 	cluster *migapi.MigCluster, client compat.Client, err error) {
 	cluster, err = r.validateCluster(pvProgress)
 	if err != nil {
-		log.V(4).Info("Validation check for referenced MigCluster failed", err)
+		log.V(4).Info("Validation check for referenced MigCluster failed", "error", err)
 		err = liberr.Wrap(err)
 		return
 	}


### PR DESCRIPTION
log.V(4).error will override the loglevel and print the error regardless. I changed these to info messages with the error as a k/v.