### PR TITLE
Add common migMigration key to all controller involved in migration

### DIFF
--- a/pkg/apis/migration/v1alpha1/directimagestreammigration_types.go
+++ b/pkg/apis/migration/v1alpha1/directimagestreammigration_types.go
@@ -97,6 +97,19 @@ func (r *DirectImageStreamMigration) GetDIMforDISM(client k8sclient.Client) (*Di
 	return nil, nil
 }
 
+// Get the Migration associated with this DirectImageStreamMigration. If not owned, return nil.
+func (r *DirectImageStreamMigration) GetMigrationForDISM(client k8sclient.Client) (*MigMigration, error) {
+	dim, err := r.GetDIMforDISM(client)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+	migration, err := dim.GetMigrationForDIM(client)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+	return migration, nil
+}
+
 func (r *DirectImageStreamMigration) GetImageStream(c k8sclient.Client) (*imagev1.ImageStream, error) {
 	cluster, err := r.GetSourceCluster(c)
 	if err != nil {

--- a/pkg/apis/migration/v1alpha1/directvolumemigrationprogress_types.go
+++ b/pkg/apis/migration/v1alpha1/directvolumemigrationprogress_types.go
@@ -131,6 +131,19 @@ func (r *DirectVolumeMigrationProgress) GetDVMforDVMP(client k8sclient.Client) (
 	return nil, nil
 }
 
+// Get the MigMigration that owns this DirectVolumeMigrationProgress. If not owned, return nil.
+func (r *DirectVolumeMigrationProgress) GetMigrationforDVMP(client k8sclient.Client) (*MigMigration, error) {
+	dvm, err := r.GetDVMforDVMP(client)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+	migration, err := dvm.GetMigrationForDVM(client)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+	return migration, nil
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DirectVolumeMigrationProgressList contains a list of DirectVolumeMigrationProgress

--- a/pkg/controller/directimagemigration/directimagemigration_controller.go
+++ b/pkg/controller/directimagemigration/directimagemigration_controller.go
@@ -126,6 +126,12 @@ func (r *ReconcileDirectImageMigration) Reconcile(request reconcile.Request) (re
 		return reconcile.Result{Requeue: true}, err
 	}
 
+	// Set MigMigration name key on logger
+	migration, err := imageMigration.GetMigrationForDIM(r)
+	if migration != nil {
+		log.SetValues("migMigration", migration.Name)
+	}
+
 	// Set up jaeger tracing
 	reconcileSpan := r.initTracer(imageMigration)
 	if reconcileSpan != nil {

--- a/pkg/controller/directimagestreammigration/directimagestreammigration_controller.go
+++ b/pkg/controller/directimagestreammigration/directimagestreammigration_controller.go
@@ -117,6 +117,12 @@ func (r *ReconcileDirectImageStreamMigration) Reconcile(request reconcile.Reques
 		return reconcile.Result{Requeue: true}, err
 	}
 
+	// Set MigMigration name key on logger
+	migration, err := imageStreamMigration.GetMigrationForDISM(r)
+	if migration != nil {
+		log.SetValues("migMigration", migration.Name)
+	}
+
 	// Set up jaeger tracing
 	reconcileSpan, err := r.initTracer(*imageStreamMigration)
 	if reconcileSpan != nil {

--- a/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller.go
+++ b/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller.go
@@ -119,7 +119,7 @@ func (r *ReconcileDirectVolumeMigrationProgress) Reconcile(request reconcile.Req
 	}
 
 	// Set MigMigration name key on logger
-	migration, err := pvProgress.GetDVMforDVMP(r)
+	migration, err := pvProgress.GetMigrationforDVMP(r)
 	if migration != nil {
 		log.SetValues("migMigration", migration.Name)
 	}

--- a/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller.go
+++ b/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller.go
@@ -118,6 +118,12 @@ func (r *ReconcileDirectVolumeMigrationProgress) Reconcile(request reconcile.Req
 		return reconcile.Result{Requeue: true}, err
 	}
 
+	// Set MigMigration name key on logger
+	migration, err := pvProgress.GetDVMforDVMP(r)
+	if migration != nil {
+		log.SetValues("migMigration", migration.Name)
+	}
+
 	// Set up jaeger tracing
 	reconcileSpan, err := r.initTracer(*pvProgress)
 	if reconcileSpan != nil {


### PR DESCRIPTION
@eriknelson requested we get this one into 1.4.3 since it is an easy add-on.

This change makes DVM, DVMP, DIM, DISM attach the migMigration name to their log messages if they are associated with a migmigration, otherwise they just leave it out.

```json
{"level":"info","ts":1617223088168,
"logger":"directvolume|78jbc",
"msg":"Getting Rsync Password from Secret on host MigCluster",
"dvm":"56dcf8d0-9260-11eb-b77e-f5309eab2e0b-tjx7r",
"migMigration":"56dcf8d0-9260-11eb-b77e-f5309eab2e0b",
"phase":"RunRsyncOperations",
"secret":""}    
```

The idea here is that we will be able to easily grep for all log messages associated with a particular migration.

This matches the key already being used in the migmigration controller.