### PR TITLE
Bug 1949238: No warning on NodeName. Warn if NodeSelector is non-default

### DIFF
--- a/pkg/controller/migplan/migplan_controller_test.go
+++ b/pkg/controller/migplan/migplan_controller_test.go
@@ -385,7 +385,88 @@ func TestReconcileMigPlan_ensureMigAnalytics(t *testing.T) {
 	}
 }
 
-func TestReconcileMigPlan_waitForMigAnalyticsReady(t *testing.T) {
+func TestReconcileMigPlan_hasCustomNodeSelectors(t *testing.T) {
+	// Test data for verifying hasCustomNodeSelectors will return FALSE given a
+	// list of Pods without any custom nodeselectors.
+	podsWithoutCustomNodeSelectors := []corev1.Pod{
+		corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-without-custom-nodeselector",
+				Namespace: "mssql-persistent",
+			},
+			Spec: corev1.PodSpec{
+				NodeSelector: map[string]string{
+					"node-role.kubernetes.io/compute": "true",
+				},
+			},
+		},
+		corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-2-without-custom-nodeselector",
+				Namespace: "mssql-persistent",
+			},
+		},
+	}
+
+	// Test data for verifying hasCustomNodeSelectors will return TRUE given a
+	// list of Pods WITH custom node selectors
+	podsWithCustomNodeSelectors := []corev1.Pod{
+		corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-without-custom-nodeselector",
+				Namespace: "mssql-persistent",
+			},
+			Spec: corev1.PodSpec{
+				NodeSelector: map[string]string{
+					"my-custom-role.foobar.io/compute": "true",
+				},
+			},
+		},
+		corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-2-without-custom-nodeselector",
+				Namespace: "mssql-persistent",
+			},
+		},
+	}
+	type args struct {
+		plan                       *migapi.MigPlan
+		sourceClusterPodsToMigrate []corev1.Pod
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Test that 'hasCustomNodeSelectors' returns FALSE given a list of Pods WITHOUT custom nodeselectors",
+			args: args{
+				plan:                       migPlan,
+				sourceClusterPodsToMigrate: podsWithoutCustomNodeSelectors,
+			},
+			want: false,
+		},
+		{
+			name: "Test that 'hasCustomNodeSelectors' returns TRUE given a list of Pods WITH custom nodeselectors",
+			args: args{
+				plan:                       migPlan,
+				sourceClusterPodsToMigrate: podsWithCustomNodeSelectors,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := ReconcileMigPlan{}
+			got := r.hasCustomNodeSelectors(tt.args.sourceClusterPodsToMigrate)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("test.name=[%v]: hasCustomNodeSelectors() got = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test(t *testing.T) {
 	type fields struct {
 		Client        client.Client
 		EventRecorder record.EventRecorder

--- a/pkg/controller/migplan/migplan_controller_test.go
+++ b/pkg/controller/migplan/migplan_controller_test.go
@@ -415,6 +415,7 @@ func TestReconcileMigPlan_hasCustomNodeSelectors(t *testing.T) {
 			},
 			Spec: corev1.PodSpec{
 				NodeSelector: map[string]string{
+					"node-role.kubernetes.io/compute":  "true",
 					"my-custom-role.foobar.io/compute": "true",
 				},
 			},

--- a/pkg/controller/migplan/migplan_controller_test.go
+++ b/pkg/controller/migplan/migplan_controller_test.go
@@ -411,7 +411,7 @@ func TestReconcileMigPlan_hasCustomNodeSelectors(t *testing.T) {
 	podsWithCustomNodeSelectors := []corev1.Pod{
 		corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "pod-without-custom-nodeselector",
+				Name: "pod-with-custom-nodeselector",
 			},
 			Spec: corev1.PodSpec{
 				NodeSelector: map[string]string{

--- a/pkg/controller/migplan/migplan_controller_test.go
+++ b/pkg/controller/migplan/migplan_controller_test.go
@@ -391,8 +391,7 @@ func TestReconcileMigPlan_hasCustomNodeSelectors(t *testing.T) {
 	podsWithoutCustomNodeSelectors := []corev1.Pod{
 		corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pod-without-custom-nodeselector",
-				Namespace: "mssql-persistent",
+				Name: "pod-without-custom-nodeselector",
 			},
 			Spec: corev1.PodSpec{
 				NodeSelector: map[string]string{
@@ -402,8 +401,7 @@ func TestReconcileMigPlan_hasCustomNodeSelectors(t *testing.T) {
 		},
 		corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pod-2-without-custom-nodeselector",
-				Namespace: "mssql-persistent",
+				Name: "pod-2-without-custom-nodeselector",
 			},
 		},
 	}
@@ -413,8 +411,7 @@ func TestReconcileMigPlan_hasCustomNodeSelectors(t *testing.T) {
 	podsWithCustomNodeSelectors := []corev1.Pod{
 		corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pod-without-custom-nodeselector",
-				Namespace: "mssql-persistent",
+				Name: "pod-without-custom-nodeselector",
 			},
 			Spec: corev1.PodSpec{
 				NodeSelector: map[string]string{
@@ -424,8 +421,7 @@ func TestReconcileMigPlan_hasCustomNodeSelectors(t *testing.T) {
 		},
 		corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pod-2-without-custom-nodeselector",
-				Namespace: "mssql-persistent",
+				Name: "pod-2-without-custom-nodeselector",
 			},
 		},
 	}
@@ -460,7 +456,7 @@ func TestReconcileMigPlan_hasCustomNodeSelectors(t *testing.T) {
 			r := ReconcileMigPlan{}
 			got := r.hasCustomNodeSelectors(tt.args.sourceClusterPodsToMigrate)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("test.name=[%v]: hasCustomNodeSelectors() got = %v, want %v", tt.name, got, tt.want)
+				t.Errorf("hasCustomNodeSelectors() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -394,7 +394,8 @@ func (r ReconcileMigPlan) validatePodProperties(ctx context.Context, plan *migap
 	return nil
 }
 
-// Checks the list of Pods for any non-default nodeselectors. Returns list of custom nodeselectors.
+// Checks the list of Pods for any non-default nodeselectors.
+// Returns true if custom nodeselectors found on any Pod.
 func (r ReconcileMigPlan) hasCustomNodeSelectors(podList []kapi.Pod) bool {
 	// Known default node selector values. Ignore these if we spot them on Pods
 	defaultNodeSelectors := map[string]string{

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -398,20 +398,22 @@ func (r ReconcileMigPlan) validatePodProperties(ctx context.Context, plan *migap
 // Returns true if custom nodeselectors found on any Pod.
 func (r ReconcileMigPlan) hasCustomNodeSelectors(podList []kapi.Pod) bool {
 	// Known default node selector values. Ignore these if we spot them on Pods
-	defaultNodeSelectors := map[string]string{
-		"node-role.kubernetes.io/compute": "true",
+	defaultNodeSelectors := []string{
+		"node-role.kubernetes.io/compute",
 	}
 	for _, pod := range podList {
-		// Return true if pod has node selectors not in the default list
-		if pod.Spec.NodeSelector != nil {
-			for defaultSelector, _ := range defaultNodeSelectors {
-				if _, found := pod.Spec.NodeSelector[defaultSelector]; !found {
+		if pod.Spec.NodeSelector == nil {
+			continue
+		}
+		for nodeSelector := range pod.Spec.NodeSelector {
+			for _, defaultSelector := range defaultNodeSelectors {
+				// Return true if node selector on Pod is not one of the defaults
+				if nodeSelector != defaultSelector {
 					return true
 				}
 			}
 		}
 	}
-
 	return false
 }
 

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -379,16 +379,19 @@ func (r ReconcileMigPlan) validatePodProperties(ctx context.Context, plan *migap
 	}
 
 	if len(nsWithNodeSelectors) > 0 {
-		msgFormat := "Found Pods with `Spec.NodeSelector` or `Spec.NodeName` set in namespaces: [%s]. " +
-			"These fields will be cleared on Pods restored into the target cluster."
+		msgFormat := "Found Pods with non-default `Spec.NodeSelector` set in namespaces: [%s]. " +
+			"This field will be cleared on Pods restored into the target cluster."
 		plan.Status.SetCondition(migapi.Condition{
 			Type:     NsHaveNodeSelectors,
 			Status:   True,
 			Reason:   NodeSelectorsDetected,
 			Category: Warn,
+			Durable:  true,
 			Message: fmt.Sprintf(msgFormat,
 				strings.Join(nsWithNodeSelectors, ", ")),
 		})
+	} else {
+		plan.Status.DeleteCondition(NsHaveNodeSelectors)
 	}
 
 	return nil


### PR DESCRIPTION
This PR:
 - stops MigPlan Wizard from warning the user about NodeSelectors when they are just using the default one
 - stops MigPlan wizard from warning the user if NodeName is set, since NodeName appears to be _always_ set on OCP 3.11.
 - adds TCs for above
 - makes the warning condition durable so it doesn't disappear when the migration starts