### PR TITLE
Add Pods (Stage, Registry, Rsync, Stunnel), Routes, PVCs, PVs, Hooks (Jobs, Pods) to migration plan tree view.

### DIFF
--- a/pkg/apis/migration/v1alpha1/annotations.go
+++ b/pkg/apis/migration/v1alpha1/annotations.go
@@ -1,0 +1,30 @@
+package v1alpha1
+
+// Velero Plugin Annotations
+const (
+	StageOrFinalMigrationAnnotation = "migration.openshift.io/migmigration-type" // (stage|final)
+	StageMigration                  = "stage"
+	FinalMigration                  = "final"
+	PvActionAnnotation              = "openshift.io/migrate-type"          // (move|copy)
+	PvStorageClassAnnotation        = "openshift.io/target-storage-class"  // storageClassName
+	PvAccessModeAnnotation          = "openshift.io/target-access-mode"    // accessMode
+	PvCopyMethodAnnotation          = "migration.openshift.io/copy-method" // (snapshot|filesystem)
+	QuiesceAnnotation               = "openshift.io/migrate-quiesce-pods"  // (true|false)
+	QuiesceNodeSelector             = "migration.openshift.io/quiesceDaemonSet"
+	SuspendAnnotation               = "migration.openshift.io/preQuiesceSuspend"
+	ReplicasAnnotation              = "migration.openshift.io/preQuiesceReplicas"
+	NodeSelectorAnnotation          = "migration.openshift.io/preQuiesceNodeSelector"
+	StagePodImageAnnotation         = "migration.openshift.io/stage-pod-image"
+)
+
+// Restic Annotations
+const (
+	ResticPvBackupAnnotation = "backup.velero.io/backup-volumes" // comma-separated list of volume names
+	ResticPvVerifyAnnotation = "backup.velero.io/verify-volumes" // comma-separated list of volume names
+)
+
+// Migration Annotations
+const (
+	// Disables the internal image copy
+	DisableImageCopy = "migration.openshift.io/disable-image-copy"
+)

--- a/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
+++ b/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
@@ -24,12 +24,6 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// labels
-const (
-	// RsyncPodIdentityLabel identifies sibling Rsync attempts/pods
-	RsyncPodIdentityLabel = "migration.openshift.io/created-for-pvc"
-)
-
 type PVCToMigrate struct {
 	*kapi.ObjectReference `json:",inline"`
 	TargetStorageClass    string                            `json:"targetStorageClass"`

--- a/pkg/apis/migration/v1alpha1/labels.go
+++ b/pkg/apis/migration/v1alpha1/labels.go
@@ -60,8 +60,12 @@ const (
 	// to allow migplan restored resources rollback
 	// The value is Task.PlanResources.MigPlan.UID
 	MigPlanLabel = "migration.openshift.io/migrated-by-migplan" // (migplan UID)
+	// Identifies associated Backup name
+	MigBackupLabel = "migration.openshift.io/migrated-by-backup" // (backup name)
 	// Identifies Pod as a stage pod to allow
 	// for cleanup at migration start and rollback
 	// The value is always "true" if set.
 	StagePodLabel = "migration.openshift.io/is-stage-pod"
+	// RsyncPodIdentityLabel identifies sibling Rsync attempts/pods
+	RsyncPodIdentityLabel = "migration.openshift.io/created-for-pvc"
 )

--- a/pkg/apis/migration/v1alpha1/labels.go
+++ b/pkg/apis/migration/v1alpha1/labels.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// Labels
+// Common labels
 const (
 	PartOfLabel = "app.kubernetes.io/part-of" // = Application
 	Application = "openshift-migration"
@@ -23,3 +23,45 @@ func CorrelationLabel(r interface{}, uid types.UID) (key, value string) {
 func labelKey(r interface{}) string {
 	return strings.ToLower(migref.ToKind(r))
 }
+
+// Labels.
+const (
+	// Resources included in the stage backup.
+	// Referenced by the Backup.LabelSelector. The value is the Task.UID().
+	IncludedInStageBackupLabel = "migration-included-stage-backup"
+	// Designated as an `initial` Backup.
+	// The value is the Task.UID().
+	InitialBackupLabel = "migration-initial-backup"
+	// Designated as an `stage` Backup.
+	// The value is the Task.UID().
+	StageBackupLabel = "migration-stage-backup"
+	// Designated as an `stage` Restore.
+	// The value is the Task.UID().
+	StageRestoreLabel = "migration-stage-restore"
+	// Designated as a `final` Restore.
+	// The value is the Task.UID().
+	FinalRestoreLabel = "migration-final-restore"
+	// Identifies associated directvolumemigration resource
+	// The value is the Task.UID()
+	DirectVolumeMigrationLabel = "migration-direct-volume"
+	// Identifies the resource as migrated by us
+	// for easy search or application rollback.
+	// The value is the Task.UID().
+	MigMigrationLabel = "migration.openshift.io/migrated-by-migmigration" // (migmigration UID)
+	// Identifies associated migmigration
+	// to assist manual debugging
+	// The value is Task.Owner.Name
+	MigMigrationDebugLabel = "migration.openshift.io/migmigration-name"
+	// Identifies associated migplan
+	// to assist manual debugging
+	// The value is Task.Owner.Spec.migPlanRef.Name
+	MigPlanDebugLabel = "migration.openshift.io/migplan-name"
+	// Identifies associated migplan
+	// to allow migplan restored resources rollback
+	// The value is Task.PlanResources.MigPlan.UID
+	MigPlanLabel = "migration.openshift.io/migrated-by-migplan" // (migplan UID)
+	// Identifies Pod as a stage pod to allow
+	// for cleanup at migration start and rollback
+	// The value is always "true" if set.
+	StagePodLabel = "migration.openshift.io/is-stage-pod"
+)

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -321,8 +321,10 @@ func (r *MigPlan) BuildRegistryDeployment(storage *MigStorage, proxySecret *kapi
 	dirName, registryImage string, mCorrelationLabels map[string]string) *appsv1.Deployment {
 	// Merge correlation labels for plan and migration
 	combinedLabels := r.GetCorrelationLabels()
-	for k, v := range mCorrelationLabels {
-		combinedLabels[k] = v
+	if mCorrelationLabels != nil {
+		for k, v := range mCorrelationLabels {
+			combinedLabels[k] = v
+		}
 	}
 	combinedLabels[MigrationRegistryLabel] = True
 	combinedLabels["app"] = name
@@ -394,8 +396,10 @@ func (r *MigPlan) UpdateRegistryDeployment(storage *MigStorage, deployment *apps
 		"migplan":              string(r.UID),
 		MigrationRegistryLabel: True,
 	}
-	for k, v := range mCorrelationLabels {
-		podLabels[k] = v
+	if mCorrelationLabels != nil {
+		for k, v := range mCorrelationLabels {
+			podLabels[k] = v
+		}
 	}
 
 	deployment.Spec = appsv1.DeploymentSpec{

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -317,19 +317,25 @@ func (r *MigPlan) EqualsRegistrySecret(a, b *kapi.Secret) bool {
 }
 
 // Build a Registry Deployment.
-func (r *MigPlan) BuildRegistryDeployment(storage *MigStorage, proxySecret *kapi.Secret, name, dirName, registryImage string) *appsv1.Deployment {
-	labels := r.GetCorrelationLabels()
-	labels[MigrationRegistryLabel] = True
-	labels["app"] = name
-	labels["migplan"] = string(r.UID)
+func (r *MigPlan) BuildRegistryDeployment(storage *MigStorage, proxySecret *kapi.Secret, name,
+	dirName, registryImage string, mCorrelationLabels map[string]string) *appsv1.Deployment {
+	// Merge correlation labels for plan and migration
+	combinedLabels := r.GetCorrelationLabels()
+	for k, v := range mCorrelationLabels {
+		combinedLabels[k] = v
+	}
+	combinedLabels[MigrationRegistryLabel] = True
+	combinedLabels["app"] = name
+	combinedLabels["migplan"] = string(r.UID)
+
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:    labels,
+			Labels:    combinedLabels,
 			Name:      name,
 			Namespace: VeleroNamespace,
 		},
 	}
-	r.UpdateRegistryDeployment(storage, deployment, proxySecret, name, dirName, registryImage)
+	r.UpdateRegistryDeployment(storage, deployment, proxySecret, name, dirName, registryImage, mCorrelationLabels)
 	return deployment
 }
 
@@ -365,7 +371,8 @@ func (r *MigPlan) GetProxySecret(client k8sclient.Client) (*kapi.Secret, error) 
 }
 
 // Update a Registry Deployment as desired for the specified cluster.
-func (r *MigPlan) UpdateRegistryDeployment(storage *MigStorage, deployment *appsv1.Deployment, proxySecret *kapi.Secret, name, dirName, registryImage string) {
+func (r *MigPlan) UpdateRegistryDeployment(storage *MigStorage, deployment *appsv1.Deployment,
+	proxySecret *kapi.Secret, name, dirName, registryImage string, mCorrelationLabels map[string]string) {
 
 	envFrom := []kapi.EnvFromSource{}
 	// If Proxy secret exists, set env from it
@@ -380,23 +387,24 @@ func (r *MigPlan) UpdateRegistryDeployment(storage *MigStorage, deployment *apps
 		envFrom = append(envFrom, source)
 	}
 
+	// Merge migration correlation labels with Pod labels
+	podLabels := map[string]string{
+		"app":                  name,
+		"deployment":           name,
+		"migplan":              string(r.UID),
+		MigrationRegistryLabel: True,
+	}
+	for k, v := range mCorrelationLabels {
+		podLabels[k] = v
+	}
+
 	deployment.Spec = appsv1.DeploymentSpec{
 		Replicas: pointer.Int32Ptr(1),
-		Selector: metav1.SetAsLabelSelector(map[string]string{
-			"app":                  name,
-			"deployment":           name,
-			"migplan":              string(r.UID),
-			MigrationRegistryLabel: True,
-		}),
+		Selector: metav1.SetAsLabelSelector(podLabels),
 		Template: kapi.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				CreationTimestamp: metav1.Time{},
-				Labels: map[string]string{
-					"app":                  name,
-					"deployment":           name,
-					"migplan":              string(r.UID),
-					MigrationRegistryLabel: True,
-				},
+				Labels:            podLabels,
 			},
 			Spec: kapi.PodSpec{
 				Containers: []kapi.Container{

--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -71,6 +71,11 @@ func (t *Task) createDestinationPVCs() error {
 		if pvcLabels == nil {
 			pvcLabels = make(map[string]string)
 		}
+		// Merge DVM correlation labels into PVC labels for debug view
+		corrLabels := t.Owner.GetCorrelationLabels()
+		for k, v := range corrLabels {
+			pvcLabels[k] = v
+		}
 
 		if t.MigrationUID != "" && t.PlanResources.MigPlan != nil {
 			pvcLabels[MigratedByMigrationLabel] = t.MigrationUID

--- a/pkg/controller/directvolumemigration/stunnel.go
+++ b/pkg/controller/directvolumemigration/stunnel.go
@@ -237,11 +237,11 @@ func (t *Task) createStunnelConfig() error {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns,
 				Name:      DirectVolumeMigrationStunnelConfig,
-				Labels: map[string]string{
-					"app": DirectVolumeMigrationRsyncTransfer,
-				},
 			},
 		}
+		clientConfigMap.Labels = t.Owner.GetCorrelationLabels()
+		clientConfigMap.Labels["app"] = DirectVolumeMigrationRsyncTransfer
+
 		err = yaml.Unmarshal(clientTpl.Bytes(), &clientConfigMap)
 		if err != nil {
 			return err
@@ -251,11 +251,11 @@ func (t *Task) createStunnelConfig() error {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns,
 				Name:      DirectVolumeMigrationStunnelConfig,
-				Labels: map[string]string{
-					"app": DirectVolumeMigrationRsyncTransfer,
-				},
 			},
 		}
+		destConfigMap.Labels = t.Owner.GetCorrelationLabels()
+		destConfigMap.Labels["app"] = DirectVolumeMigrationRsyncTransfer
+
 		err = yaml.Unmarshal(destTpl.Bytes(), &destConfigMap)
 		if err != nil {
 			return err
@@ -453,9 +453,6 @@ func (t *Task) createStunnelClientPods() error {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      DirectVolumeMigrationRsyncTransferSvc,
 				Namespace: ns,
-				Labels: map[string]string{
-					"app": DirectVolumeMigrationRsyncTransfer,
-				},
 			},
 			Spec: corev1.ServiceSpec{
 				Ports: []corev1.ServicePort{
@@ -470,6 +467,9 @@ func (t *Task) createStunnelClientPods() error {
 				Type:     corev1.ServiceTypeClusterIP,
 			},
 		}
+		svc.Labels = t.Owner.GetCorrelationLabels()
+		svc.Labels["app"] = DirectVolumeMigrationRsyncTransfer
+
 		volumes := []corev1.Volume{
 			{
 				Name: "stunnel-conf",

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -572,8 +572,8 @@ func (t *Task) getDestinationClient() (compat.Client, error) {
 
 // Get DVM labels for the migration
 func (t *Task) buildDVMLabels() map[string]string {
-	dvmLabels := make(map[string]string)
 
+	dvmLabels := t.Owner.GetCorrelationLabels()
 	dvmLabels["app"] = DirectVolumeMigrationRsyncTransfer
 	dvmLabels["owner"] = DirectVolumeMigration
 	dvmLabels[migapi.PartOfLabel] = migapi.Application

--- a/pkg/controller/discovery/container/hook.go
+++ b/pkg/controller/discovery/container/hook.go
@@ -13,13 +13,13 @@ import (
 )
 
 //
-// A collection of k8s MigHook resources.
-type MigHook struct {
+// A collection of k8s Hook resources.
+type Hook struct {
 	// Base
 	BaseCollection
 }
 
-func (r *MigHook) AddWatch(dsController controller.Controller) error {
+func (r *Hook) AddWatch(dsController controller.Controller) error {
 	err := dsController.Watch(
 		&source.Kind{
 			Type: &migapi.MigHook{},
@@ -34,7 +34,7 @@ func (r *MigHook) AddWatch(dsController controller.Controller) error {
 	return nil
 }
 
-func (r *MigHook) Reconcile() error {
+func (r *Hook) Reconcile() error {
 	mark := time.Now()
 	sr := SimpleReconciler{
 		Db: r.ds.Container.Db,
@@ -46,7 +46,7 @@ func (r *MigHook) Reconcile() error {
 	}
 	r.hasReconciled = true
 	Log.Info(
-		"MigHook (collection) reconciled.",
+		"Hook (collection) reconciled.",
 		"ns",
 		r.ds.Cluster.Namespace,
 		"name",
@@ -57,7 +57,7 @@ func (r *MigHook) Reconcile() error {
 	return nil
 }
 
-func (r *MigHook) GetDiscovered() ([]model.Model, error) {
+func (r *Hook) GetDiscovered() ([]model.Model, error) {
 	models := []model.Model{}
 	onCluster := migapi.MigHookList{}
 	err := r.ds.Client.List(context.TODO(), nil, &onCluster)
@@ -74,7 +74,7 @@ func (r *MigHook) GetDiscovered() ([]model.Model, error) {
 	return models, nil
 }
 
-func (r *MigHook) GetStored() ([]model.Model, error) {
+func (r *Hook) GetStored() ([]model.Model, error) {
 	models := []model.Model{}
 	list, err := model.Hook{}.List(
 		r.ds.Container.Db,
@@ -94,7 +94,7 @@ func (r *MigHook) GetStored() ([]model.Model, error) {
 // Predicate methods.
 //
 
-func (r *MigHook) Create(e event.CreateEvent) bool {
+func (r *Hook) Create(e event.CreateEvent) bool {
 	Log.Reset()
 	object, cast := e.Object.(*migapi.MigHook)
 	if !cast {
@@ -107,7 +107,7 @@ func (r *MigHook) Create(e event.CreateEvent) bool {
 	return false
 }
 
-func (r *MigHook) Update(e event.UpdateEvent) bool {
+func (r *Hook) Update(e event.UpdateEvent) bool {
 	Log.Reset()
 	object, cast := e.ObjectNew.(*migapi.MigHook)
 	if !cast {
@@ -120,7 +120,7 @@ func (r *MigHook) Update(e event.UpdateEvent) bool {
 	return false
 }
 
-func (r *MigHook) Delete(e event.DeleteEvent) bool {
+func (r *Hook) Delete(e event.DeleteEvent) bool {
 	Log.Reset()
 	object, cast := e.Object.(*migapi.MigHook)
 	if !cast {
@@ -133,6 +133,6 @@ func (r *MigHook) Delete(e event.DeleteEvent) bool {
 	return false
 }
 
-func (r *MigHook) Generic(e event.GenericEvent) bool {
+func (r *Hook) Generic(e event.GenericEvent) bool {
 	return false
 }

--- a/pkg/controller/discovery/container/hook.go
+++ b/pkg/controller/discovery/container/hook.go
@@ -1,0 +1,138 @@
+package container
+
+import (
+	"context"
+	"time"
+
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+//
+// A collection of k8s MigHook resources.
+type MigHook struct {
+	// Base
+	BaseCollection
+}
+
+func (r *MigHook) AddWatch(dsController controller.Controller) error {
+	err := dsController.Watch(
+		&source.Kind{
+			Type: &migapi.MigHook{},
+		},
+		&handler.EnqueueRequestForObject{},
+		r)
+	if err != nil {
+		Log.Trace(err)
+		return err
+	}
+
+	return nil
+}
+
+func (r *MigHook) Reconcile() error {
+	mark := time.Now()
+	sr := SimpleReconciler{
+		Db: r.ds.Container.Db,
+	}
+	err := sr.Reconcile(r)
+	if err != nil {
+		Log.Trace(err)
+		return err
+	}
+	r.hasReconciled = true
+	Log.Info(
+		"MigHook (collection) reconciled.",
+		"ns",
+		r.ds.Cluster.Namespace,
+		"name",
+		r.ds.Cluster.Name,
+		"duration",
+		time.Since(mark))
+
+	return nil
+}
+
+func (r *MigHook) GetDiscovered() ([]model.Model, error) {
+	models := []model.Model{}
+	onCluster := migapi.MigHookList{}
+	err := r.ds.Client.List(context.TODO(), nil, &onCluster)
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	for _, discovered := range onCluster.Items {
+		dim := &model.Hook{}
+		dim.With(&discovered)
+		models = append(models, dim)
+	}
+
+	return models, nil
+}
+
+func (r *MigHook) GetStored() ([]model.Model, error) {
+	models := []model.Model{}
+	list, err := model.Hook{}.List(
+		r.ds.Container.Db,
+		model.ListOptions{})
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	for _, dim := range list {
+		models = append(models, dim)
+	}
+
+	return models, nil
+}
+
+//
+// Predicate methods.
+//
+
+func (r *MigHook) Create(e event.CreateEvent) bool {
+	Log.Reset()
+	object, cast := e.Object.(*migapi.MigHook)
+	if !cast {
+		return false
+	}
+	dim := model.Hook{}
+	dim.With(object)
+	r.ds.Create(&dim)
+
+	return false
+}
+
+func (r *MigHook) Update(e event.UpdateEvent) bool {
+	Log.Reset()
+	object, cast := e.ObjectNew.(*migapi.MigHook)
+	if !cast {
+		return false
+	}
+	restore := model.Hook{}
+	restore.With(object)
+	r.ds.Update(&restore)
+
+	return false
+}
+
+func (r *MigHook) Delete(e event.DeleteEvent) bool {
+	Log.Reset()
+	object, cast := e.Object.(*migapi.MigHook)
+	if !cast {
+		return false
+	}
+	dim := model.Hook{}
+	dim.With(object)
+	r.ds.Delete(&dim)
+
+	return false
+}
+
+func (r *MigHook) Generic(e event.GenericEvent) bool {
+	return false
+}

--- a/pkg/controller/discovery/container/pod.go
+++ b/pkg/controller/discovery/container/pod.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -22,7 +22,7 @@ type Pod struct {
 func (r *Pod) AddWatch(dsController controller.Controller) error {
 	err := dsController.Watch(
 		&source.Kind{
-			Type: &v1.Pod{},
+			Type: &corev1.Pod{},
 		},
 		&handler.EnqueueRequestForObject{},
 		r)
@@ -57,7 +57,7 @@ func (r *Pod) Reconcile() error {
 
 func (r *Pod) GetDiscovered() ([]model.Model, error) {
 	models := []model.Model{}
-	onCluster := v1.PodList{}
+	onCluster := corev1.PodList{}
 	err := r.ds.Client.List(context.TODO(), nil, &onCluster)
 	if err != nil {
 		Log.Trace(err)
@@ -102,7 +102,7 @@ func (r *Pod) GetStored() ([]model.Model, error) {
 
 func (r *Pod) Create(e event.CreateEvent) bool {
 	Log.Reset()
-	object, cast := e.Object.(*v1.Pod)
+	object, cast := e.Object.(*corev1.Pod)
 	if !cast {
 		return false
 	}
@@ -119,7 +119,7 @@ func (r *Pod) Create(e event.CreateEvent) bool {
 
 func (r *Pod) Update(e event.UpdateEvent) bool {
 	Log.Reset()
-	object, cast := e.ObjectNew.(*v1.Pod)
+	object, cast := e.ObjectNew.(*corev1.Pod)
 	if !cast {
 		return false
 	}
@@ -136,7 +136,7 @@ func (r *Pod) Update(e event.UpdateEvent) bool {
 
 func (r *Pod) Delete(e event.DeleteEvent) bool {
 	Log.Reset()
-	object, cast := e.Object.(*v1.Pod)
+	object, cast := e.Object.(*corev1.Pod)
 	if !cast {
 		return false
 	}

--- a/pkg/controller/discovery/container/route.go
+++ b/pkg/controller/discovery/container/route.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
-	v1 "k8s.io/api/core/v1"
+	v1 "github.com/openshift/api/route/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -13,16 +13,16 @@ import (
 )
 
 //
-// A collection of k8s Pod resources.
-type Pod struct {
+// A collection of k8s Route resources.
+type Route struct {
 	// Base
 	BaseCollection
 }
 
-func (r *Pod) AddWatch(dsController controller.Controller) error {
+func (r *Route) AddWatch(dsController controller.Controller) error {
 	err := dsController.Watch(
 		&source.Kind{
-			Type: &v1.Pod{},
+			Type: &v1.Route{},
 		},
 		&handler.EnqueueRequestForObject{},
 		r)
@@ -34,7 +34,7 @@ func (r *Pod) AddWatch(dsController controller.Controller) error {
 	return nil
 }
 
-func (r *Pod) Reconcile() error {
+func (r *Route) Reconcile() error {
 	mark := time.Now()
 	sr := SimpleReconciler{Db: r.ds.Container.Db}
 	err := sr.Reconcile(r)
@@ -44,7 +44,7 @@ func (r *Pod) Reconcile() error {
 	}
 	r.hasReconciled = true
 	Log.Info(
-		"Pod (collection) reconciled.",
+		"Route (collection) reconciled.",
 		"ns",
 		r.ds.Cluster.Namespace,
 		"name",
@@ -55,16 +55,16 @@ func (r *Pod) Reconcile() error {
 	return nil
 }
 
-func (r *Pod) GetDiscovered() ([]model.Model, error) {
+func (r *Route) GetDiscovered() ([]model.Model, error) {
 	models := []model.Model{}
-	onCluster := v1.PodList{}
+	onCluster := v1.RouteList{}
 	err := r.ds.Client.List(context.TODO(), nil, &onCluster)
 	if err != nil {
 		Log.Trace(err)
 		return nil, err
 	}
 	for _, discovered := range onCluster.Items {
-		ns := &model.Pod{
+		ns := &model.Route{
 			Base: model.Base{
 				Cluster: r.ds.Cluster.PK,
 			},
@@ -76,9 +76,9 @@ func (r *Pod) GetDiscovered() ([]model.Model, error) {
 	return models, nil
 }
 
-func (r *Pod) GetStored() ([]model.Model, error) {
+func (r *Route) GetStored() ([]model.Model, error) {
 	models := []model.Model{}
-	list, err := model.Pod{
+	list, err := model.Route{
 		Base: model.Base{
 			Cluster: r.ds.Cluster.PK,
 		},
@@ -89,8 +89,8 @@ func (r *Pod) GetStored() ([]model.Model, error) {
 		Log.Trace(err)
 		return nil, err
 	}
-	for _, pod := range list {
-		models = append(models, pod)
+	for _, route := range list {
+		models = append(models, route)
 	}
 
 	return models, nil
@@ -100,57 +100,57 @@ func (r *Pod) GetStored() ([]model.Model, error) {
 // Predicate methods.
 //
 
-func (r *Pod) Create(e event.CreateEvent) bool {
+func (r *Route) Create(e event.CreateEvent) bool {
 	Log.Reset()
-	object, cast := e.Object.(*v1.Pod)
+	object, cast := e.Object.(*v1.Route)
 	if !cast {
 		return false
 	}
-	pod := model.Pod{
+	route := model.Route{
 		Base: model.Base{
 			Cluster: r.ds.Cluster.PK,
 		},
 	}
-	pod.With(object)
-	r.ds.Create(&pod)
+	route.With(object)
+	r.ds.Create(&route)
 
 	return false
 }
 
-func (r *Pod) Update(e event.UpdateEvent) bool {
+func (r *Route) Update(e event.UpdateEvent) bool {
 	Log.Reset()
-	object, cast := e.ObjectNew.(*v1.Pod)
+	object, cast := e.ObjectNew.(*v1.Route)
 	if !cast {
 		return false
 	}
-	pod := model.Pod{
+	route := model.Route{
 		Base: model.Base{
 			Cluster: r.ds.Cluster.PK,
 		},
 	}
-	pod.With(object)
-	r.ds.Update(&pod)
+	route.With(object)
+	r.ds.Update(&route)
 
 	return false
 }
 
-func (r *Pod) Delete(e event.DeleteEvent) bool {
+func (r *Route) Delete(e event.DeleteEvent) bool {
 	Log.Reset()
-	object, cast := e.Object.(*v1.Pod)
+	object, cast := e.Object.(*v1.Route)
 	if !cast {
 		return false
 	}
-	pod := model.Pod{
+	route := model.Route{
 		Base: model.Base{
 			Cluster: r.ds.Cluster.PK,
 		},
 	}
-	pod.With(object)
-	r.ds.Delete(&pod)
+	route.With(object)
+	r.ds.Delete(&route)
 
 	return false
 }
 
-func (r *Pod) Generic(e event.GenericEvent) bool {
+func (r *Route) Generic(e event.GenericEvent) bool {
 	return false
 }

--- a/pkg/controller/discovery/controller.go
+++ b/pkg/controller/discovery/controller.go
@@ -162,7 +162,7 @@ func (r *ReconcileDiscovery) Reconcile(request reconcile.Request) (reconcile.Res
 		&container.DirectImageMigration{},
 		&container.DirectVolumeMigrationProgress{},
 		&container.DirectImageStreamMigration{},
-		&container.MigHook{},
+		&container.Hook{},
 		&container.PodVolumeBackup{},
 		&container.PodVolumeRestore{},
 		&container.Namespace{},

--- a/pkg/controller/discovery/controller.go
+++ b/pkg/controller/discovery/controller.go
@@ -170,6 +170,7 @@ func (r *ReconcileDiscovery) Reconcile(request reconcile.Request) (reconcile.Res
 		&container.Route{},
 		&container.PVC{},
 		&container.Pod{},
+		&container.Job{},
 		&container.PV{},
 		&container.StorageClass{},
 	)

--- a/pkg/controller/discovery/controller.go
+++ b/pkg/controller/discovery/controller.go
@@ -162,6 +162,7 @@ func (r *ReconcileDiscovery) Reconcile(request reconcile.Request) (reconcile.Res
 		&container.DirectImageMigration{},
 		&container.DirectVolumeMigrationProgress{},
 		&container.DirectImageStreamMigration{},
+		&container.MigHook{},
 		&container.PodVolumeBackup{},
 		&container.PodVolumeRestore{},
 		&container.Namespace{},

--- a/pkg/controller/discovery/controller.go
+++ b/pkg/controller/discovery/controller.go
@@ -166,6 +166,7 @@ func (r *ReconcileDiscovery) Reconcile(request reconcile.Request) (reconcile.Res
 		&container.PodVolumeRestore{},
 		&container.Namespace{},
 		&container.Service{},
+		&container.Route{},
 		&container.PVC{},
 		&container.Pod{},
 		&container.PV{},

--- a/pkg/controller/discovery/model/cluster.go
+++ b/pkg/controller/discovery/model/cluster.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"encoding/json"
+
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 )
 
@@ -18,6 +19,7 @@ func (m *Cluster) With(object *migapi.MigCluster) {
 	m.Version = object.ResourceVersion
 	m.Namespace = object.Namespace
 	m.Name = object.Name
+	m.labels = object.Labels
 	m.EncodeObject(object)
 }
 

--- a/pkg/controller/discovery/model/directimage.go
+++ b/pkg/controller/discovery/model/directimage.go
@@ -19,6 +19,7 @@ func (m *DirectImageMigration) With(object *migapi.DirectImageMigration) {
 	m.Version = object.ResourceVersion
 	m.Namespace = object.Namespace
 	m.Name = object.Name
+	m.labels = object.Labels
 	m.EncodeObject(object)
 }
 

--- a/pkg/controller/discovery/model/directimagestream.go
+++ b/pkg/controller/discovery/model/directimagestream.go
@@ -19,6 +19,7 @@ func (m *DirectImageStreamMigration) With(object *migapi.DirectImageStreamMigrat
 	m.Version = object.ResourceVersion
 	m.Namespace = object.Namespace
 	m.Name = object.Name
+	m.labels = object.Labels
 	m.EncodeObject(object)
 }
 

--- a/pkg/controller/discovery/model/directvolume.go
+++ b/pkg/controller/discovery/model/directvolume.go
@@ -19,6 +19,7 @@ func (m *DirectVolumeMigration) With(object *migapi.DirectVolumeMigration) {
 	m.Version = object.ResourceVersion
 	m.Namespace = object.Namespace
 	m.Name = object.Name
+	m.labels = object.Labels
 	m.EncodeObject(object)
 }
 

--- a/pkg/controller/discovery/model/directvolumeprogress.go
+++ b/pkg/controller/discovery/model/directvolumeprogress.go
@@ -19,6 +19,7 @@ func (m *DirectVolumeMigrationProgress) With(object *migapi.DirectVolumeMigratio
 	m.Version = object.ResourceVersion
 	m.Namespace = object.Namespace
 	m.Name = object.Name
+	m.labels = object.Labels
 	m.EncodeObject(object)
 }
 

--- a/pkg/controller/discovery/model/hook.go
+++ b/pkg/controller/discovery/model/hook.go
@@ -33,9 +33,9 @@ func (m *Hook) EncodeObject(dim *migapi.MigHook) {
 //
 // Decode the object.
 func (m *Hook) DecodeObject() *migapi.MigHook {
-	dim := &migapi.MigHook{}
-	json.Unmarshal([]byte(m.Object), dim)
-	return dim
+	hook := &migapi.MigHook{}
+	json.Unmarshal([]byte(m.Object), hook)
+	return hook
 }
 
 //

--- a/pkg/controller/discovery/model/hook.go
+++ b/pkg/controller/discovery/model/hook.go
@@ -1,0 +1,87 @@
+package model
+
+import (
+	"encoding/json"
+
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+)
+
+//
+// Hook model.
+type Hook struct {
+	CR
+}
+
+//
+// Update the model `with` a Hook.
+func (m *Hook) With(object *migapi.MigHook) {
+	m.UID = string(object.UID)
+	m.Version = object.ResourceVersion
+	m.Namespace = object.Namespace
+	m.Name = object.Name
+	m.EncodeObject(object)
+}
+
+//
+// Encode the object.
+func (m *Hook) EncodeObject(dim *migapi.MigHook) {
+	object, _ := json.Marshal(dim)
+	m.Object = string(object)
+}
+
+//
+// Decode the object.
+func (m *Hook) DecodeObject() *migapi.MigHook {
+	dim := &migapi.MigHook{}
+	json.Unmarshal([]byte(m.Object), dim)
+	return dim
+}
+
+//
+// Count in the DB.
+func (m Hook) Count(db DB, options ListOptions) (int64, error) {
+	return Table{db}.Count(&m, options)
+}
+
+//
+// Fetch the model from the DB.
+func (m Hook) List(db DB, options ListOptions) ([]*Hook, error) {
+	list := []*Hook{}
+	listed, err := Table{db}.List(&m, options)
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	for _, intPtr := range listed {
+		list = append(list, intPtr.(*Hook))
+	}
+
+	return list, err
+}
+
+//
+// Fetch the model from the DB.
+func (m *Hook) Get(db DB) error {
+	return Table{db}.Get(m)
+}
+
+//
+// Insert the model into the DB.
+func (m *Hook) Insert(db DB) error {
+	m.SetPk()
+	return Table{db}.Insert(m)
+}
+
+//
+// Update the model in the DB.
+func (m *Hook) Update(db DB) error {
+	m.SetPk()
+	return Table{db}.Update(m)
+}
+
+//
+// Delete the model in the DB.
+func (m *Hook) Delete(db DB) error {
+	m.SetPk()
+	return Table{db}.Delete(m)
+}

--- a/pkg/controller/discovery/model/hook.go
+++ b/pkg/controller/discovery/model/hook.go
@@ -19,6 +19,7 @@ func (m *Hook) With(object *migapi.MigHook) {
 	m.Version = object.ResourceVersion
 	m.Namespace = object.Namespace
 	m.Name = object.Name
+	m.labels = object.Labels
 	m.EncodeObject(object)
 }
 

--- a/pkg/controller/discovery/model/job.go
+++ b/pkg/controller/discovery/model/job.go
@@ -1,0 +1,88 @@
+package model
+
+import (
+	"encoding/json"
+
+	batchv1 "k8s.io/api/batch/v1"
+)
+
+//
+// Job model.
+type Job struct {
+	Base
+}
+
+//
+// Update the model `with` a k8s Job.
+func (m *Job) With(object *batchv1.Job) {
+	m.UID = string(object.UID)
+	m.Version = object.ResourceVersion
+	m.Namespace = object.Namespace
+	m.Name = object.Name
+	m.labels = object.Labels
+	m.EncodeObject(object)
+}
+
+//
+// Encode the object.
+func (m *Job) EncodeObject(job *batchv1.Job) {
+	object, _ := json.Marshal(job)
+	m.Object = string(object)
+}
+
+//
+// Encode the object.
+func (m *Job) DecodeObject() *batchv1.Job {
+	job := &batchv1.Job{}
+	json.Unmarshal([]byte(m.Object), job)
+	return job
+}
+
+//
+// Count in the DB.
+func (m Job) Count(db DB, options ListOptions) (int64, error) {
+	return Table{db}.Count(&m, options)
+}
+
+//
+// Fetch the from in the DB.
+func (m Job) List(db DB, options ListOptions) ([]*Job, error) {
+	list := []*Job{}
+	listed, err := Table{db}.List(&m, options)
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	for _, intPtr := range listed {
+		list = append(list, intPtr.(*Job))
+	}
+
+	return list, nil
+}
+
+//
+// Fetch the model from the DB.
+func (m *Job) Get(db DB) error {
+	return Table{db}.Get(m)
+}
+
+//
+// Insert the model into the DB.
+func (m *Job) Insert(db DB) error {
+	m.SetPk()
+	return Table{db}.Insert(m)
+}
+
+//
+// Update the model in the DB.
+func (m *Job) Update(db DB) error {
+	m.SetPk()
+	return Table{db}.Update(m)
+}
+
+//
+// Delete the model in the DB.
+func (m *Job) Delete(db DB) error {
+	m.SetPk()
+	return Table{db}.Delete(m)
+}

--- a/pkg/controller/discovery/model/model.go
+++ b/pkg/controller/discovery/model/model.go
@@ -267,6 +267,8 @@ type CR struct {
 	Name string `sql:"const,unique(b),key"`
 	// The raw json-encoded k8s resource.
 	Object string `sql:""`
+	// Labels.
+	labels Labels
 }
 
 //
@@ -299,5 +301,5 @@ func (m *CR) Meta() *Meta {
 //
 // Get associated labels.
 func (m *CR) Labels() Labels {
-	return Labels{}
+	return m.labels
 }

--- a/pkg/controller/discovery/model/model.go
+++ b/pkg/controller/discovery/model/model.go
@@ -54,6 +54,7 @@ func Create() (*sql.DB, error) {
 		&DirectImageMigration{},
 		&DirectVolumeMigrationProgress{},
 		&DirectImageStreamMigration{},
+		&Hook{},
 		&Backup{},
 		&Restore{},
 		&PodVolumeBackup{},

--- a/pkg/controller/discovery/model/model.go
+++ b/pkg/controller/discovery/model/model.go
@@ -59,6 +59,7 @@ func Create() (*sql.DB, error) {
 		&PodVolumeBackup{},
 		&PodVolumeRestore{},
 		&Namespace{},
+		&Route{},
 		&Service{},
 		&Pod{},
 		&PV{},

--- a/pkg/controller/discovery/model/model.go
+++ b/pkg/controller/discovery/model/model.go
@@ -65,6 +65,7 @@ func Create() (*sql.DB, error) {
 		&Pod{},
 		&PV{},
 		&PVC{},
+		&Job{},
 		&StorageClass{},
 	}
 	for _, m := range models {

--- a/pkg/controller/discovery/model/plan.go
+++ b/pkg/controller/discovery/model/plan.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"encoding/json"
+
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 )
 
@@ -98,6 +99,7 @@ func (m *Migration) With(object *migapi.MigMigration) {
 	m.Version = object.ResourceVersion
 	m.Namespace = object.Namespace
 	m.Name = object.Name
+	m.labels = object.Labels
 	m.EncodeObject(object)
 }
 

--- a/pkg/controller/discovery/model/pv.go
+++ b/pkg/controller/discovery/model/pv.go
@@ -2,7 +2,8 @@ package model
 
 import (
 	"encoding/json"
-	"k8s.io/api/core/v1"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 //
@@ -18,6 +19,7 @@ func (m *PV) With(object *v1.PersistentVolume) {
 	m.Version = object.ResourceVersion
 	m.Namespace = object.Namespace
 	m.Name = object.Name
+	m.labels = object.Labels
 	m.EncodeObject(object)
 }
 

--- a/pkg/controller/discovery/model/pvc.go
+++ b/pkg/controller/discovery/model/pvc.go
@@ -2,7 +2,8 @@ package model
 
 import (
 	"encoding/json"
-	"k8s.io/api/core/v1"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 //
@@ -18,6 +19,7 @@ func (m *PVC) With(object *v1.PersistentVolumeClaim) {
 	m.Version = object.ResourceVersion
 	m.Namespace = object.Namespace
 	m.Name = object.Name
+	m.labels = object.Labels
 	m.EncodeObject(object)
 }
 

--- a/pkg/controller/discovery/model/route.go
+++ b/pkg/controller/discovery/model/route.go
@@ -1,0 +1,89 @@
+package model
+
+import (
+	"encoding/json"
+
+	v1 "github.com/openshift/api/route/v1"
+)
+
+//
+// Route model
+type Route struct {
+	Base
+}
+
+//
+// Update the model `with` a k8s Route.
+func (m *Route) With(object *v1.Route) {
+	m.UID = string(object.UID)
+	m.Version = object.ResourceVersion
+	m.Namespace = object.Namespace
+	m.Name = object.Name
+	m.labels = object.Labels
+	m.EncodeObject(object)
+
+}
+
+//
+// Encode the object.
+func (m *Route) EncodeObject(pod *v1.Route) {
+	object, _ := json.Marshal(pod)
+	m.Object = string(object)
+}
+
+//
+// Decode the object.
+func (m *Route) DecodeObject() *v1.Route {
+	pod := &v1.Route{}
+	json.Unmarshal([]byte(m.Object), pod)
+	return pod
+}
+
+//
+// Count in the DB.
+func (m Route) Count(db DB, options ListOptions) (int64, error) {
+	return Table{db}.Count(&m, options)
+}
+
+//
+// Fetch the model from in the DB.
+func (m Route) List(db DB, options ListOptions) ([]*Route, error) {
+	list := []*Route{}
+	listed, err := Table{db}.List(&m, options)
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	for _, intPtr := range listed {
+		list = append(list, intPtr.(*Route))
+	}
+
+	return list, nil
+}
+
+//
+// Fetch the model from the DB.
+func (m *Route) Get(db DB) error {
+	return Table{db}.Get(m)
+}
+
+//
+// Insert the model into the DB.
+func (m *Route) Insert(db DB) error {
+	m.SetPk()
+	return Table{db}.Insert(m)
+}
+
+//
+// Update the model in the DB.
+func (m *Route) Update(db DB) error {
+	m.SetPk()
+	return Table{db}.Update(m)
+}
+
+//
+// Delete the model in the DB.
+func (m *Route) Delete(db DB) error {
+	m.SetPk()
+	return Table{db}.Delete(m)
+}

--- a/pkg/controller/discovery/model/service.go
+++ b/pkg/controller/discovery/model/service.go
@@ -2,7 +2,8 @@ package model
 
 import (
 	"encoding/json"
-	"k8s.io/api/core/v1"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 //
@@ -18,6 +19,7 @@ func (m *Service) With(object *v1.Service) {
 	m.Version = object.ResourceVersion
 	m.Namespace = object.Namespace
 	m.Name = object.Name
+	m.labels = object.Labels
 	m.EncodeObject(object)
 }
 

--- a/pkg/controller/discovery/model/storageclass.go
+++ b/pkg/controller/discovery/model/storageclass.go
@@ -19,6 +19,7 @@ func (m *StorageClass) With(object *v1.StorageClass) {
 	m.Version = object.ResourceVersion
 	m.Namespace = object.Namespace
 	m.Name = object.Name
+	m.labels = object.Labels
 	m.EncodeObject(object)
 }
 

--- a/pkg/controller/discovery/model/velero.go
+++ b/pkg/controller/discovery/model/velero.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"encoding/json"
+
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 )
 
@@ -18,6 +19,7 @@ func (m *Backup) With(object *velero.Backup) {
 	m.Version = object.ResourceVersion
 	m.Namespace = object.Namespace
 	m.Name = object.Name
+	m.labels = object.Labels
 	m.EncodeObject(object)
 }
 
@@ -98,6 +100,7 @@ func (m *Restore) With(object *velero.Restore) {
 	m.Version = object.ResourceVersion
 	m.Namespace = object.Namespace
 	m.Name = object.Name
+	m.labels = object.Labels
 	m.EncodeObject(object)
 }
 
@@ -178,6 +181,7 @@ func (m *PodVolumeBackup) With(object *velero.PodVolumeBackup) {
 	m.Version = object.ResourceVersion
 	m.Namespace = object.Namespace
 	m.Name = object.Name
+	m.labels = object.Labels
 	m.EncodeObject(object)
 }
 
@@ -258,6 +262,7 @@ func (m *PodVolumeRestore) With(object *velero.PodVolumeRestore) {
 	m.Version = object.ResourceVersion
 	m.Namespace = object.Namespace
 	m.Name = object.Name
+	m.labels = object.Labels
 	m.EncodeObject(object)
 }
 

--- a/pkg/controller/discovery/web/hook.go
+++ b/pkg/controller/discovery/web/hook.go
@@ -1,0 +1,187 @@
+package web
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
+	auth "k8s.io/api/authorization/v1"
+)
+
+const (
+	HookParam = "hook"
+	HooksRoot = Root + "/hooks"
+	HookRoot  = HooksRoot + "/:" + HookParam
+)
+
+// Hook (route) handler.
+type HookHandler struct {
+	// Base
+	BaseHandler
+	// Hook referenced in the request.
+	hook model.Hook
+}
+
+//
+// Add DIM routes.
+func (h HookHandler) AddRoutes(r *gin.Engine) {
+	r.GET(HooksRoot, h.List)
+	r.GET(HooksRoot+"/", h.List)
+	r.GET(HookRoot, h.Get)
+}
+
+//
+// Prepare to fulfil the request.
+// Fetch the referenced hook.
+// Perform SAR authorization.
+func (h *HookHandler) Prepare(ctx *gin.Context) int {
+	status := h.BaseHandler.Prepare(ctx)
+	if status != http.StatusOK {
+		return status
+	}
+	name := ctx.Param(HookParam)
+	if name != "" {
+		h.hook = model.Hook{
+			CR: model.CR{
+				Namespace: ctx.Param(NsParam),
+				Name:      ctx.Param(HookParam),
+			},
+		}
+		err := h.hook.Get(h.container.Db)
+		if err != nil {
+			if err != sql.ErrNoRows {
+				Log.Trace(err)
+				return http.StatusInternalServerError
+			} else {
+				return http.StatusNotFound
+			}
+		}
+	}
+	status = h.allow(h.getSAR())
+	if status != http.StatusOK {
+		return status
+	}
+
+	return http.StatusOK
+}
+
+// Build the appropriate SAR object.
+// The subject is the Hook.
+func (h *HookHandler) getSAR() auth.SelfSubjectAccessReview {
+	return auth.SelfSubjectAccessReview{
+		Spec: auth.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &auth.ResourceAttributes{
+				Group:     "apps",
+				Resource:  "Hook",
+				Namespace: h.hook.Namespace,
+				Name:      h.hook.Name,
+				Verb:      "get",
+			},
+		},
+	}
+}
+
+//
+// List all of the dims in the namespace.
+func (h HookHandler) List(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	db := h.container.Db
+	collection := model.Hook{}
+	count, err := collection.Count(db, model.ListOptions{})
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	list, err := collection.List(db, model.ListOptions{})
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	content := HookList{
+		Count: count,
+	}
+	for _, m := range list {
+		r := Hook{}
+		r.With(m)
+		r.SelfLink = h.Link(m)
+		content.Items = append(content.Items, r)
+	}
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Get a specific dim.
+func (h HookHandler) Get(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	err := h.hook.Get(h.container.Db)
+	if err != nil {
+		if err != sql.ErrNoRows {
+			Log.Trace(err)
+			ctx.Status(http.StatusInternalServerError)
+			return
+		} else {
+			ctx.Status(http.StatusNotFound)
+			return
+		}
+	}
+	r := Hook{}
+	r.With(&h.hook)
+	r.SelfLink = h.Link(&h.hook)
+	content := r
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Build self link.
+func (h HookHandler) Link(m *model.Hook) string {
+	return h.BaseHandler.Link(
+		HookRoot,
+		Params{
+			NsParam:   m.Namespace,
+			HookParam: m.Name,
+		})
+}
+
+//
+// Hook REST resource.
+type Hook struct {
+	// The k8s namespace.
+	Namespace string `json:"namespace,omitempty"`
+	// The k8s name.
+	Name string `json:"name"`
+	// Self URI.
+	SelfLink string `json:"selfLink"`
+	// Raw k8s object.
+	Object *migapi.MigHook `json:"object,omitempty"`
+}
+
+//
+// Build the resource.
+func (r *Hook) With(m *model.Hook) {
+	r.Namespace = m.Namespace
+	r.Name = m.Name
+	r.Object = m.DecodeObject()
+}
+
+//
+// Hook collection REST resource.
+type HookList struct {
+	// Total number in the collection.
+	Count int64 `json:"count"`
+	// List of resources.
+	Items []Hook `json:"resources"`
+}

--- a/pkg/controller/discovery/web/job.go
+++ b/pkg/controller/discovery/web/job.go
@@ -1,0 +1,149 @@
+package web
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
+	batchv1 "k8s.io/api/batch/v1"
+)
+
+const (
+	JobParam = "job"
+	JobsRoot = NamespaceRoot + "/jobs"
+	JobRoot  = JobsRoot + "/:" + JobParam
+)
+
+//
+// Job (route) handler.
+type JobHandler struct {
+	// Base
+	ClusterScoped
+}
+
+//
+// Add routes.
+func (h JobHandler) AddRoutes(r *gin.Engine) {
+	r.GET(JobsRoot, h.List)
+	r.GET(JobsRoot+"/", h.List)
+	r.GET(JobRoot, h.Get)
+}
+
+//
+// List all of the Jobs on a cluster.
+func (h JobHandler) List(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	db := h.container.Db
+	collection := model.Job{
+		Base: model.Base{
+			Cluster: h.cluster.PK,
+		},
+	}
+	count, err := collection.Count(db, model.ListOptions{})
+	if err != nil {
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	list, err := collection.List(
+		db,
+		model.ListOptions{
+			Page: &h.page,
+		})
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	content := JobList{
+		Count: count,
+	}
+	for _, m := range list {
+		r := Job{}
+		r.With(m)
+		r.SelfLink = h.Link(&h.cluster, m)
+		content.Items = append(content.Items, r)
+	}
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Get a specific Job on a cluster.
+func (h JobHandler) Get(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	m := model.Job{
+		Base: model.Base{
+			Cluster:   h.cluster.PK,
+			Namespace: ctx.Param(Ns2Param),
+			Name:      ctx.Param(JobParam),
+		},
+	}
+	err := m.Get(h.container.Db)
+	if err != nil {
+		if err != sql.ErrNoRows {
+			Log.Trace(err)
+			ctx.Status(http.StatusInternalServerError)
+			return
+		} else {
+			ctx.Status(http.StatusNotFound)
+			return
+		}
+	}
+	r := Job{}
+	r.With(&m)
+	r.SelfLink = h.Link(&h.cluster, &m)
+	content := r
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Build self link.
+func (h JobHandler) Link(c *model.Cluster, m *model.Job) string {
+	return h.BaseHandler.Link(
+		JobRoot,
+		Params{
+			NsParam:      c.Namespace,
+			ClusterParam: c.Name,
+			Ns2Param:     m.Namespace,
+			JobParam:     m.Name,
+		})
+}
+
+// Job REST resource
+type Job struct {
+	// The k8s namespace.
+	Namespace string `json:"namespace,omitempty"`
+	// The k8s name.
+	Name string `json:"name"`
+	// Self URI.
+	SelfLink string `json:"selfLink"`
+	// Raw k8s object.
+	Object *batchv1.Job `json:"object,omitempty"`
+}
+
+//
+// Build the resource.
+func (r *Job) With(m *model.Job) {
+	r.Namespace = m.Namespace
+	r.Name = m.Name
+	r.Object = m.DecodeObject()
+}
+
+//
+// Job collection REST resource.
+type JobList struct {
+	// Total number in the collection.
+	Count int64 `json:"count"`
+	// List of resources.
+	Items []Job `json:"resources"`
+}

--- a/pkg/controller/discovery/web/migration.go
+++ b/pkg/controller/discovery/web/migration.go
@@ -2,11 +2,12 @@ package web
 
 import (
 	"database/sql"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
 	auth "k8s.io/api/authorization/v1"
-	"net/http"
 )
 
 // Migration route root.

--- a/pkg/controller/discovery/web/plan.go
+++ b/pkg/controller/discovery/web/plan.go
@@ -312,8 +312,13 @@ func (t *PlanTree) getRoot() *TreeNode {
 //
 // Add related migrations.
 func (t *PlanTree) addMigrations(parent *TreeNode) error {
+	planObject := t.plan.DecodeObject()
 	collection := model.Migration{}
-	list, err := collection.List(t.db, model.ListOptions{})
+	list, err := collection.List(t.db, model.ListOptions{
+		Labels: model.Labels{
+			"migration.openshift.io/migplan-name": planObject.Name,
+		},
+	})
 	if err != nil {
 		Log.Trace(err)
 		return err

--- a/pkg/controller/discovery/web/plan.go
+++ b/pkg/controller/discovery/web/plan.go
@@ -387,7 +387,11 @@ func (t *PlanTree) addBackups(migration *model.Migration, parent *TreeNode) erro
 		},
 	}
 	cLabel := t.cLabel(migration.DecodeObject())
-	list, err := collection.List(t.db, model.ListOptions{})
+	list, err := collection.List(t.db, model.ListOptions{
+		Labels: model.Labels{
+			cLabel.Name: cLabel.Value,
+		},
+	})
 	if err != nil {
 		Log.Trace(err)
 		return err
@@ -397,11 +401,11 @@ func (t *PlanTree) addBackups(migration *model.Migration, parent *TreeNode) erro
 		if object.Labels == nil {
 			continue
 		}
-		if v, found := object.Labels[cLabel.Name]; found {
-			if v != cLabel.Value {
-				continue
-			}
-		}
+		// if v, found := object.Labels[cLabel.Name]; found {
+		// 	if v != cLabel.Value {
+		// 		continue
+		// 	}
+		// }
 		node := TreeNode{
 			Kind:       migref.ToKind(m),
 			ObjectLink: BackupHandler{}.Link(&cluster, m),

--- a/pkg/controller/discovery/web/plan.go
+++ b/pkg/controller/discovery/web/plan.go
@@ -402,9 +402,63 @@ func (t *PlanTree) addBackups(migration *model.Migration, parent *TreeNode) erro
 			Log.Trace(err)
 			return err
 		}
+		// Add move and snapshot PVCs if this is a stage backup
+		_, found := object.Labels["migration-stage-backup"]
+		if found {
+			err = t.addMoveAndSnapshotPVCsForCluster(cluster, &node)
+			if err != nil {
+				Log.Trace(err)
+				return err
+			}
+		}
 		parent.Children = append(parent.Children, node)
 	}
 
+	return nil
+}
+
+// Add PVCs that will be moved or snapshotted
+func (t *PlanTree) addMoveAndSnapshotPVCsForCluster(cluster model.Cluster, parent *TreeNode) error {
+	collection := model.PVC{
+		Base: model.Base{
+			Cluster: cluster.PK,
+		},
+	}
+	// Get list of PVC names that will be moved / snapshotted from MigPlan
+	plan := t.plan.DecodeObject()
+	pvcsToInclude := []migapi.PVC{}
+	for _, pv := range plan.Spec.PersistentVolumes.List {
+		// Add to list if not using file copy|skip method
+		if pv.Selection.Action != migapi.PvCopyAction && pv.Selection.Action != migapi.PvSkipAction {
+			pvcsToInclude = append(pvcsToInclude, pv.PVC)
+		}
+	}
+
+	list, err := collection.List(t.db, model.ListOptions{})
+	if err != nil {
+		Log.Trace(err)
+		return err
+	}
+	for _, m := range list {
+		object := m.DecodeObject()
+		for _, pvc := range pvcsToInclude {
+			if pvc.Name == object.Name && pvc.Namespace == object.Namespace {
+				node := TreeNode{
+					Kind:       migref.ToKind(m),
+					ObjectLink: PvcHandler{}.Link(&cluster, m),
+					Namespace:  m.Namespace,
+					Name:       m.Name,
+				}
+				err := t.addPVForPVC(cluster, m, &node)
+				if err != nil {
+					Log.Trace(err)
+					return err
+				}
+				parent.Children = append(parent.Children, node)
+				break
+			}
+		}
+	}
 	return nil
 }
 
@@ -448,7 +502,15 @@ func (t *PlanTree) addRestores(migration *model.Migration, parent *TreeNode) err
 			Log.Trace(err)
 			return err
 		}
-
+		// Add move and snapshot PVCs if this is a stage restore
+		_, found := object.Labels["migration-stage-restore"]
+		if found {
+			err = t.addMoveAndSnapshotPVCsForCluster(cluster, &node)
+			if err != nil {
+				Log.Trace(err)
+				return err
+			}
+		}
 		parent.Children = append(parent.Children, node)
 	}
 

--- a/pkg/controller/discovery/web/plan.go
+++ b/pkg/controller/discovery/web/plan.go
@@ -635,14 +635,6 @@ func (t *PlanTree) addDirectVolumeProgresses(directVolume *model.DirectVolumeMig
 		}
 
 		parent.Children = append(parent.Children, node)
-		// parent.Children = append(
-		// 	parent.Children,
-		// 	TreeNode{
-		// 		Kind:       migref.ToKind(m),
-		// 		ObjectLink: DirectVolumeMigrationProgressHandler{}.Link(m),
-		// 		Namespace:  m.Namespace,
-		// 		Name:       m.Name,
-		// 	})
 	}
 	return nil
 }

--- a/pkg/controller/discovery/web/plan.go
+++ b/pkg/controller/discovery/web/plan.go
@@ -439,6 +439,7 @@ func (t *PlanTree) addMoveAndSnapshotPVCsForCluster(cluster model.Cluster, paren
 		}
 	}
 
+	// Search for PVCs in all namespaces that are part of MigPlan.
 	for _, pvcNamespace := range planObject.Spec.Namespaces {
 		collection := model.PVC{
 			Base: model.Base{
@@ -490,7 +491,11 @@ func (t *PlanTree) addRestores(migration *model.Migration, parent *TreeNode) err
 		},
 	}
 	cLabel := t.cLabel(migration.DecodeObject())
-	list, err := collection.List(t.db, model.ListOptions{})
+	list, err := collection.List(t.db, model.ListOptions{
+		Labels: model.Labels{
+			cLabel.Name: cLabel.Value,
+		},
+	})
 	if err != nil {
 		Log.Trace(err)
 		return err

--- a/pkg/controller/discovery/web/route.go
+++ b/pkg/controller/discovery/web/route.go
@@ -1,0 +1,153 @@
+package web
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
+	v1 "github.com/openshift/api/route/v1"
+)
+
+const (
+	RouteParam = "route"
+	RoutesRoot = NamespaceRoot + "/routes"
+	RouteRoot  = RoutesRoot + "/:" + RouteParam
+)
+
+//
+// Route (route) handler.
+type RouteHandler struct {
+	// Base
+	ClusterScoped
+}
+
+//
+// Add routes.
+func (h RouteHandler) AddRoutes(r *gin.Engine) {
+	r.GET(RoutesRoot, h.List)
+	r.GET(RoutesRoot+"/", h.List)
+	r.GET(RouteRoot, h.Get)
+}
+
+//
+// Get a specific route.
+func (h RouteHandler) Get(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	namespace := ctx.Param(Ns2Param)
+	name := ctx.Param(RouteParam)
+	m := model.Route{
+		Base: model.Base{
+			Cluster:   h.cluster.PK,
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+	err := m.Get(h.container.Db)
+	if err != nil {
+		if err != sql.ErrNoRows {
+			Log.Trace(err)
+			ctx.Status(http.StatusInternalServerError)
+			return
+		} else {
+			ctx.Status(http.StatusNotFound)
+			return
+		}
+	}
+	r := Route{}
+	r.With(&m)
+	r.SelfLink = h.Link(&h.cluster, &m)
+	content := r
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// List routes on a cluster in a namespace.
+func (h RouteHandler) List(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	db := h.container.Db
+	collection := model.Route{
+		Base: model.Base{
+			Cluster:   h.cluster.PK,
+			Namespace: ctx.Param(Ns2Param),
+		},
+	}
+	count, err := collection.Count(db, model.ListOptions{})
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	list, err := collection.List(
+		db,
+		model.ListOptions{
+			Page: &h.page,
+		})
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	content := RouteList{
+		Count: count,
+	}
+	for _, m := range list {
+		r := Route{}
+		r.With(m)
+		r.SelfLink = h.Link(&h.cluster, m)
+		content.Items = append(content.Items, r)
+	}
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Build self link.
+func (h RouteHandler) Link(c *model.Cluster, m *model.Route) string {
+	return h.BaseHandler.Link(
+		RouteRoot,
+		Params{
+			NsParam:      c.Namespace,
+			ClusterParam: c.Name,
+			Ns2Param:     m.Namespace,
+			RouteParam:   m.Name,
+		})
+}
+
+// Route REST resource
+type Route struct {
+	// The k8s namespace.
+	Namespace string `json:"namespace,omitempty"`
+	// The k8s name.
+	Name string `json:"name"`
+	// Self URI.
+	SelfLink string `json:"selfLink"`
+	// Raw k8s object.
+	Object *v1.Route `json:"object,omitempty"`
+}
+
+//
+// Build the resource.
+func (r *Route) With(m *model.Route) {
+	r.Namespace = m.Namespace
+	r.Name = m.Name
+	r.Object = m.DecodeObject()
+}
+
+//
+// Route collection REST resource.
+type RouteList struct {
+	// Total number in the collection.
+	Count int64 `json:"count"`
+	// List of resources.
+	Items []Route `json:"resources"`
+}

--- a/pkg/controller/discovery/web/web.go
+++ b/pkg/controller/discovery/web/web.go
@@ -140,6 +140,13 @@ func (w *WebServer) addRoutes(r *gin.Engine) {
 				},
 			},
 		},
+		JobHandler{
+			ClusterScoped: ClusterScoped{
+				BaseHandler: BaseHandler{
+					container: w.Container,
+				},
+			},
+		},
 		ServiceHandler{
 			ClusterScoped: ClusterScoped{
 				BaseHandler: BaseHandler{

--- a/pkg/controller/discovery/web/web.go
+++ b/pkg/controller/discovery/web/web.go
@@ -147,6 +147,13 @@ func (w *WebServer) addRoutes(r *gin.Engine) {
 				},
 			},
 		},
+		RouteHandler{
+			ClusterScoped: ClusterScoped{
+				BaseHandler: BaseHandler{
+					container: w.Container,
+				},
+			},
+		},
 		PlanHandler{
 			BaseHandler: BaseHandler{
 				container: w.Container,

--- a/pkg/controller/discovery/web/web.go
+++ b/pkg/controller/discovery/web/web.go
@@ -159,6 +159,11 @@ func (w *WebServer) addRoutes(r *gin.Engine) {
 				container: w.Container,
 			},
 		},
+		HookHandler{
+			BaseHandler: BaseHandler{
+				container: w.Container,
+			},
+		},
 		MigrationHandler{
 			BaseHandler: BaseHandler{
 				container: w.Container,

--- a/pkg/controller/migmigration/dvm.go
+++ b/pkg/controller/migmigration/dvm.go
@@ -41,7 +41,7 @@ func (t *Task) createDirectVolumeMigration() error {
 func (t *Task) buildDirectVolumeMigration() *migapi.DirectVolumeMigration {
 	// Set correlation labels
 	labels := t.Owner.GetCorrelationLabels()
-	labels[DirectVolumeMigrationLabel] = t.UID()
+	labels[migapi.DirectVolumeMigrationLabel] = t.UID()
 	pvcList := t.getDirectVolumeClaimList()
 	if pvcList == nil {
 		return nil
@@ -66,7 +66,7 @@ func (t *Task) buildDirectVolumeMigration() *migapi.DirectVolumeMigration {
 func (t *Task) getDirectVolumeMigration() (*migapi.DirectVolumeMigration, error) {
 	// Get correlation labels
 	labels := t.Owner.GetCorrelationLabels()
-	labels[DirectVolumeMigrationLabel] = t.UID()
+	labels[migapi.DirectVolumeMigrationLabel] = t.UID()
 	// Get DVM with label
 	list := migapi.DirectVolumeMigrationList{}
 	err := t.Client.List(

--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -377,13 +377,13 @@ func (r *ReconcileMigMigration) ensureDebugLabels(migration *migapi.MigMigration
 	if migration.Labels == nil {
 		migration.Labels = make(map[string]string)
 	} else {
-		if value, exists := migration.Labels[MigPlanDebugLabel]; exists {
+		if value, exists := migration.Labels[migapi.MigPlanDebugLabel]; exists {
 			if value == migration.Spec.MigPlanRef.Name {
 				return nil
 			}
 		}
 	}
-	migration.Labels[MigPlanDebugLabel] = migration.Spec.MigPlanRef.Name
+	migration.Labels[migapi.MigPlanDebugLabel] = migration.Spec.MigPlanRef.Name
 	err := r.Update(context.TODO(), migration)
 	if err != nil {
 		return liberr.Wrap(err)

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -138,9 +138,9 @@ func (r *ReconcileMigMigration) migrate(ctx context.Context, migration *migapi.M
 func (r *ReconcileMigMigration) getAnnotations(migration *migapi.MigMigration) map[string]string {
 	annotations := make(map[string]string)
 	if migration.Spec.Stage {
-		annotations[StageOrFinalMigrationAnnotation] = StageMigration
+		annotations[migapi.StageOrFinalMigrationAnnotation] = migapi.StageMigration
 	} else {
-		annotations[StageOrFinalMigrationAnnotation] = FinalMigration
+		annotations[migapi.StageOrFinalMigrationAnnotation] = migapi.FinalMigration
 	}
 	return annotations
 }

--- a/pkg/controller/migmigration/registry.go
+++ b/pkg/controller/migmigration/registry.go
@@ -63,7 +63,7 @@ func (t *Task) getAnnotations(client k8sclient.Client) (map[string]string, error
 		}
 	}
 	if t.quiesce() {
-		annotations[QuiesceAnnotation] = "true"
+		annotations[migapi.QuiesceAnnotation] = "true"
 	}
 	return annotations, nil
 }

--- a/pkg/controller/migmigration/registry.go
+++ b/pkg/controller/migmigration/registry.go
@@ -255,7 +255,7 @@ func (t *Task) ensureRegistryDeployment(client k8sclient.Client, secret *kapi.Se
 	}
 
 	// Construct Registry DC
-	newDeployment := plan.BuildRegistryDeployment(storage, proxySecret, name, dirName, registryImage)
+	newDeployment := plan.BuildRegistryDeployment(storage, proxySecret, name, dirName, registryImage, t.Owner.GetCorrelationLabels())
 	foundDeployment, err := plan.GetRegistryDeployment(client)
 	if err != nil {
 		return liberr.Wrap(err)
@@ -270,7 +270,7 @@ func (t *Task) ensureRegistryDeployment(client k8sclient.Client, secret *kapi.Se
 	if plan.EqualsRegistryDeployment(newDeployment, foundDeployment) {
 		return nil
 	}
-	plan.UpdateRegistryDeployment(storage, foundDeployment, proxySecret, name, dirName, registryImage)
+	plan.UpdateRegistryDeployment(storage, foundDeployment, proxySecret, name, dirName, registryImage, t.Owner.GetCorrelationLabels())
 	err = client.Update(context.TODO(), foundDeployment)
 	if err != nil {
 		return liberr.Wrap(err)

--- a/pkg/controller/migmigration/stage.go
+++ b/pkg/controller/migmigration/stage.go
@@ -816,7 +816,7 @@ func (t *Task) ensureStagePodsTerminated() (bool, error) {
 
 // Label applied to all stage pods for easy cleanup
 func (t *Task) stagePodCleanupLabel() map[string]string {
-	return map[string]string{StagePodLabel: migapi.True}
+	return map[string]string{migapi.StagePodLabel: migapi.True}
 }
 
 // Build map of all stage pod labels
@@ -833,7 +833,7 @@ func (t *Task) stagePodLabels() map[string]string {
 		labels[labelName] = labelValue
 	}
 
-	labels[IncludedInStageBackupLabel] = t.UID()
+	labels[migapi.IncludedInStageBackupLabel] = t.UID()
 
 	// merge label indicating this is a stage pod for later cleanup purposes
 	stagePodCleanupLabel := t.stagePodCleanupLabel()


### PR DESCRIPTION
These are the resources that tend to get a migration stuck. Adding them to the tree view and keeping their status up to date should make it immediately obvious what to look at from the UI when something is stuck.

Merge with https://github.com/konveyor/mig-ui/pull/1164

Todo:

- [x] Stage Pods
- [x] Registry Pods
- [x] PVCs
- [x] Rsync Pods
- [x] Stunnel Pods
- [x] Rsync Routes
- [x] Indirect PVCs
- [x] Direct PVCs
- [x] Ensure Stunnel/Rsync Pods from both clusters are captured
- [x] Hooks, Hook Jobs, Hook Job Pods
- [x] Support PVCs and PVs created by PV move operation
- [x] Support PVCs and PVs created by PV snapshot operation
- [x] Fix label selectors on list calls 
- [x] Use label consts instead of duplicating string vals 


## Notes on the implementation
 - I added a bunch of boilerplate code to the discovery controller required to watch new types of resources (Routes, Pods, PVCs, PVs, Jobs). The boilerplate probably accounts for 3/4 of the added LoC.
 - I had to move the shared labels and annotations to `v1alpha1` pkg to access them from Discovery. They should have been here in the first place so that folks who consume our API can get to these labels / annotations with the API pkg.
 - I'm using label selectors on all queries where it's possible against the discovery DB
 - I had to add some new labels to a few things around the code base to make it possible for everything to show up in the tree view.
 - In a future PR, I'd like to add an endpoint that just grabs resources for a particular _migration_ instead of the whole plan

### Test instructions - UI + controller workflow
```
# Configure operator to use local controller and point discovery URL at localhost
make use-local-controller

# Start local controller
AUTH_OPTIONAL=1 make run-fast

# Start local UI
# Checkout https://github.com/konveyor/mig-ui/pull/1164
yarn start:remote
```

### Test instructions - querying the discovery service locally

Run some type of migration. The tree view in the UI should populate with a bunch of resource information including current status.

```
# Start discovery service
AUTH_OPTIONAL=1 ROLE=discovery make run-fast

# Get the schema, format with jq
curl http://localhost:8080/schema | jq

{
  "Version": "beta1",
  "Release": 2,
  "Paths": [
    [...]
    "/namespaces/:ns1/clusters/:cluster/namespaces/:ns2",
    "/namespaces/:ns1/clusters/:cluster/namespaces/:ns2/podvolumebackups",
    "/namespaces/:ns1/clusters/:cluster/namespaces/:ns2/podvolumebackups/",
    [...]
}

# Query for tree view
curl http://localhost:8080/namespaces/openshift-migration/plans/PLAN-NAME/tree | jq

```

## Demo
https://user-images.githubusercontent.com/7576968/115086026-7ef4db00-9ed9-11eb-88e6-d49c9bf95db8.mp4