### PR TITLE
Fix panic due to missing nil check starting span when jaeger not enabled

### DIFF
--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -344,8 +344,10 @@ func (t *Task) Run(ctx context.Context) error {
 	t.Requeue = FastReQ
 
 	// Jaeger span
-	span, ctx := opentracing.StartSpanFromContextWithTracer(ctx, t.Tracer, "migration-phase-"+t.Phase)
-	defer span.Finish()
+	if opentracing.SpanFromContext(ctx) != nil {
+		span, _ := opentracing.StartSpanFromContextWithTracer(ctx, t.Tracer, "migration-phase-"+t.Phase)
+		defer span.Finish()
+	}
 
 	err := t.init()
 	if err != nil {


### PR DESCRIPTION
It appears this check got lost during merge conflict resolution. All other task.go have this check already.

```
{"level":"info","ts":1617894357086,"logger":"migration|bsl9l","msg":"Marking MigMigration as started.","migMigration":"ebd3fcb0-987b-11eb-8a38-8f823c621bc0"}
E0408 11:05:57.086514   54377 runtime.go:69] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
/Users/dwhatley/code/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/runtime/runtime.go:76
/Users/dwhatley/code/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/runtime/runtime.go:65
/Users/dwhatley/code/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/runtime/runtime.go:51
/Users/dwhatley/pkg/go1.14.4/src/runtime/panic.go:969
/Users/dwhatley/pkg/go1.14.4/src/runtime/panic.go:212
/Users/dwhatley/pkg/go1.14.4/src/runtime/signal_unix.go:695
/Users/dwhatley/code/go/pkg/mod/github.com/opentracing/opentracing-go@v1.2.0/gocontext.go:63
/Users/dwhatley/code/go/src/github.com/konveyor/mig-controller/pkg/controller/migmigration/task.go:347
/Users/dwhatley/code/go/src/github.com/konveyor/mig-controller/pkg/controller/migmigration/migrate.go:70
/Users/dwhatley/code/go/src/github.com/konveyor/mig-controller/pkg/controller/migmigration/migmigration_controller.go:242
/Users/dwhatley/code/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.1.11/pkg/internal/controller/controller.go:215
/Users/dwhatley/code/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.1.11/pkg/internal/controller/controller.go:158
/Users/dwhatley/code/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/wait/wait.go:133
/Users/dwhatley/code/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/wait/wait.go:134
/Users/dwhatley/code/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/wait/wait.go:88
/Users/dwhatley/pkg/go1.14.4/src/runtime/asm_amd64.s:1373
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x51b4442]

goroutine 1067 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/Users/dwhatley/code/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/runtime/runtime.go:58 +0x105
panic(0x5bc7740, 0x74c68d0)
	/Users/dwhatley/pkg/go1.14.4/src/runtime/panic.go:969 +0x166
github.com/opentracing/opentracing-go.StartSpanFromContextWithTracer(0x63d70c0, 0xc0000520d0, 0x0, 0x0, 0x5ec7ddb, 0x10, 0x0, 0x0, 0x0, 0x4085170, ...)
	/Users/dwhatley/code/go/pkg/mod/github.com/opentracing/opentracing-go@v1.2.0/gocontext.go:63 +0x72
github.com/konveyor/mig-controller/pkg/controller/migmigration.(*Task).Run(0xc002ad3a68, 0x63d70c0, 0xc0000520d0, 0x0, 0x0)
	/Users/dwhatley/code/go/src/github.com/konveyor/mig-controller/pkg/controller/migmigration/task.go:347 +0x1bf
github.com/konveyor/mig-controller/pkg/controller/migmigration.(*ReconcileMigMigration).migrate(0xc000854900, 0x63d70c0, 0xc0000520d0, 0xc00141e1c0, 0x0, 0x0, 0x0)
	/Users/dwhatley/code/go/src/github.com/konveyor/mig-controller/pkg/controller/migmigration/migrate.go:70 +0x3a0
github.com/konveyor/mig-controller/pkg/controller/migmigration.(*ReconcileMigMigration).Reconcile(0xc000854900, 0xc001c3e260, 0x13, 0xc0022566f0, 0x24, 0xc0002bdf00, 0x0, 0x0, 0x0)
	/Users/dwhatley/code/go/src/github.com/konveyor/mig-controller/pkg/controller/migmigration/migmigration_controller.go:242 +0x959
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000196960, 0x639fe00)
	/Users/dwhatley/code/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.1.11/pkg/internal/controller/controller.go:215 +0x1d6
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1()
	/Users/dwhatley/code/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.1.11/pkg/internal/controller/controller.go:158 +0x36
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000b37a00)
	/Users/dwhatley/code/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/wait/wait.go:133 +0x5f
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000b37a00, 0x3b9aca00, 0x0, 0x5fa9b01, 0xc0002020c0)
	/Users/dwhatley/code/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/wait/wait.go:134 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc000b37a00, 0x3b9aca00, 0xc0002020c0)
	/Users/dwhatley/code/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20181127025237-2b1284ed4c93/pkg/util/wait/wait.go:88 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start
	/Users/dwhatley/code/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.1.11/pkg/internal/controller/controller.go:157 +0x2fd
```