### PR TITLE
Add some logs to restic DF executor

### DIFF
--- a/pkg/controller/miganalytic/restic_executor.go
+++ b/pkg/controller/miganalytic/restic_executor.go
@@ -62,6 +62,10 @@ func (r *ResticDFCommandExecutor) DF(podRef *corev1.Pod, persistentVolumes []Mig
 		RestCfg: restCfg,
 		Args:    cmdString,
 	}
+	log.Info("Executing df command inside source cluster Restic Pod to measure actual usage for extended PV analysis",
+		"pod", path.Join(podRef.Namespace, podRef.Name),
+		"command", cmdString)
+
 	err := podCommand.Run()
 	if err != nil {
 		log.Error(err, "Failed running df command inside Restic Pod",
@@ -152,6 +156,14 @@ func (r *ResticDFCommandExecutor) Execute(pvcNodeMap map[string][]MigAnalyticPer
 			pvcDFInfo.Name = pvc.Name
 			pvcDFInfo.Namespace = pvc.Namespace
 			gatheredData = append(gatheredData, pvcDFInfo)
+			log.Info("Got DF command output from Restic Pod",
+				"persistentVolumeClaim", path.Join(pvc.Namespace, pvc.Name),
+				"resticPodUID", pvc.PodUID,
+				"pvcStorageClass", pvc.StorageClass,
+				"pvcRequestedCapacity", pvc.RequestedCapacity,
+				"pvcProvisionedCapacity", pvc.ProvisionedCapacity,
+				"usagePercentage", pvcDFInfo.UsagePercentage,
+				"totalSize", pvcDFInfo.TotalSize)
 		}
 	}
 	return gatheredData, nil


### PR DESCRIPTION
```
{"level":"info","ts":1618421992428,"logger":"analytics|jj5k5",
"msg":"Executing df command inside source cluster Restic Pod to measure actual usage for extended PV analysis",
"migAnalytic":"plan-pvc-bmark-78b7f",
"pod":"openshift-migration/restic-w9n4k",
"command":["/bin/bash","-c","df -BMB /host_pods/db48b9e6-9ca7-11eb-952a-163f1b255103/volumes/*/vol197 /host_pods/db48b9e6-9ca7-11eb-952a-163f1b255103/volumes/*/vol59 /host_pods/db48b9e6-9ca7-11eb-952a-163f1b255103/volumes/*/vol175"]}

{"level":"info","ts":1618421992611,
"logger":"analytics|jj5k5",
"msg":"Got DF command output from Restic Pod",
"migAnalytic":"plan-pvc-bmark-78b7f",
"persistentVolumeClaim":"pvc-migrate-bmark/pvc-0",
"resticPodUID":"db48b9e6-9ca7-11eb-952a163f1b255103",
"pvcStorageClass":null,
"pvcRequestedCapacity":"2Gi",
"pvcProvisionedCapacity":"10Gi",
"usagePercentage":8,"
totalSize":"211240M"}

[... more...]
```