### PR TITLE
Skip extra steps for "make test" target so it runs faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ci: all
 all: test manager
 
 # Run tests
-test: generate fmt vet manifests
+test:
 	go test -tags "${BUILDTAGS}" ./pkg/... ./cmd/... -coverprofile cover.out
 
 # Build manager binary

--- a/pkg/controller/discovery/container/hook.go
+++ b/pkg/controller/discovery/container/hook.go
@@ -1,0 +1,138 @@
+package container
+
+import (
+	"context"
+	"time"
+
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+//
+// A collection of k8s MigHook resources.
+type MigHook struct {
+	// Base
+	BaseCollection
+}
+
+func (r *MigHook) AddWatch(dsController controller.Controller) error {
+	err := dsController.Watch(
+		&source.Kind{
+			Type: &migapi.MigHook{},
+		},
+		&handler.EnqueueRequestForObject{},
+		r)
+	if err != nil {
+		Log.Trace(err)
+		return err
+	}
+
+	return nil
+}
+
+func (r *MigHook) Reconcile() error {
+	mark := time.Now()
+	sr := SimpleReconciler{
+		Db: r.ds.Container.Db,
+	}
+	err := sr.Reconcile(r)
+	if err != nil {
+		Log.Trace(err)
+		return err
+	}
+	r.hasReconciled = true
+	Log.Info(
+		"MigHook (collection) reconciled.",
+		"ns",
+		r.ds.Cluster.Namespace,
+		"name",
+		r.ds.Cluster.Name,
+		"duration",
+		time.Since(mark))
+
+	return nil
+}
+
+func (r *MigHook) GetDiscovered() ([]model.Model, error) {
+	models := []model.Model{}
+	onCluster := migapi.MigHookList{}
+	err := r.ds.Client.List(context.TODO(), nil, &onCluster)
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	for _, discovered := range onCluster.Items {
+		dim := &model.Hook{}
+		dim.With(&discovered)
+		models = append(models, dim)
+	}
+
+	return models, nil
+}
+
+func (r *MigHook) GetStored() ([]model.Model, error) {
+	models := []model.Model{}
+	list, err := model.Hook{}.List(
+		r.ds.Container.Db,
+		model.ListOptions{})
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	for _, dim := range list {
+		models = append(models, dim)
+	}
+
+	return models, nil
+}
+
+//
+// Predicate methods.
+//
+
+func (r *MigHook) Create(e event.CreateEvent) bool {
+	Log.Reset()
+	object, cast := e.Object.(*migapi.MigHook)
+	if !cast {
+		return false
+	}
+	dim := model.Hook{}
+	dim.With(object)
+	r.ds.Create(&dim)
+
+	return false
+}
+
+func (r *MigHook) Update(e event.UpdateEvent) bool {
+	Log.Reset()
+	object, cast := e.ObjectNew.(*migapi.MigHook)
+	if !cast {
+		return false
+	}
+	restore := model.Hook{}
+	restore.With(object)
+	r.ds.Update(&restore)
+
+	return false
+}
+
+func (r *MigHook) Delete(e event.DeleteEvent) bool {
+	Log.Reset()
+	object, cast := e.Object.(*migapi.MigHook)
+	if !cast {
+		return false
+	}
+	dim := model.Hook{}
+	dim.With(object)
+	r.ds.Delete(&dim)
+
+	return false
+}
+
+func (r *MigHook) Generic(e event.GenericEvent) bool {
+	return false
+}

--- a/pkg/controller/discovery/controller.go
+++ b/pkg/controller/discovery/controller.go
@@ -162,6 +162,7 @@ func (r *ReconcileDiscovery) Reconcile(request reconcile.Request) (reconcile.Res
 		&container.DirectImageMigration{},
 		&container.DirectVolumeMigrationProgress{},
 		&container.DirectImageStreamMigration{},
+		&container.MigHook{},
 		&container.PodVolumeBackup{},
 		&container.PodVolumeRestore{},
 		&container.Namespace{},

--- a/pkg/controller/discovery/model/hook.go
+++ b/pkg/controller/discovery/model/hook.go
@@ -1,0 +1,87 @@
+package model
+
+import (
+	"encoding/json"
+
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+)
+
+//
+// Hook model.
+type Hook struct {
+	CR
+}
+
+//
+// Update the model `with` a Hook.
+func (m *Hook) With(object *migapi.MigHook) {
+	m.UID = string(object.UID)
+	m.Version = object.ResourceVersion
+	m.Namespace = object.Namespace
+	m.Name = object.Name
+	m.EncodeObject(object)
+}
+
+//
+// Encode the object.
+func (m *Hook) EncodeObject(dim *migapi.MigHook) {
+	object, _ := json.Marshal(dim)
+	m.Object = string(object)
+}
+
+//
+// Decode the object.
+func (m *Hook) DecodeObject() *migapi.MigHook {
+	dim := &migapi.MigHook{}
+	json.Unmarshal([]byte(m.Object), dim)
+	return dim
+}
+
+//
+// Count in the DB.
+func (m Hook) Count(db DB, options ListOptions) (int64, error) {
+	return Table{db}.Count(&m, options)
+}
+
+//
+// Fetch the model from the DB.
+func (m Hook) List(db DB, options ListOptions) ([]*Hook, error) {
+	list := []*Hook{}
+	listed, err := Table{db}.List(&m, options)
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	for _, intPtr := range listed {
+		list = append(list, intPtr.(*Hook))
+	}
+
+	return list, err
+}
+
+//
+// Fetch the model from the DB.
+func (m *Hook) Get(db DB) error {
+	return Table{db}.Get(m)
+}
+
+//
+// Insert the model into the DB.
+func (m *Hook) Insert(db DB) error {
+	m.SetPk()
+	return Table{db}.Insert(m)
+}
+
+//
+// Update the model in the DB.
+func (m *Hook) Update(db DB) error {
+	m.SetPk()
+	return Table{db}.Update(m)
+}
+
+//
+// Delete the model in the DB.
+func (m *Hook) Delete(db DB) error {
+	m.SetPk()
+	return Table{db}.Delete(m)
+}

--- a/pkg/controller/discovery/model/model.go
+++ b/pkg/controller/discovery/model/model.go
@@ -54,6 +54,7 @@ func Create() (*sql.DB, error) {
 		&DirectImageMigration{},
 		&DirectVolumeMigrationProgress{},
 		&DirectImageStreamMigration{},
+		&Hook{},
 		&Backup{},
 		&Restore{},
 		&PodVolumeBackup{},

--- a/pkg/controller/discovery/web/hook.go
+++ b/pkg/controller/discovery/web/hook.go
@@ -1,0 +1,187 @@
+package web
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
+	auth "k8s.io/api/authorization/v1"
+)
+
+const (
+	HookParam = "hook"
+	HooksRoot = Root + "/hooks"
+	HookRoot  = HooksRoot + "/:" + HookParam
+)
+
+// Hook (route) handler.
+type HookHandler struct {
+	// Base
+	BaseHandler
+	// Hook referenced in the request.
+	hook model.Hook
+}
+
+//
+// Add DIM routes.
+func (h HookHandler) AddRoutes(r *gin.Engine) {
+	r.GET(HooksRoot, h.List)
+	r.GET(HooksRoot+"/", h.List)
+	r.GET(HookRoot, h.Get)
+}
+
+//
+// Prepare to fulfil the request.
+// Fetch the referenced hook.
+// Perform SAR authorization.
+func (h *HookHandler) Prepare(ctx *gin.Context) int {
+	status := h.BaseHandler.Prepare(ctx)
+	if status != http.StatusOK {
+		return status
+	}
+	name := ctx.Param(HookParam)
+	if name != "" {
+		h.hook = model.Hook{
+			CR: model.CR{
+				Namespace: ctx.Param(NsParam),
+				Name:      ctx.Param(HookParam),
+			},
+		}
+		err := h.hook.Get(h.container.Db)
+		if err != nil {
+			if err != sql.ErrNoRows {
+				Log.Trace(err)
+				return http.StatusInternalServerError
+			} else {
+				return http.StatusNotFound
+			}
+		}
+	}
+	status = h.allow(h.getSAR())
+	if status != http.StatusOK {
+		return status
+	}
+
+	return http.StatusOK
+}
+
+// Build the appropriate SAR object.
+// The subject is the Hook.
+func (h *HookHandler) getSAR() auth.SelfSubjectAccessReview {
+	return auth.SelfSubjectAccessReview{
+		Spec: auth.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &auth.ResourceAttributes{
+				Group:     "apps",
+				Resource:  "Hook",
+				Namespace: h.hook.Namespace,
+				Name:      h.hook.Name,
+				Verb:      "get",
+			},
+		},
+	}
+}
+
+//
+// List all of the dims in the namespace.
+func (h HookHandler) List(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	db := h.container.Db
+	collection := model.Hook{}
+	count, err := collection.Count(db, model.ListOptions{})
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	list, err := collection.List(db, model.ListOptions{})
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	content := HookList{
+		Count: count,
+	}
+	for _, m := range list {
+		r := Hook{}
+		r.With(m)
+		r.SelfLink = h.Link(m)
+		content.Items = append(content.Items, r)
+	}
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Get a specific dim.
+func (h HookHandler) Get(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	err := h.hook.Get(h.container.Db)
+	if err != nil {
+		if err != sql.ErrNoRows {
+			Log.Trace(err)
+			ctx.Status(http.StatusInternalServerError)
+			return
+		} else {
+			ctx.Status(http.StatusNotFound)
+			return
+		}
+	}
+	r := Hook{}
+	r.With(&h.hook)
+	r.SelfLink = h.Link(&h.hook)
+	content := r
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Build self link.
+func (h HookHandler) Link(m *model.Hook) string {
+	return h.BaseHandler.Link(
+		HookRoot,
+		Params{
+			NsParam:   m.Namespace,
+			HookParam: m.Name,
+		})
+}
+
+//
+// Hook REST resource.
+type Hook struct {
+	// The k8s namespace.
+	Namespace string `json:"namespace,omitempty"`
+	// The k8s name.
+	Name string `json:"name"`
+	// Self URI.
+	SelfLink string `json:"selfLink"`
+	// Raw k8s object.
+	Object *migapi.MigHook `json:"object,omitempty"`
+}
+
+//
+// Build the resource.
+func (r *Hook) With(m *model.Hook) {
+	r.Namespace = m.Namespace
+	r.Name = m.Name
+	r.Object = m.DecodeObject()
+}
+
+//
+// Hook collection REST resource.
+type HookList struct {
+	// Total number in the collection.
+	Count int64 `json:"count"`
+	// List of resources.
+	Items []Hook `json:"resources"`
+}

--- a/pkg/controller/discovery/web/plan.go
+++ b/pkg/controller/discovery/web/plan.go
@@ -355,6 +355,11 @@ func (t *PlanTree) addMigrations(parent *TreeNode) error {
 			Log.Trace(err)
 			return err
 		}
+		err = t.addHooks(m, &node)
+		if err != nil {
+			Log.Trace(err)
+			return err
+		}
 		parent.Children = append(parent.Children, node)
 	}
 
@@ -476,6 +481,81 @@ func (t *PlanTree) addDirectVolumes(migration *model.Migration, parent *TreeNode
 			Name:       m.Name,
 		}
 		err := t.addDirectVolumeProgresses(m, &node)
+		if err != nil {
+			Log.Trace(err)
+			return err
+		}
+		parent.Children = append(parent.Children, node)
+	}
+
+	return nil
+}
+
+//
+// Add mighooks
+func (t *PlanTree) addHooks(migration *model.Migration, parent *TreeNode) error {
+	migrationObject := migration.DecodeObject()
+	// Skip adding hooks if this is a stage migration
+	if migrationObject.Spec.Stage == true {
+		return nil
+	}
+	// Decode plan to look at attached hooks
+	planObject := t.plan.DecodeObject()
+
+	collection := model.Hook{}
+	list, err := collection.List(t.db, model.ListOptions{})
+	if err != nil {
+		Log.Trace(err)
+		return err
+	}
+	for _, m := range list {
+		object := m.DecodeObject()
+
+		for _, hookRef := range planObject.Spec.Hooks {
+			if hookRef.Reference == nil {
+				continue
+			}
+			if object.Name == hookRef.Reference.Name && object.Namespace == hookRef.Reference.Namespace {
+				node := TreeNode{
+					Kind:       migref.ToKind(m),
+					ObjectLink: HookHandler{}.Link(m),
+					Namespace:  m.Namespace,
+					Name:       m.Name,
+				}
+				// err := t.addHookJobs(m, &node)
+				// if err != nil {
+				// 	Log.Trace(err)
+				// 	return err
+				// }
+				parent.Children = append(parent.Children, node)
+				continue
+			}
+		}
+	}
+	return nil
+}
+
+//
+// Add jobs associated with hooks
+func (t *PlanTree) addHookJobs(hook *model.Hook, parent *TreeNode) error {
+	collection := model.DirectImageMigration{}
+	list, err := collection.List(t.db, model.ListOptions{})
+	if err != nil {
+		Log.Trace(err)
+		return err
+	}
+	for _, m := range list {
+		object := m.DecodeObject()
+		if object.Labels == nil {
+			continue
+		}
+		node := TreeNode{
+			Kind:       migref.ToKind(m),
+			ObjectLink: DirectImageMigrationHandler{}.Link(m),
+			Namespace:  m.Namespace,
+			Name:       m.Name,
+		}
+		err := t.addDirectImageStreams(m, &node)
 		if err != nil {
 			Log.Trace(err)
 			return err

--- a/pkg/controller/discovery/web/web.go
+++ b/pkg/controller/discovery/web/web.go
@@ -152,6 +152,11 @@ func (w *WebServer) addRoutes(r *gin.Engine) {
 				container: w.Container,
 			},
 		},
+		HookHandler{
+			BaseHandler: BaseHandler{
+				container: w.Container,
+			},
+		},
 		MigrationHandler{
 			BaseHandler: BaseHandler{
 				container: w.Container,


### PR DESCRIPTION
It seems to me that having `make test` be slowed down by also running `generate fmt vet manifests` is going to make people (e.g. me) less likely to want to run tests. 

This just strips down the `make test` target.

Looking for feedback on if it's important for these extra targets to be bundled with `make test`. I may have a blindspot. I think this was the default behavior with kubebuilder code generation.