### PR TITLE
Use server-side filtering of events when looking for abnormalities

### DIFF
--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -144,8 +144,7 @@ func (t *Task) areRsyncTransferPodsRunning() (bool, error) {
 				migevent.LogAbnormalEventsForResource(
 					destClient, t.Log,
 					"Found abnormal event for Rsync transfer Pod on destination cluster",
-					types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
-					"pod")
+					types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, "Pod")
 
 				for _, podCond := range pod.Status.Conditions {
 					if podCond.Reason == corev1.PodReasonUnschedulable {
@@ -768,8 +767,7 @@ func (t *Task) areRsyncRoutesAdmitted() (bool, []string, error) {
 		migevent.LogAbnormalEventsForResource(
 			destClient, t.Log,
 			"Found abnormal event for Rsync Route on destination cluster",
-			types.NamespacedName{Namespace: route.Namespace, Name: route.Name},
-			"route")
+			types.NamespacedName{Namespace: route.Namespace, Name: route.Name}, "Route")
 
 		admitted := false
 		message := "no status condition available for the route"

--- a/pkg/controller/directvolumemigration/stunnel.go
+++ b/pkg/controller/directvolumemigration/stunnel.go
@@ -618,7 +618,7 @@ func (t *Task) areStunnelClientPodsRunning() (bool, error) {
 					srcClient, t.Log,
 					"Found abnormal event for Stunnel Client Pod on source cluster",
 					types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
-					"pod")
+					"Pod")
 
 				for _, podCond := range pod.Status.Conditions {
 					if podCond.Reason == corev1.PodReasonUnschedulable {

--- a/pkg/controller/migmigration/hooks.go
+++ b/pkg/controller/migmigration/hooks.go
@@ -159,8 +159,7 @@ func (t *Task) ensureJob(job *batchv1.Job, hook migapi.MigPlanHook, migHook miga
 		migevent.LogAbnormalEventsForResource(
 			client, t.Log,
 			"Found abnormal event for Hook Job",
-			types.NamespacedName{Namespace: runningJob.Namespace, Name: runningJob.Name},
-			"job")
+			types.NamespacedName{Namespace: runningJob.Namespace, Name: runningJob.Name}, "Job")
 	}
 
 	if runningJob == nil && err == nil {

--- a/pkg/controller/migmigration/pod.go
+++ b/pkg/controller/migmigration/pod.go
@@ -152,8 +152,7 @@ func (t *Task) haveResticPodsStarted() (bool, error) {
 		migevent.LogAbnormalEventsForResource(
 			client, t.Log,
 			"Found abnormal event for Restic Pod",
-			types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
-			"pod")
+			types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, "Pod")
 
 		if pod.DeletionTimestamp != nil {
 			t.Log.Info("Deletion timestamp found on Restic Pod, "+
@@ -277,8 +276,7 @@ func (t *Task) haveVeleroPodsStarted() (bool, error) {
 			migevent.LogAbnormalEventsForResource(
 				client, t.Log,
 				"Found abnormal event for Velero Pod",
-				types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
-				"pod")
+				types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, "Pod")
 
 			if pod.DeletionTimestamp != nil {
 				t.Log.Info("Found Velero Pod with deletion timestamp."+

--- a/pkg/controller/migmigration/stage.go
+++ b/pkg/controller/migmigration/stage.go
@@ -523,8 +523,7 @@ func (t *Task) stagePodReport(client k8sclient.Client) (report PodStartReport, e
 		migevent.LogAbnormalEventsForResource(
 			client, t.Log,
 			"Found abnormal event for Stage Pod",
-			types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
-			"pod")
+			types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, "Pod")
 
 		initReady := true
 		for _, c := range pod.Status.InitContainerStatuses {

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -300,13 +300,12 @@ func ensureRegistryHealth(c k8sclient.Client, migration *migapi.MigMigration) (i
 			return nEnsured, "", liberr.Wrap(err)
 		}
 
-		for _, registryPod := range registryPods.Items {
+		for _, pod := range registryPods.Items {
 			// Logs abnormal events for Registry Pods if any are found
 			migevent.LogAbnormalEventsForResource(
 				client, log,
 				"Found abnormal event for Registry Pod",
-				types.NamespacedName{Namespace: registryPod.Namespace, Name: registryPod.Name},
-				"pod")
+				types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, "Pod")
 		}
 
 		registryPodCount := len(registryPods.Items)


### PR DESCRIPTION
We may want to get this into 1.4.3 if possible.

I verified this is working as expected in a debugger.

The changes in this PR are equivalent to doing this from the `oc` cli tool:

```
oc get event -n mssql-persistent --field-selector 'involvedObject.kind=Pod,involvedObject.name=directvolumemigration-rsync-transfer' -v=6
```