### PR TITLE
Add events to discovery service, queryable by involvedObject UID

### DIFF
--- a/pkg/controller/discovery/container/event.go
+++ b/pkg/controller/discovery/container/event.go
@@ -1,0 +1,157 @@
+package container
+
+import (
+	"context"
+	"time"
+
+	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// A collection of k8s Event resources.
+type Event struct {
+	// Base
+	BaseCollection
+}
+
+func (r *Event) AddWatch(dsController controller.Controller) error {
+	err := dsController.Watch(
+		&source.Kind{
+			Type: &v1.Event{},
+		},
+		&handler.EnqueueRequestForObject{},
+		r)
+	if err != nil {
+		Log.Trace(err)
+		return err
+	}
+
+	return nil
+}
+
+func (r *Event) Reconcile() error {
+	mark := time.Now()
+	sr := SimpleReconciler{
+		Db: r.ds.Container.Db,
+	}
+	err := sr.Reconcile(r)
+	if err != nil {
+		Log.Trace(err)
+		return err
+	}
+	r.hasReconciled = true
+	Log.Info(
+		"Event (collection) reconciled.",
+		"ns",
+		r.ds.Cluster.Namespace,
+		"name",
+		r.ds.Cluster.Name,
+		"duration",
+		time.Since(mark))
+
+	return nil
+}
+
+func (r *Event) GetDiscovered() ([]model.Model, error) {
+	models := []model.Model{}
+	onCluster := v1.EventList{}
+	err := r.ds.Client.List(context.TODO(), nil, &onCluster)
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	for _, discovered := range onCluster.Items {
+		pvc := &model.Event{
+			Base: model.Base{
+				Cluster: r.ds.Cluster.PK,
+			},
+		}
+		pvc.With(&discovered)
+		models = append(models, pvc)
+	}
+
+	return models, nil
+}
+
+func (r *Event) GetStored() ([]model.Model, error) {
+	models := []model.Model{}
+	list, err := model.Event{
+		Base: model.Base{
+			Cluster: r.ds.Cluster.PK,
+		},
+	}.List(
+		r.ds.Container.Db,
+		model.ListOptions{})
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	for _, pvc := range list {
+		models = append(models, pvc)
+	}
+
+	return models, nil
+}
+
+//
+// Predicate methods.
+//
+
+func (r *Event) Create(e event.CreateEvent) bool {
+	Log.Reset()
+	object, cast := e.Object.(*v1.Event)
+	if !cast {
+		return false
+	}
+	pvc := model.Event{
+		Base: model.Base{
+			Cluster: r.ds.Cluster.PK,
+		},
+	}
+	pvc.With(object)
+	r.ds.Create(&pvc)
+
+	return false
+}
+
+func (r *Event) Update(e event.UpdateEvent) bool {
+	Log.Reset()
+	object, cast := e.ObjectNew.(*v1.Event)
+	if !cast {
+		return false
+	}
+	pvc := model.Event{
+		Base: model.Base{
+			Cluster: r.ds.Cluster.PK,
+		},
+	}
+	pvc.With(object)
+	r.ds.Update(&pvc)
+
+	return false
+}
+
+func (r *Event) Delete(e event.DeleteEvent) bool {
+	Log.Reset()
+	object, cast := e.Object.(*v1.Event)
+	if !cast {
+		return false
+	}
+	pvc := model.Event{
+		Base: model.Base{
+			Cluster: r.ds.Cluster.PK,
+		},
+	}
+	pvc.With(object)
+	r.ds.Delete(&pvc)
+
+	return false
+}
+
+func (r *Event) Generic(e event.GenericEvent) bool {
+	return false
+}

--- a/pkg/controller/discovery/controller.go
+++ b/pkg/controller/discovery/controller.go
@@ -171,6 +171,7 @@ func (r *ReconcileDiscovery) Reconcile(request reconcile.Request) (reconcile.Res
 		&container.PVC{},
 		&container.Pod{},
 		&container.Job{},
+		&container.Event{},
 		&container.PV{},
 		&container.StorageClass{},
 	)

--- a/pkg/controller/discovery/controller.go
+++ b/pkg/controller/discovery/controller.go
@@ -154,8 +154,7 @@ func (r *ReconcileDiscovery) Reconcile(request reconcile.Request) (reconcile.Res
 	if !r.IsValid(cluster) {
 		return reconcile.Result{Requeue: false}, nil
 	}
-	err = r.container.Add(
-		cluster,
+	containers := []container.Collection{
 		&container.Backup{},
 		&container.Restore{},
 		&container.DirectVolumeMigration{},
@@ -171,9 +170,15 @@ func (r *ReconcileDiscovery) Reconcile(request reconcile.Request) (reconcile.Res
 		&container.PVC{},
 		&container.Pod{},
 		&container.Job{},
-		&container.Event{},
 		&container.PV{},
 		&container.StorageClass{},
+	}
+	if Settings.Discovery.CollectEvents {
+		containers = append(containers, &container.Event{})
+	}
+	err = r.container.Add(
+		cluster,
+		containers...,
 	)
 	if err != nil {
 		log.Trace(err)

--- a/pkg/controller/discovery/model/event.go
+++ b/pkg/controller/discovery/model/event.go
@@ -3,7 +3,7 @@ package model
 import (
 	"encoding/json"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 //
@@ -14,7 +14,7 @@ type Event struct {
 
 //
 // Update the model `with` a k8s Event.
-func (m *Event) With(object *v1.Event) {
+func (m *Event) With(object *corev1.Event) {
 	m.UID = string(object.UID)
 	m.Version = object.ResourceVersion
 	m.Namespace = object.Namespace
@@ -30,15 +30,15 @@ func (m *Event) With(object *v1.Event) {
 
 //
 // Encode the object.
-func (m *Event) EncodeObject(event *v1.Event) {
+func (m *Event) EncodeObject(event *corev1.Event) {
 	object, _ := json.Marshal(event)
 	m.Object = string(object)
 }
 
 //
 // Encode the object.
-func (m *Event) DecodeObject() *v1.Event {
-	event := &v1.Event{}
+func (m *Event) DecodeObject() *corev1.Event {
+	event := &corev1.Event{}
 	json.Unmarshal([]byte(m.Object), event)
 	return event
 }

--- a/pkg/controller/discovery/model/event.go
+++ b/pkg/controller/discovery/model/event.go
@@ -1,0 +1,93 @@
+package model
+
+import (
+	"encoding/json"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+//
+// Event model.
+type Event struct {
+	Base
+}
+
+//
+// Update the model `with` a k8s Event.
+func (m *Event) With(object *v1.Event) {
+	m.UID = string(object.UID)
+	m.Version = object.ResourceVersion
+	m.Namespace = object.Namespace
+	m.Name = object.Name
+	m.labels = Labels{
+		"involvedObjectKind":      object.InvolvedObject.Kind,
+		"involvedObjectName":      object.InvolvedObject.Name,
+		"involvedObjectNamespace": object.InvolvedObject.Namespace,
+		"involvedObjectUID":       string(object.InvolvedObject.UID),
+	}
+	m.EncodeObject(object)
+}
+
+//
+// Encode the object.
+func (m *Event) EncodeObject(event *v1.Event) {
+	object, _ := json.Marshal(event)
+	m.Object = string(object)
+}
+
+//
+// Encode the object.
+func (m *Event) DecodeObject() *v1.Event {
+	event := &v1.Event{}
+	json.Unmarshal([]byte(m.Object), event)
+	return event
+}
+
+//
+// Count in the DB.
+func (m Event) Count(db DB, options ListOptions) (int64, error) {
+	return Table{db}.Count(&m, options)
+}
+
+//
+// Fetch the from in the DB.
+func (m Event) List(db DB, options ListOptions) ([]*Event, error) {
+	list := []*Event{}
+	listed, err := Table{db}.List(&m, options)
+	if err != nil {
+		Log.Trace(err)
+		return nil, err
+	}
+	for _, intPtr := range listed {
+		list = append(list, intPtr.(*Event))
+	}
+
+	return list, nil
+}
+
+//
+// Fetch the model from the DB.
+func (m *Event) Get(db DB) error {
+	return Table{db}.Get(m)
+}
+
+//
+// Insert the model into the DB.
+func (m *Event) Insert(db DB) error {
+	m.SetPk()
+	return Table{db}.Insert(m)
+}
+
+//
+// Update the model in the DB.
+func (m *Event) Update(db DB) error {
+	m.SetPk()
+	return Table{db}.Update(m)
+}
+
+//
+// Delete the model in the DB.
+func (m *Event) Delete(db DB) error {
+	m.SetPk()
+	return Table{db}.Delete(m)
+}

--- a/pkg/controller/discovery/model/model.go
+++ b/pkg/controller/discovery/model/model.go
@@ -66,6 +66,7 @@ func Create() (*sql.DB, error) {
 		&PV{},
 		&PVC{},
 		&Job{},
+		&Event{},
 		&StorageClass{},
 	}
 	for _, m := range models {

--- a/pkg/controller/discovery/web/event.go
+++ b/pkg/controller/discovery/web/event.go
@@ -86,7 +86,11 @@ func (h EventHandler) Get(ctx *gin.Context) {
 		ctx.Status(http.StatusInternalServerError)
 		return
 	}
-	list, err := collection.List(db, model.ListOptions{})
+	list, err := collection.List(db, model.ListOptions{
+		Labels: model.Labels{
+			"involvedObjectUID": ctx.Param(EventInvolvedUIDParam),
+		},
+	})
 	if err != nil {
 		Log.Trace(err)
 		ctx.Status(http.StatusInternalServerError)

--- a/pkg/controller/discovery/web/event.go
+++ b/pkg/controller/discovery/web/event.go
@@ -1,0 +1,149 @@
+package web
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	EventParam = "event"
+	EventsRoot = NamespaceRoot + "/events"
+	EventRoot  = EventsRoot + "/:" + EventParam
+)
+
+//
+// Event (route) handler.
+type EventHandler struct {
+	// Base
+	ClusterScoped
+}
+
+//
+// Add routes.
+func (h EventHandler) AddRoutes(r *gin.Engine) {
+	r.GET(EventsRoot, h.List)
+	r.GET(EventsRoot+"/", h.List)
+	r.GET(EventRoot, h.Get)
+}
+
+//
+// List all of the Events on a cluster.
+func (h EventHandler) List(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	db := h.container.Db
+	collection := model.Event{
+		Base: model.Base{
+			Cluster: h.cluster.PK,
+		},
+	}
+	count, err := collection.Count(db, model.ListOptions{})
+	if err != nil {
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	list, err := collection.List(
+		db,
+		model.ListOptions{
+			Page: &h.page,
+		})
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	content := EventList{
+		Count: count,
+	}
+	for _, m := range list {
+		r := Event{}
+		r.With(m)
+		r.SelfLink = h.Link(&h.cluster, m)
+		content.Items = append(content.Items, r)
+	}
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Get a specific Event on a cluster.
+func (h EventHandler) Get(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	m := model.Event{
+		Base: model.Base{
+			Cluster:   h.cluster.PK,
+			Namespace: ctx.Param(Ns2Param),
+			Name:      ctx.Param(EventParam),
+		},
+	}
+	err := m.Get(h.container.Db)
+	if err != nil {
+		if err != sql.ErrNoRows {
+			Log.Trace(err)
+			ctx.Status(http.StatusInternalServerError)
+			return
+		} else {
+			ctx.Status(http.StatusNotFound)
+			return
+		}
+	}
+	r := Event{}
+	r.With(&m)
+	r.SelfLink = h.Link(&h.cluster, &m)
+	content := r
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Build self link.
+func (h EventHandler) Link(c *model.Cluster, m *model.Event) string {
+	return h.BaseHandler.Link(
+		EventRoot,
+		Params{
+			NsParam:      c.Namespace,
+			ClusterParam: c.Name,
+			Ns2Param:     m.Namespace,
+			EventParam:   m.Name,
+		})
+}
+
+// Event REST resource
+type Event struct {
+	// The k8s namespace.
+	Namespace string `json:"namespace,omitempty"`
+	// The k8s name.
+	Name string `json:"name"`
+	// Self URI.
+	SelfLink string `json:"selfLink"`
+	// Raw k8s object.
+	Object *v1.Event `json:"object,omitempty"`
+}
+
+//
+// Build the resource.
+func (r *Event) With(m *model.Event) {
+	r.Namespace = m.Namespace
+	r.Name = m.Name
+	r.Object = m.DecodeObject()
+}
+
+//
+// Event collection REST resource.
+type EventList struct {
+	// Total number in the collection.
+	Count int64 `json:"count"`
+	// List of resources.
+	Items []Event `json:"resources"`
+}

--- a/pkg/controller/discovery/web/event.go
+++ b/pkg/controller/discovery/web/event.go
@@ -98,6 +98,7 @@ func (h EventHandler) Get(ctx *gin.Context) {
 	}
 	content := EventList{
 		Count: count,
+		UID:   ctx.Param(EventInvolvedUIDParam),
 	}
 	for _, m := range list {
 		r := Event{}
@@ -145,6 +146,8 @@ func (r *Event) With(m *model.Event) {
 type EventList struct {
 	// Total number in the collection.
 	Count int64 `json:"count"`
+	// UID of involvedObject events were retrieved for
+	UID string `json:"uid"`
 	// List of resources.
 	Items []Event `json:"resources"`
 }

--- a/pkg/controller/discovery/web/web.go
+++ b/pkg/controller/discovery/web/web.go
@@ -148,10 +148,8 @@ func (w *WebServer) addRoutes(r *gin.Engine) {
 			},
 		},
 		EventHandler{
-			ClusterScoped: ClusterScoped{
-				BaseHandler: BaseHandler{
-					container: w.Container,
-				},
+			BaseHandler: BaseHandler{
+				container: w.Container,
 			},
 		},
 		ServiceHandler{

--- a/pkg/controller/discovery/web/web.go
+++ b/pkg/controller/discovery/web/web.go
@@ -147,6 +147,13 @@ func (w *WebServer) addRoutes(r *gin.Engine) {
 				},
 			},
 		},
+		EventHandler{
+			ClusterScoped: ClusterScoped{
+				BaseHandler: BaseHandler{
+					container: w.Container,
+				},
+			},
+		},
 		ServiceHandler{
 			ClusterScoped: ClusterScoped{
 				BaseHandler: BaseHandler{

--- a/pkg/settings/discovery.go
+++ b/pkg/settings/discovery.go
@@ -9,7 +9,8 @@ import (
 const (
 	AllowedOrigins = "CORS_ALLOWED_ORIGINS"
 	WorkingDir     = "WORKING_DIR"
-	AuthOptinal    = "AUTH_OPTIONAL"
+	AuthOptional   = "AUTH_OPTIONAL"
+	CollectEvents  = "DISCOVERY_COLLECT_EVENTS"
 )
 
 // CORS
@@ -18,13 +19,15 @@ type CORS struct {
 	AllowedOrigins []string
 }
 
-// Plan settings.
+// Discovery settings.
 //   Origins: Permitted CORS allowed origins.
 //   AuthOptional: Authorization header is optional.
+//   CollectEvents: Discovery Service event collection switch. May want to turn off in large clusters.
 type Discovery struct {
-	CORS         CORS
-	WorkingDir   string
-	AuthOptional bool
+	CORS          CORS
+	WorkingDir    string
+	AuthOptional  bool
+	CollectEvents bool
 }
 
 // Load settings.
@@ -48,7 +51,9 @@ func (r *Discovery) Load() error {
 		r.WorkingDir = os.TempDir()
 	}
 	// Auth
-	r.AuthOptional = getEnvBool(AuthOptinal, false)
+	r.AuthOptional = getEnvBool(AuthOptional, false)
+	// CollectEvents
+	r.CollectEvents = getEnvBool(CollectEvents, true)
 
 	return nil
 }


### PR DESCRIPTION
Collecting events in the discovery service allows the tree view to become a lot more useful, we'll be able to tally up abnormal events related to migration resources and show them overlaid on each line in the tree view.

**New API**
To query all events for a particular resource, you can use its UID.
E.g.
```
# Get events for object with UID
curl http://localhost:8080/namespaces/:ns1/events/:involvedobjectuid

# Get events for the object with UID dc46e3b1-b290-11eb-8a86-16b833b160e9 (on any cluster, any namespace)
curl http://localhost:8080/namespaces/openshift-migration/events/dc46e3b1-b290-11eb-8a86-16b833b160e9
```

Todo:

- [x] Add events to discovery
- [x] Remove events via watch mechanism according to event-ttl policy (default 3 hrs)
- [x] Add a config switch to disable event collection if this turns out to be problematic on large clusters 