### PR TITLE
Combine Stunnel with Rsync

### DIFF
--- a/pkg/controller/directvolumemigration/descriptions.go
+++ b/pkg/controller/directvolumemigration/descriptions.go
@@ -33,8 +33,6 @@ var phaseDescriptions = map[string]string{
 	CreateRsyncTransferPods:              "Creating Rsync daemon pods on the target cluster",
 	WaitForRsyncTransferPodsRunning:      "Waiting for the Rsync daemon pod to run",
 	EnsureRsyncRouteAdmitted:             "Waiting for Rsync route to be admitted.",
-	CreateStunnelClientPods:              "Creating Stunnel client pods on the source cluster",
-	WaitForStunnelClientPodsRunning:      "Waiting for the Stunnel client pods to run",
 	CreateRsyncClientPods:                "Creating Rsync client pods",
 	WaitForRsyncClientPodsCompleted:      "Waiting for the Rsync client pods to be completed",
 	DeleteRsyncResources:                 "Deleting Rsync resources created by this migration",

--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -1730,7 +1730,7 @@ func (req rsyncClientPodRequirements) getRsyncClientPodTemplate() corev1.Pod {
 	rsyncCommand = append(rsyncCommand, fmt.Sprintf("rsync://root@%s/%s", req.destIP, req.pvInfo.name))
 
 	rsyncCommandStr := strings.Join(rsyncCommand, " ")
-	rsyncCommandBashScript := fmt.Sprintf("trap \"touch /usr/share/rsync-stunnel-mgmt/rsync-client-container-done\" exit $rc; timeout=600; SECONDS=0; while [ $SECONDS -lt $timeout ]; do nc -z localhost 2222; if [ $? -eq 0 ]; then %s; rc=$?; break; fi; done;", rsyncCommandStr)
+	rsyncCommandBashScript := fmt.Sprintf("trap \"touch /usr/share/rsync-stunnel-mgmt/rsync-client-container-done\" EXIT SIGINT SIGTERM; timeout=600; SECONDS=0; while [ $SECONDS -lt $timeout ]; do nc -z localhost 2222; rc=$?; if [ $rc -eq 0 ]; then %s; rc=$?; break; fi; done; exit $rc;", rsyncCommandStr)
 	rsyncContainerCommand := []string{
 		"/bin/bash",
 		"-c",

--- a/pkg/controller/directvolumemigration/rsync_test.go
+++ b/pkg/controller/directvolumemigration/rsync_test.go
@@ -74,7 +74,7 @@ func getRsyncClientPodRequirements(pvcName string, ns string) rsyncClientPodRequ
 		image:      "quay.io/konveyor/rsync-transfer:latest",
 		password:   "verySecurePassword",
 		privileged: false,
-		resourceReq: corev1.ResourceRequirements{
+		rsyncResourceReq: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1"),
 				corev1.ResourceMemory: resource.MustParse("1Gi"),

--- a/pkg/controller/directvolumemigration/stunnel.go
+++ b/pkg/controller/directvolumemigration/stunnel.go
@@ -60,7 +60,7 @@ data:
     syslog = no
     output = /dev/stdout
     [rsync]
-    accept = localhost:2222
+    accept = localhost:{{ .StunnelPort }}
     CAFile = /etc/stunnel/certs/ca.crt
     cert = /etc/stunnel/certs/tls.crt
 {{ if not (eq .ProxyHost "") }}

--- a/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller.go
+++ b/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller.go
@@ -200,10 +200,8 @@ func (r *RsyncPodProgressTask) Run() error {
 		if err != nil {
 			return liberr.Wrap(err)
 		}
-		rsyncPodStatus, err := r.getRsyncClientContainerStatus(pod, r)
-		if err != nil {
-			return liberr.Wrap(err)
-		}
+		rsyncPodStatus := r.getRsyncClientContainerStatus(pod, r)
+
 		if rsyncPodStatus != nil {
 			pvProgress.Status.RsyncPodStatus = *rsyncPodStatus
 		}
@@ -341,7 +339,7 @@ func (r *RsyncPodProgressTask) updateCumulativeElapsedTime() {
 
 // getRsyncClientContainerStatus returns observed status of Rsync container in the given pod
 // podLogGetterFunction is a function capable of retrieving logs from a given pod, injected to make testing easier
-func (r *RsyncPodProgressTask) getRsyncClientContainerStatus(podRef *kapi.Pod) *migapi.RsyncPodStatus {
+func (r *RsyncPodProgressTask) getRsyncClientContainerStatus(podRef *kapi.Pod, p GetPodLogger) *migapi.RsyncPodStatus {
 	rsyncPodStatus := migapi.RsyncPodStatus{
 		PodName:           podRef.Name,
 		CreationTimestamp: &podRef.CreationTimestamp,

--- a/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller.go
+++ b/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller.go
@@ -347,7 +347,8 @@ func (r *RsyncPodProgressTask) getRsyncClientContainerStatus(podRef *kapi.Pod, p
 		LogMessage:        podRef.Status.Message,
 	}
 	var containerStatus *kapi.ContainerStatus
-	for _, c := range podRef.Status.ContainerStatuses {
+	for i := range podRef.Status.ContainerStatuses {
+		c := podRef.Status.ContainerStatuses[i]
 		if c.Name == RsyncContainerName {
 			containerStatus = &c
 		}

--- a/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller_test.go
+++ b/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller_test.go
@@ -371,7 +371,6 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 		fields  fields
 		args    args
 		want    *migapi.RsyncPodStatus
-		wantErr bool
 	}{
 		{
 			name: "Given a ready and running Pod.",
@@ -452,7 +451,6 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 				LastObservedTransferRate:    "66.13MB/s",
 				ExitCode:                    nil,
 			},
-			wantErr: false,
 		},
 		{
 			name: "Given a non ready Pod but rsync container is terminated successfully.",
@@ -535,7 +533,6 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 				LastObservedTransferRate:    "",
 				ExitCode:                    &zero,
 			},
-			wantErr: false,
 		},
 		{
 			name: "Given a succeeded Pod.",
@@ -621,7 +618,6 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 				LastObservedTransferRate:    "",
 				ExitCode:                    &zero,
 			},
-			wantErr: false,
 		},
 		{
 			name: "Given a failed reference Pod.",
@@ -704,7 +700,6 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 				LastObservedTransferRate:    "",
 				ExitCode:                    &one,
 			},
-			wantErr: false,
 		},
 		{
 			name: "Given a non ready and failed rsync container.",
@@ -788,7 +783,6 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 				LastObservedTransferRate:    "",
 				ExitCode:                    &one,
 			},
-			wantErr: false,
 		},
 		{
 			name: "Given a non ready rsync container and refPod in pending state.",
@@ -871,7 +865,6 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 				LastObservedTransferRate:    "",
 				ExitCode:                    nil,
 			},
-			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -882,11 +875,7 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 				SrcClient: tt.fields.SrcClient,
 				Owner:     tt.fields.Owner,
 			}
-			got, err := r.getRsyncClientContainerStatus(tt.args.podRef, tt.args.p)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("getRsyncClientContainerStatus() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			got := r.getRsyncClientContainerStatus(tt.args.podRef, tt.args.p)
 			if !isRsyncStatusEqual(got, tt.want) {
 				t.Errorf("getRsyncClientContainerStatus() got = %v, want %v", got, tt.want)
 			}

--- a/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller_test.go
+++ b/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller_test.go
@@ -374,7 +374,7 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Given a ready and running Pod, appropriate container status is returned",
+			name: "Given a ready and running Pod.",
 			fields: fields{
 				Client:    fake.NewFakeClient(),
 				SrcClient: fakecompat.NewFakeClient(),
@@ -455,7 +455,7 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Given a non ready Pod but rsync container is terminated successfully, appropriate container status is returned",
+			name: "Given a non ready Pod but rsync container is terminated successfully.",
 			fields: fields{
 				Client:    fake.NewFakeClient(),
 				SrcClient: fakecompat.NewFakeClient(),
@@ -538,7 +538,7 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Given a succeeded Pod, appropriate container status is returned",
+			name: "Given a succeeded Pod.",
 			fields: fields{
 				Client:    fake.NewFakeClient(),
 				SrcClient: fakecompat.NewFakeClient(),
@@ -585,10 +585,12 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 						Phase: kapi.PodSucceeded,
 						ContainerStatuses: []kapi.ContainerStatus{
 							{
-								Name: "stunnel",
-								State: kapi.ContainerState{
-									Running: &kapi.ContainerStateRunning{
-										StartedAt: metav1.Time{},
+								Name:  "stunnel",
+								Ready: false,
+								LastTerminationState: kapi.ContainerState{
+									Terminated: &kapi.ContainerStateTerminated{
+										FinishedAt: metav1.Time{},
+										ExitCode:   0,
 									},
 								},
 							},
@@ -622,7 +624,7 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Given a failed reference Pod, appropriate container status is returned",
+			name: "Given a failed reference Pod.",
 			fields: fields{
 				Client:    fake.NewFakeClient(),
 				SrcClient: fakecompat.NewFakeClient(),
@@ -705,7 +707,7 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Given a non ready and failed rsync container, appropriate container status is returned",
+			name: "Given a non ready and failed rsync container.",
 			fields: fields{
 				Client:    fake.NewFakeClient(),
 				SrcClient: fakecompat.NewFakeClient(),
@@ -751,10 +753,12 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 					Status: kapi.PodStatus{
 						ContainerStatuses: []kapi.ContainerStatus{
 							{
-								Name: "stunnel",
-								State: kapi.ContainerState{
-									Running: &kapi.ContainerStateRunning{
-										StartedAt: metav1.Time{},
+								Name:  "stunnel",
+								Ready: false,
+								LastTerminationState: kapi.ContainerState{
+									Terminated: &kapi.ContainerStateTerminated{
+										FinishedAt: metav1.Time{},
+										ExitCode:   1,
 									},
 								},
 							},
@@ -787,7 +791,7 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Given a non ready rsync container and refPod in pending state, appropriate container status is returned",
+			name: "Given a non ready rsync container and refPod in pending state.",
 			fields: fields{
 				Client:    fake.NewFakeClient(),
 				SrcClient: fakecompat.NewFakeClient(),
@@ -834,10 +838,11 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 						Phase: kapi.PodPending,
 						ContainerStatuses: []kapi.ContainerStatus{
 							{
-								Name: "stunnel",
+								Name:  "stunnel",
+								Ready: false,
 								State: kapi.ContainerState{
-									Running: &kapi.ContainerStateRunning{
-										StartedAt: metav1.Time{},
+									Waiting: &kapi.ContainerStateWaiting{
+										Reason: ContainerCreating,
 									},
 								},
 							},

--- a/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller_test.go
+++ b/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller_test.go
@@ -19,8 +19,12 @@ package directvolumemigrationprogress
 import (
 	"bytes"
 	"context"
+	"github.com/konveyor/mig-controller/pkg/compat"
+	fakecompat "github.com/konveyor/mig-controller/pkg/compat/fake"
 	"io"
+	kapi "k8s.io/api/core/v1"
 	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"strings"
 	"testing"
 	"time"
@@ -335,4 +339,566 @@ func Test_getLastMatch(t *testing.T) {
 			}
 		})
 	}
+}
+
+type fakeGetPodLogs struct {
+	podLogMessage string
+	err           error
+}
+
+func (f fakeGetPodLogs) getPodLogs(pod *kapi.Pod, containerName string, tailLines *int64, previous bool) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.podLogMessage, nil
+}
+
+func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
+	zero := int32(0)
+	one := int32(1)
+	type fields struct {
+		Cluster   *migapi.MigCluster
+		Client    client.Client
+		SrcClient compat.Client
+		Owner     *migapi.DirectVolumeMigrationProgress
+	}
+	type args struct {
+		podRef *kapi.Pod
+		p      GetPodLogger
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *migapi.RsyncPodStatus
+		wantErr bool
+	}{
+		{
+			name: "Given a ready and running Pod, appropriate container status is returned",
+			fields: fields{
+				Client:    fake.NewFakeClient(),
+				SrcClient: fakecompat.NewFakeClient(),
+				Cluster: &migapi.MigCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "migcluster-host",
+						Namespace: "openshift-migration",
+					},
+					Spec: migapi.MigClusterSpec{
+						IsHostCluster: false,
+						Insecure:      true,
+					},
+					Status: migapi.MigClusterStatus{
+						Conditions: migapi.Conditions{
+							List: []migapi.Condition{
+								{
+									Type:     "Ready",
+									Status:   "True",
+									Category: "Required",
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				podRef: &kapi.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "dvm-rsync",
+						Namespace:         "test-app-1",
+						CreationTimestamp: metav1.Time{},
+					},
+					Spec: kapi.PodSpec{
+						Containers: []kapi.Container{
+							{
+								Name: "stunnel",
+							},
+							{
+								Name: "rsync-client",
+							},
+						},
+					},
+					Status: kapi.PodStatus{
+						ContainerStatuses: []kapi.ContainerStatus{
+							{
+								Name: "stunnel",
+								State: kapi.ContainerState{
+									Running: &kapi.ContainerStateRunning{
+										StartedAt: metav1.Time{},
+									},
+								},
+							},
+							{
+								Name:  "rsync-client",
+								Ready: true,
+								State: kapi.ContainerState{
+									Running: &kapi.ContainerStateRunning{
+										StartedAt: metav1.Time{},
+									},
+								},
+							},
+						},
+					},
+				},
+				p: fakeGetPodLogs{
+					podLogMessage: "\"2021/04/23 16:16:14 [169] cd+++++++++ diagnostic.data/\\n427.68K   0%   11.02MB/s    0:00:00 (xfr#24, to-chk=4/31)202\\n452.92K   0%   10.80MB/s    0:00:00 (xfr#25, to-chk=3/31)202\\n2021/04/23 16:16:14 [169] cd+++++++++ journal/\\n69.69M  22%   66.13MB/s    0:00:03  \\r        105.31M  33%   \"",
+					err:           nil,
+				},
+			},
+			want: &migapi.RsyncPodStatus{
+				PodName:                     "dvm-rsync",
+				PodPhase:                    kapi.PodRunning,
+				LogMessage:                  "\"2021/04/23 16:16:14 [169] cd+++++++++ diagnostic.data/\\n427.68K   0%   11.02MB/s    0:00:00 (xfr#24, to-chk=4/31)202\\n452.92K   0%   10.80MB/s    0:00:00 (xfr#25, to-chk=3/31)202\\n2021/04/23 16:16:14 [169] cd+++++++++ journal/\\n69.69M  22%   66.13MB/s    0:00:03  \\r        105.31M  33%   \"",
+				LastObservedProgressPercent: "33%",
+				LastObservedTransferRate:    "66.13MB/s",
+				ExitCode:                    nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Given a non ready Pod but rsync container is terminated successfully, appropriate container status is returned",
+			fields: fields{
+				Client:    fake.NewFakeClient(),
+				SrcClient: fakecompat.NewFakeClient(),
+				Cluster: &migapi.MigCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "migcluster-host",
+						Namespace: "openshift-migration",
+					},
+					Spec: migapi.MigClusterSpec{
+						IsHostCluster: false,
+						Insecure:      true,
+					},
+					Status: migapi.MigClusterStatus{
+						Conditions: migapi.Conditions{
+							List: []migapi.Condition{
+								{
+									Type:     "Ready",
+									Status:   "True",
+									Category: "Required",
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				podRef: &kapi.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "dvm-rsync",
+						Namespace:         "test-app-1",
+						CreationTimestamp: metav1.Time{},
+					},
+					Spec: kapi.PodSpec{
+						Containers: []kapi.Container{
+							{
+								Name: "stunnel",
+							},
+							{
+								Name: "rsync-client",
+							},
+						},
+					},
+					Status: kapi.PodStatus{
+						ContainerStatuses: []kapi.ContainerStatus{
+							{
+								Name: "stunnel",
+								State: kapi.ContainerState{
+									Running: &kapi.ContainerStateRunning{
+										StartedAt: metav1.Time{},
+									},
+								},
+							},
+							{
+								Name:  "rsync-client",
+								Ready: false,
+								LastTerminationState: kapi.ContainerState{
+									Terminated: &kapi.ContainerStateTerminated{
+										FinishedAt: metav1.Time{},
+										ExitCode:   0,
+									},
+								},
+							},
+						},
+					},
+				},
+				p: fakeGetPodLogs{
+					podLogMessage: "",
+					err:           nil,
+				},
+			},
+			want: &migapi.RsyncPodStatus{
+				PodName:                     "dvm-rsync",
+				PodPhase:                    kapi.PodSucceeded,
+				LogMessage:                  "",
+				CreationTimestamp:           &metav1.Time{},
+				LastObservedProgressPercent: "100%",
+				LastObservedTransferRate:    "",
+				ExitCode:                    &zero,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Given a succeeded Pod, appropriate container status is returned",
+			fields: fields{
+				Client:    fake.NewFakeClient(),
+				SrcClient: fakecompat.NewFakeClient(),
+				Cluster: &migapi.MigCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "migcluster-host",
+						Namespace: "openshift-migration",
+					},
+					Spec: migapi.MigClusterSpec{
+						IsHostCluster: false,
+						Insecure:      true,
+					},
+					Status: migapi.MigClusterStatus{
+						Conditions: migapi.Conditions{
+							List: []migapi.Condition{
+								{
+									Type:     "Ready",
+									Status:   "True",
+									Category: "Required",
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				podRef: &kapi.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "dvm-rsync",
+						Namespace:         "test-app-1",
+						CreationTimestamp: metav1.Time{},
+					},
+					Spec: kapi.PodSpec{
+						Containers: []kapi.Container{
+							{
+								Name: "stunnel",
+							},
+							{
+								Name: "rsync-client",
+							},
+						},
+					},
+					Status: kapi.PodStatus{
+						Phase: kapi.PodSucceeded,
+						ContainerStatuses: []kapi.ContainerStatus{
+							{
+								Name: "stunnel",
+								State: kapi.ContainerState{
+									Running: &kapi.ContainerStateRunning{
+										StartedAt: metav1.Time{},
+									},
+								},
+							},
+							{
+								Name:  "rsync-client",
+								Ready: false,
+								LastTerminationState: kapi.ContainerState{
+									Terminated: &kapi.ContainerStateTerminated{
+										FinishedAt: metav1.Time{},
+										ExitCode:   0,
+									},
+								},
+							},
+						},
+					},
+				},
+				p: fakeGetPodLogs{
+					podLogMessage: "",
+					err:           nil,
+				},
+			},
+			want: &migapi.RsyncPodStatus{
+				PodName:                     "dvm-rsync",
+				PodPhase:                    kapi.PodSucceeded,
+				LogMessage:                  "",
+				CreationTimestamp:           &metav1.Time{},
+				LastObservedProgressPercent: "100%",
+				LastObservedTransferRate:    "",
+				ExitCode:                    &zero,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Given a failed reference Pod, appropriate container status is returned",
+			fields: fields{
+				Client:    fake.NewFakeClient(),
+				SrcClient: fakecompat.NewFakeClient(),
+				Cluster: &migapi.MigCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "migcluster-host",
+						Namespace: "openshift-migration",
+					},
+					Spec: migapi.MigClusterSpec{
+						IsHostCluster: false,
+						Insecure:      true,
+					},
+					Status: migapi.MigClusterStatus{
+						Conditions: migapi.Conditions{
+							List: []migapi.Condition{
+								{
+									Type:     "Ready",
+									Status:   "True",
+									Category: "Required",
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				podRef: &kapi.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "dvm-rsync",
+						Namespace:         "test-app-1",
+						CreationTimestamp: metav1.Time{},
+					},
+					Spec: kapi.PodSpec{
+						Containers: []kapi.Container{
+							{
+								Name: "stunnel",
+							},
+							{
+								Name: "rsync-client",
+							},
+						},
+					},
+					Status: kapi.PodStatus{
+						Phase: kapi.PodFailed,
+						ContainerStatuses: []kapi.ContainerStatus{
+							{
+								Name: "stunnel",
+								State: kapi.ContainerState{
+									Running: &kapi.ContainerStateRunning{
+										StartedAt: metav1.Time{},
+									},
+								},
+							},
+							{
+								Name:  "rsync-client",
+								Ready: false,
+								LastTerminationState: kapi.ContainerState{
+									Terminated: &kapi.ContainerStateTerminated{
+										FinishedAt: metav1.Time{},
+										ExitCode:   1,
+									},
+								},
+							},
+						},
+					},
+				},
+				p: fakeGetPodLogs{
+					podLogMessage: "",
+					err:           nil,
+				},
+			},
+			want: &migapi.RsyncPodStatus{
+				PodName:                     "dvm-rsync",
+				PodPhase:                    kapi.PodFailed,
+				LogMessage:                  "",
+				LastObservedProgressPercent: "",
+				LastObservedTransferRate:    "",
+				ExitCode:                    &one,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Given a non ready and failed rsync container, appropriate container status is returned",
+			fields: fields{
+				Client:    fake.NewFakeClient(),
+				SrcClient: fakecompat.NewFakeClient(),
+				Cluster: &migapi.MigCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "migcluster-host",
+						Namespace: "openshift-migration",
+					},
+					Spec: migapi.MigClusterSpec{
+						IsHostCluster: false,
+						Insecure:      true,
+					},
+					Status: migapi.MigClusterStatus{
+						Conditions: migapi.Conditions{
+							List: []migapi.Condition{
+								{
+									Type:     "Ready",
+									Status:   "True",
+									Category: "Required",
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				podRef: &kapi.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "dvm-rsync",
+						Namespace:         "test-app-1",
+						CreationTimestamp: metav1.Time{},
+					},
+					Spec: kapi.PodSpec{
+						Containers: []kapi.Container{
+							{
+								Name: "stunnel",
+							},
+							{
+								Name: "rsync-client",
+							},
+						},
+					},
+					Status: kapi.PodStatus{
+						ContainerStatuses: []kapi.ContainerStatus{
+							{
+								Name: "stunnel",
+								State: kapi.ContainerState{
+									Running: &kapi.ContainerStateRunning{
+										StartedAt: metav1.Time{},
+									},
+								},
+							},
+							{
+								Name:  "rsync-client",
+								Ready: false,
+								LastTerminationState: kapi.ContainerState{
+									Terminated: &kapi.ContainerStateTerminated{
+										FinishedAt: metav1.Time{},
+										ExitCode:   1,
+									},
+								},
+							},
+						},
+					},
+				},
+				p: fakeGetPodLogs{
+					podLogMessage: "",
+					err:           nil,
+				},
+			},
+			want: &migapi.RsyncPodStatus{
+				PodName:                     "dvm-rsync",
+				PodPhase:                    kapi.PodFailed,
+				LogMessage:                  "",
+				LastObservedProgressPercent: "",
+				LastObservedTransferRate:    "",
+				ExitCode:                    &one,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Given a non ready rsync container and refPod in pending state, appropriate container status is returned",
+			fields: fields{
+				Client:    fake.NewFakeClient(),
+				SrcClient: fakecompat.NewFakeClient(),
+				Cluster: &migapi.MigCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "migcluster-host",
+						Namespace: "openshift-migration",
+					},
+					Spec: migapi.MigClusterSpec{
+						IsHostCluster: false,
+						Insecure:      true,
+					},
+					Status: migapi.MigClusterStatus{
+						Conditions: migapi.Conditions{
+							List: []migapi.Condition{
+								{
+									Type:     "Ready",
+									Status:   "True",
+									Category: "Required",
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				podRef: &kapi.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "dvm-rsync",
+						Namespace:         "test-app-1",
+						CreationTimestamp: metav1.Time{},
+					},
+					Spec: kapi.PodSpec{
+						Containers: []kapi.Container{
+							{
+								Name: "stunnel",
+							},
+							{
+								Name: "rsync-client",
+							},
+						},
+					},
+					Status: kapi.PodStatus{
+						Phase: kapi.PodPending,
+						ContainerStatuses: []kapi.ContainerStatus{
+							{
+								Name: "stunnel",
+								State: kapi.ContainerState{
+									Running: &kapi.ContainerStateRunning{
+										StartedAt: metav1.Time{},
+									},
+								},
+							},
+							{
+								Name:  "rsync-client",
+								Ready: false,
+								State: kapi.ContainerState{
+									Waiting: &kapi.ContainerStateWaiting{
+										Reason: ContainerCreating,
+									},
+								},
+							},
+						},
+					},
+				},
+				p: fakeGetPodLogs{
+					podLogMessage: "",
+					err:           nil,
+				},
+			},
+			want: &migapi.RsyncPodStatus{
+				PodName:                     "dvm-rsync",
+				PodPhase:                    kapi.PodPending,
+				LogMessage:                  "",
+				LastObservedProgressPercent: "",
+				LastObservedTransferRate:    "",
+				ExitCode:                    nil,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RsyncPodProgressTask{
+				Cluster:   tt.fields.Cluster,
+				Client:    tt.fields.Client,
+				SrcClient: tt.fields.SrcClient,
+				Owner:     tt.fields.Owner,
+			}
+			got, err := r.getRsyncClientContainerStatus(tt.args.podRef, tt.args.p)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getRsyncClientContainerStatus() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !isRsyncStatusEqual(got, tt.want) {
+				t.Errorf("getRsyncClientContainerStatus() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func isRsyncStatusEqual(r1 *migapi.RsyncPodStatus, r2 *migapi.RsyncPodStatus) bool {
+	if r1 == nil && r2 == nil {
+		return true
+	}
+	if r1 == nil || r2 == nil {
+		return false
+	}
+	if r1.PodName == r2.PodName && r1.PodPhase == r2.PodPhase && len(r1.LogMessage) == len(r2.LogMessage) && reflect.DeepEqual(r1.ExitCode, r2.ExitCode) &&
+		r1.LastObservedTransferRate == r2.LastObservedTransferRate && r1.LastObservedProgressPercent == r2.LastObservedProgressPercent {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
This PR does the following:
- Stunnel Configuration changes:
    - Removal of `foreground = yes` so that the stunnel process runs as daemon.
    - Addition of `output = /dev/stdout` for streaming of stunnel process logs as we are running the process in daemon mode.
    - Updating `accept = localhost:2222` in order to facilitate data transfer between rsync and stunnel over the lcoalhost interface.
- Transfer Image changes: These involve the addition of new packages/utilities used for embedding new workflow log in the container commands of rsync and stunnel.
- Accommodate Stunnel alongside Rsync in the `RunRsyncOperations` phase:
    - Modifying `getRsyncClientPodRequirements` to have destination IP for rsync process as `localhost`.
    - Modifying  `getRsyncClientPodTemplate` :
        - To add Stunnel Volumes consisting of stunnel configuration file, stunnel certs as well as the volume called `rsync-stunnel-ipc` (used for facilitating inter-process communication between rsync and stunnel).  
        - To add Stunnel VolumeMounts of stunnel certs, configs, `rsync-stunnel-ipc`. 
        - To add `rsync-stunnel-ipc` alongside the PV involved in the migration of the application.
        - To add bash scripts for rsync container command as well as the stunnel contaienr command.
        - To add stunnel container manifest consisting of all the above changes stunnel changes.

Enhancement doc reference: https://github.com/konveyor/enhancements/pull/18
Dependent PRs: https://github.com/konveyor/rsync-transfer/pull/4