### PR TITLE
Make local DISM dev easy to set up with make use-local-controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,17 +37,11 @@ tilt:
 
 # Patch MigrationController CR to use local mig-controller + discovery service
 use-local-controller:
-	oc --namespace openshift-migration patch migrationcontroller migration-controller --type=json \
-	--patch '[{ "op": "add", "path": "/spec/discovery_api_url", "value": "http://localhost:8080" }]'
-	oc --namespace openshift-migration patch migrationcontroller migration-controller --type=json \
-	--patch '[{ "op": "replace", "path": "/spec/migration_controller", "value": false }]'
+	hack/use-local-controller.sh
 
 # Patch MigrationController CR to use on-cluster mig-controller + discovery service
 use-oncluster-controller:
-	oc --namespace openshift-migration patch migrationcontroller migration-controller --type=json \
-	--patch '[{ "op": "replace", "path": "/spec/migration_controller", "value": true }]'
-	oc --namespace openshift-migration patch migrationcontroller migration-controller --type=json \
-	--patch '[{ "op": "remove", "path": "/spec/discovery_api_url" }]'
+	hack/use-oncluster-controller.sh
 
 # Install CRDs into a cluster
 install: manifests

--- a/hack/use-local-controller.sh
+++ b/hack/use-local-controller.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Patch the MigrationController CR for the UI use the local discovery service
+echo "Patching MigrationController 'spec.discovery_api_url: http://localhost:8080'. You may need to restart mig-ui for changes to take effect."
+oc --namespace openshift-migration patch migrationcontroller migration-controller --type=json \
+--patch '[{ "op": "add", "path": "/spec/discovery_api_url", "value": "http://localhost:8080" }]'
+echo
+
+# Patch the MigrationController CR to disable the in-cluster mig-controller deploy
+echo "Patching MigrationController 'spec.migration_controller: false'. The controller will be removed when mig-operator reconciles."
+oc --namespace openshift-migration patch migrationcontroller migration-controller --type=json \
+--patch '[{ "op": "replace", "path": "/spec/migration_controller", "value": false }]'
+echo
+
+# Expose the registry route and grab the route URL (OCP 3)
+oc expose svc docker-registry -n default
+export ROUTE_CANDIDATE=$(oc get route docker-registry -n default -o jsonpath="{.spec.host}")
+if [ -z "$ROUTE_CANDIDATE" ]; then
+    echo "OCP 3 registry svc/route not found, assuming OCP 4"
+    echo
+else
+    echo "Using OCP 3 registry route: ${ROUTE_CANDIDATE}"
+    echo
+fi
+
+
+# Expose the registry route and grab the route URL (OCP 4)
+if [[ -z "$ROUTE_CANDIDATE" ]]; then
+    oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge && sleep 2s 
+    export ROUTE_CANDIDATE=$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}')
+    if [ $? -eq 0 ]; then
+        echo "Using OCP 4 registry route: ${ROUTE_CANDIDATE}"
+        echo
+    fi
+fi
+echo
+
+# Patch the 'host' MigCluster with spec.exposedRegistryPath so local controller can perform image transfers
+if [ -z "$ROUTE_CANDIDATE" ]; then
+    echo "Unable to retrieve registry route. Skipping addition to 'host' MigCluster spec.exposedRegistryPath"
+    exit 0
+fi
+
+echo "Patching 'host' MigCluster with spec.exposedRegistryPath=${ROUTE_CANDIDATE}"
+oc --namespace openshift-migration patch migcluster host --type=json \
+--patch "[{ \"op\": \"add\", \"path\": \"/spec/exposedRegistryPath\", \"value\": \"${ROUTE_CANDIDATE}\" }]"

--- a/hack/use-oncluster-controller.sh
+++ b/hack/use-oncluster-controller.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Patch the MigrationController CR for the UI use the in-cluster discovery service
+echo "Patching MigrationController to remove overridden 'spec.discovery_api_url'. You may need to restart mig-ui for changes to take effect."
+oc --namespace openshift-migration patch migrationcontroller migration-controller --type=json \
+--patch '[{ "op": "remove", "path": "/spec/discovery_api_url" }]'
+echo
+
+# Patch the MigrationController CR to enable the in-cluster mig-controller deploy
+echo "Patching MigrationController 'spec.migration_controller: true'. The controller will be deployed when mig-operator reconciles."
+oc --namespace openshift-migration patch migrationcontroller migration-controller --type=json \
+--patch '[{ "op": "replace", "path": "/spec/migration_controller", "value": true }]'
+echo

--- a/hack/use-oncluster-controller.sh
+++ b/hack/use-oncluster-controller.sh
@@ -11,3 +11,9 @@ echo "Patching MigrationController 'spec.migration_controller: true'. The contro
 oc --namespace openshift-migration patch migrationcontroller migration-controller --type=json \
 --patch '[{ "op": "replace", "path": "/spec/migration_controller", "value": true }]'
 echo
+
+# Patch the MigrationController CR for the UI use the in-cluster discovery service
+echo "Patching 'host' MigCluster to remove 'spec.exposedRegistryPath' This will cause mig-controller to use the registry service instead."
+oc --namespace openshift-migration patch migcluster host --type=json \
+--patch '[{ "op": "remove", "path": "/spec/exposedRegistryPath" }]'
+echo


### PR DESCRIPTION
This allowed the DirectImageStreamMigration run from my local machine succeed.

Additions to the helper scripts:
 - `hack/use-oncluster-controller.sh`
   - No change, but moved commands to .sh from makefile
 - `hack/use-local-controller.sh`
   - Now exposes route registry for OCP 3 or OCP 4, and then injects the exposed route into 'host' MigCluster spec.exposedRegistryRoute.
   - Works when running controller against either OCP 3 or 4
