### PR TITLE
[MIG-625] Warn user when PV analysis fails due to orphan PVs

### DIFF
--- a/pkg/apis/migration/v1alpha1/miganalytic_types.go
+++ b/pkg/apis/migration/v1alpha1/miganalytic_types.go
@@ -23,6 +23,24 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// VolumeAdjuster condition types
+const (
+	ExtendedPVAnalysisFailed  = "ExtendedPVAnalysisFailed"
+	ExtendedPVAnalysisStarted = "ExtendedPVAnalysisStarted"
+)
+
+// VolumeAdjuster reasons
+const (
+	FailedRunningDf = "FailedRunningDf"
+)
+
+// Proposed volume size computation reasons
+const (
+	VolumeAdjustmentNoOp             = "No change in original PV capacity is needed."
+	VolumeAdjustmentUsageExceeded    = "PV usage is close to 100%, an extra headroom is added to avoid disk capacity issue in the target cluster."
+	VolumeAdjustmentCapacityMismatch = "Requested capacity of PV is not equal to its actual provisioned capacity.  Maximum of both values is used to avoid disk capacity issue in the target cluster."
+)
+
 // MigAnalyticSpec defines the desired state of MigAnalytic
 type MigAnalyticSpec struct {
 	MigPlanRef *kapi.ObjectReference `json:"migPlanRef"`

--- a/pkg/apis/migration/v1alpha1/miganalytic_types.go
+++ b/pkg/apis/migration/v1alpha1/miganalytic_types.go
@@ -37,7 +37,7 @@ const (
 // Proposed volume size computation reasons
 const (
 	VolumeAdjustmentNoOp             = "No change in PV capacity is needed."
-	VolumeAdjustmentUsageExceeded    = "PV usage is close to 100%, an extra headroom is added to avoid disk capacity issue in the target cluster."
+	VolumeAdjustmentUsageExceeded    = "PV usage is close to 100%. Additional capacity will be allocated to avoid issues migrating data to the target cluster."
 	VolumeAdjustmentCapacityMismatch = "Requested capacity of PV is not equal to its actual provisioned capacity.  Maximum of both values is used to avoid disk capacity issue in the target cluster."
 )
 

--- a/pkg/apis/migration/v1alpha1/miganalytic_types.go
+++ b/pkg/apis/migration/v1alpha1/miganalytic_types.go
@@ -38,7 +38,7 @@ const (
 const (
 	VolumeAdjustmentNoOp             = "No change in PV capacity is needed."
 	VolumeAdjustmentUsageExceeded    = "PV usage is close to 100%. Additional capacity will be allocated to avoid issues migrating data to the target cluster."
-	VolumeAdjustmentCapacityMismatch = "Requested capacity of PV is not equal to its actual provisioned capacity.  Maximum of both values is used to avoid disk capacity issue in the target cluster."
+	VolumeAdjustmentCapacityMismatch = "Requested capacity of PV is not equal to its actual provisioned capacity.  Maximum of both values will be used to avoid disk capacity issue in the target cluster."
 )
 
 // MigAnalyticSpec defines the desired state of MigAnalytic

--- a/pkg/apis/migration/v1alpha1/miganalytic_types.go
+++ b/pkg/apis/migration/v1alpha1/miganalytic_types.go
@@ -36,7 +36,7 @@ const (
 
 // Proposed volume size computation reasons
 const (
-	VolumeAdjustmentNoOp             = "No change in original PV capacity is needed."
+	VolumeAdjustmentNoOp             = "No change in PV capacity is needed."
 	VolumeAdjustmentUsageExceeded    = "PV usage is close to 100%, an extra headroom is added to avoid disk capacity issue in the target cluster."
 	VolumeAdjustmentCapacityMismatch = "Requested capacity of PV is not equal to its actual provisioned capacity.  Maximum of both values is used to avoid disk capacity issue in the target cluster."
 )

--- a/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller.go
+++ b/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller.go
@@ -218,7 +218,7 @@ func (r *RsyncPodProgressTask) Run() error {
 			if pvProgress.Status.RsyncPodExistsInHistory(pod.Name) {
 				continue
 			}
-			rsyncPodStatus := r.getRsyncClientContainerStatus(pod,r)
+			rsyncPodStatus := r.getRsyncClientContainerStatus(pod, r)
 			if rsyncPodStatus != nil {
 				// dead pods go in history
 				if IsPodTerminal(rsyncPodStatus.PodPhase) {

--- a/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller_test.go
+++ b/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller_test.go
@@ -367,10 +367,10 @@ func TestRsyncPodProgressTask_getRsyncClientContainerStatus(t *testing.T) {
 		p      GetPodLogger
 	}
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    *migapi.RsyncPodStatus
+		name   string
+		fields fields
+		args   args
+		want   *migapi.RsyncPodStatus
 	}{
 		{
 			name: "Given a ready and running Pod.",

--- a/pkg/controller/miganalytic/miganalytics_controller.go
+++ b/pkg/controller/miganalytic/miganalytics_controller.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/konveyor/controller/pkg/logging"
-	"github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/konveyor/mig-controller/pkg/compat"
 	"github.com/konveyor/mig-controller/pkg/errorutil"
 	"github.com/konveyor/mig-controller/pkg/gvk"
@@ -48,6 +47,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	liberr "github.com/konveyor/controller/pkg/error"
+	"github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
 	imagev1 "github.com/openshift/api/image/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -310,7 +310,7 @@ func (r *ReconcileMigAnalytic) analyze(analytic *migapi.MigAnalytic) error {
 
 		if analytic.Spec.AnalyzeExtendedPVCapacity {
 			analytic.Status.SetCondition(migapi.Condition{
-				Type:     ExtendedPVAnalysisStarted,
+				Type:     migapi.ExtendedPVAnalysisStarted,
 				Category: migapi.Advisory,
 				Status:   True,
 				Message:  "Started collecting detailed PV information",
@@ -349,7 +349,7 @@ func (r *ReconcileMigAnalytic) analyze(analytic *migapi.MigAnalytic) error {
 		if err != nil {
 			return liberr.Wrap(err)
 		}
-		analytic.Status.DeleteCondition(ExtendedPVAnalysisStarted)
+		analytic.Status.DeleteCondition(migapi.ExtendedPVAnalysisStarted)
 		err = r.Update(context.TODO(), analytic)
 		if err != nil {
 			return liberr.Wrap(err)

--- a/pkg/controller/miganalytic/volume_adjustment_test.go
+++ b/pkg/controller/miganalytic/volume_adjustment_test.go
@@ -271,7 +271,7 @@ func TestPersistentVolumeAdjuster_calculateProposedVolumeSize(t *testing.T) {
 				requestedCapacity: resource.MustParse("20"),
 			},
 			wantProposedSize: resource.MustParse("200"),
-			wantReason:       VolumeAdjustmentCapacityMismatch,
+			wantReason:       migapi.VolumeAdjustmentCapacityMismatch,
 		},
 		{
 			name: "Given values of usagePercentage, actualCapacity and requestedCapacity, appropriate proposed volume size is returned, here proposed size = volume with threshold size",
@@ -284,7 +284,7 @@ func TestPersistentVolumeAdjuster_calculateProposedVolumeSize(t *testing.T) {
 				requestedCapacity: resource.MustParse("20"),
 			},
 			wantProposedSize: resource.MustParse("206"),
-			wantReason:       VolumeAdjustmentUsageExceeded,
+			wantReason:       migapi.VolumeAdjustmentUsageExceeded,
 		},
 		{
 			name: "Given values of usagePercentage, actualCapacity and requestedCapacity, appropriate proposed volume size is returned, here proposed size = requested capacity",
@@ -297,7 +297,7 @@ func TestPersistentVolumeAdjuster_calculateProposedVolumeSize(t *testing.T) {
 				requestedCapacity: resource.MustParse("250"),
 			},
 			wantProposedSize: resource.MustParse("250"),
-			wantReason:       VolumeAdjustmentNoOp,
+			wantReason:       migapi.VolumeAdjustmentNoOp,
 		},
 		{
 			name: "Given values of usagePercentage, actualCapacity and requestedCapacity, appropriate volume size is returned, here volumeS size with threshold" +
@@ -311,7 +311,7 @@ func TestPersistentVolumeAdjuster_calculateProposedVolumeSize(t *testing.T) {
 				requestedCapacity: resource.MustParse("150"),
 			},
 			wantProposedSize: resource.MustParse("200"),
-			wantReason:       VolumeAdjustmentCapacityMismatch,
+			wantReason:       migapi.VolumeAdjustmentCapacityMismatch,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/controller/migmigration/metrics.go
+++ b/pkg/controller/migmigration/metrics.go
@@ -72,15 +72,15 @@ func recordMetrics(client client.Client) {
 			// for all migmigrations, count # in idle, running, completed, failed
 			for _, m := range migrations {
 				// Stage
-				if m.Spec.Stage && m.Status.HasCondition(Running) {
+				if m.Spec.Stage && m.Status.HasCondition(migapi.Running) {
 					stageRunning++
 					continue
 				}
-				if m.Spec.Stage && m.Status.HasCondition(Succeeded) {
+				if m.Spec.Stage && m.Status.HasCondition(migapi.Succeeded) {
 					stageCompleted++
 					continue
 				}
-				if m.Spec.Stage && m.Status.HasCondition(Failed) {
+				if m.Spec.Stage && m.Status.HasCondition(migapi.Failed) {
 					stageFailed++
 					continue
 				}
@@ -90,15 +90,15 @@ func recordMetrics(client client.Client) {
 				}
 
 				// Final
-				if !m.Spec.Stage && m.Status.HasCondition(Running) {
+				if !m.Spec.Stage && m.Status.HasCondition(migapi.Running) {
 					finalRunning++
 					continue
 				}
-				if !m.Spec.Stage && m.Status.HasCondition(Succeeded) {
+				if !m.Spec.Stage && m.Status.HasCondition(migapi.Succeeded) {
 					finalCompleted++
 					continue
 				}
-				if !m.Spec.Stage && m.Status.HasCondition(Failed) {
+				if !m.Spec.Stage && m.Status.HasCondition(migapi.Failed) {
 					finalFailed++
 					continue
 				}

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -91,12 +91,12 @@ func (r *ReconcileMigMigration) migrate(ctx context.Context, migration *migapi.M
 		// Close the Jaeger span for the migration
 		migtrace.CloseMigrationSpan(string(migration.GetUID()))
 
-		migration.Status.DeleteCondition(Running)
-		failed := task.Owner.Status.FindCondition(Failed)
+		migration.Status.DeleteCondition(migapi.Running)
+		failed := task.Owner.Status.FindCondition(migapi.Failed)
 		warnings := task.Owner.Status.FindConditionByCategory(migapi.Warn)
 		if failed == nil && len(warnings) == 0 {
 			migration.Status.SetCondition(migapi.Condition{
-				Type:     Succeeded,
+				Type:     migapi.Succeeded,
 				Status:   True,
 				Reason:   task.Phase,
 				Category: Advisory,
@@ -120,7 +120,7 @@ func (r *ReconcileMigMigration) migrate(ctx context.Context, migration *migapi.M
 	phase, n, total := task.Itinerary.progressReport(task.Phase)
 	message := fmt.Sprintf("Step: %d/%d", n, total)
 	migration.Status.SetCondition(migapi.Condition{
-		Type:     Running,
+		Type:     migapi.Running,
 		Status:   True,
 		Reason:   phase,
 		Category: Advisory,

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -1245,8 +1245,8 @@ func (t *Task) setProgress(progress []string) {
 // Advance the task to the next phase.
 func (t *Task) next() error {
 	// Write time taken to complete phase
-	t.Owner.Status.StageCondition(Running)
-	cond := t.Owner.Status.FindCondition(Running)
+	t.Owner.Status.StageCondition(migapi.Running)
+	cond := t.Owner.Status.FindCondition(migapi.Running)
 	if cond != nil {
 		elapsed := time.Since(cond.LastTransitionTime.Time)
 		t.Log.Info("Phase completed", "phaseElapsed", elapsed)
@@ -1425,7 +1425,7 @@ func (t *Task) fail(nextPhase string, reasons []string) {
 	t.Log.Info("Marking migration as FAILED. See Status.Errors",
 		"migrationErrors", t.Owner.Status.Errors)
 	t.Owner.Status.SetCondition(migapi.Condition{
-		Type:     Failed,
+		Type:     migapi.Failed,
 		Status:   True,
 		Reason:   t.Phase,
 		Category: Advisory,
@@ -1459,7 +1459,7 @@ func (t *Task) UID() string {
 
 // Get whether the migration has failed
 func (t *Task) failed() bool {
-	return t.Owner.HasErrors() || t.Owner.Status.HasCondition(Failed)
+	return t.Owner.HasErrors() || t.Owner.Status.HasCondition(migapi.Failed)
 }
 
 // Get whether the migration is cancelled.

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -27,10 +27,7 @@ const (
 	PlanClosed                         = "PlanClosed"
 	HasFinalMigration                  = "HasFinalMigration"
 	Postponed                          = "Postponed"
-	Running                            = "Running"
-	Succeeded                          = "Succeeded"
 	SucceededWithWarnings              = "SucceededWithWarnings"
-	Failed                             = "Failed"
 	ResticErrors                       = "ResticErrors"
 	ResticVerifyErrors                 = "ResticVerifyErrors"
 	VeleroInitialBackupPartiallyFailed = "VeleroInitialBackupPartiallyFailed"
@@ -204,21 +201,21 @@ func (r ReconcileMigMigration) validateFinalMigration(ctx context.Context, plan 
 		}
 
 		// If newest migration is a successful rollback, allow further migrations
-		if m.Spec.Rollback && m.Status.HasCondition(Succeeded) {
+		if m.Spec.Rollback && m.Status.HasCondition(migapi.Succeeded) {
 			hasCondition = false
 			break
 		}
 
 		// Stage
 		if migration.Spec.Stage {
-			if m.Status.HasAnyCondition(Running, Succeeded, Failed) {
+			if m.Status.HasAnyCondition(migapi.Running, migapi.Succeeded, migapi.Failed) {
 				hasCondition = true
 				break
 			}
 		}
 		// Final
 		if !migration.Spec.Stage {
-			if m.Status.HasCondition(Succeeded) {
+			if m.Status.HasCondition(migapi.Succeeded) {
 				hasCondition = true
 				break
 			}

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -673,7 +673,7 @@ func (r ReconcileMigPlan) generatePVResizeConditions(pvResizingRequiredVolumes [
 			Category: Warn,
 			Reason:   NotDone,
 			Message: fmt.Sprintf(
-				"Failed to compute PV resizing data for the following volumes. Please ensure that the volumes are attached to one or more running Pods: [%s]",
+				"Failed to compute PV resizing data for the following volumes. PV resizing will be disabled for these volumes and the migration may fail if the volumes are full or their requested and actual capacities differ in the source cluster. Please ensure that the volumes are attached to one or more running Pods for PV resizing to work correctly: [%s]",
 				strings.Join(pvResizingMissingVolumes, ","),
 			),
 		})

--- a/pkg/controller/migplan/migplan_controller_test.go
+++ b/pkg/controller/migplan/migplan_controller_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
-	miganalyticctl "github.com/konveyor/mig-controller/pkg/controller/miganalytic"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -548,88 +547,6 @@ func TestReconcileMigPlan_processProposedPVCapacities(t *testing.T) {
 		assertMessage bool
 	}{
 		{
-			name: "When MigAnaylitic has a ExtendedPVAnalysisFailed condition, MigPlan should show that condition",
-			args: args{
-				analytic: &migapi.MigAnalytic{
-					Status: migapi.MigAnalyticStatus{
-						Analytics: migapi.MigAnalyticPlan{
-							Namespaces: []migapi.MigAnalyticNamespace{
-								{
-									Namespace: "test-ns",
-									PersistentVolumes: []migapi.MigAnalyticPersistentVolumeClaim{
-										{
-											Name: "pvc-0",
-										},
-									},
-								},
-							},
-						},
-						Conditions: migapi.Conditions{
-							List: []migapi.Condition{
-								{
-									Type:     miganalyticctl.ExtendedPVAnalysisFailed,
-									Category: Warn,
-								}},
-						},
-					},
-				},
-				plan: &migapi.MigPlan{
-					Spec: migapi.MigPlanSpec{
-						PersistentVolumes: migapi.PersistentVolumes{
-							List: []migapi.PV{
-								{PVC: migapi.PVC{Namespace: "test-ns", Name: "pvc-0"}, Name: "pv-0"}},
-						},
-					},
-				},
-			},
-			wantConditions: []migapi.Condition{
-				{
-					Type:     miganalyticctl.ExtendedPVAnalysisFailed,
-					Category: Warn,
-				},
-			},
-			dontWantConditions: []migapi.Condition{},
-		},
-		{
-			name: "When MigAnaylitic doesn't have a ExtendedPVAnalysisFailed condition, MigPlan should not show that condition",
-			args: args{
-				analytic: &migapi.MigAnalytic{
-					Status: migapi.MigAnalyticStatus{
-						Analytics: migapi.MigAnalyticPlan{
-							Namespaces: []migapi.MigAnalyticNamespace{
-								{
-									Namespace: "test-ns",
-									PersistentVolumes: []migapi.MigAnalyticPersistentVolumeClaim{
-										{
-											Name: "pvc-0",
-										},
-									},
-								},
-							},
-						},
-						Conditions: migapi.Conditions{
-							List: []migapi.Condition{},
-						},
-					},
-				},
-				plan: &migapi.MigPlan{
-					Spec: migapi.MigPlanSpec{
-						PersistentVolumes: migapi.PersistentVolumes{
-							List: []migapi.PV{
-								{PVC: migapi.PVC{Namespace: "test-ns", Name: "pvc-0"}, Name: "pv-0"}},
-						},
-					},
-				},
-			},
-			wantConditions: []migapi.Condition{},
-			dontWantConditions: []migapi.Condition{
-				{
-					Type:     miganalyticctl.ExtendedPVAnalysisFailed,
-					Category: Warn,
-				},
-			},
-		},
-		{
 			name: "When MigAnalytic failed to get PV data from a volume because it was probably not attached to a Pod, MigPlan should show appropriate condition",
 			args: args{
 				analytic: &migapi.MigAnalytic{
@@ -660,7 +577,7 @@ func TestReconcileMigPlan_processProposedPVCapacities(t *testing.T) {
 			wantConditions: []migapi.Condition{{
 				Type:     PvUsageAnalysisFailed,
 				Category: Warn,
-				Message:  "MigPlan failed to compute PV resizing data for following volumes. Please make sure that the volumes are attached to one or more Running pods: [pv-0]",
+				Message:  "Failed to compute PV resizing data for the following volumes. PV resizing will be disabled for these volumes and the migration may fail if the volumes are full or their requested and actual capacities differ in the source cluster. Please ensure that the volumes are attached to one or more running Pods for PV resizing to work correctly: [pv-0]",
 			}},
 			dontWantConditions: []migapi.Condition{},
 			assertMessage:      true,

--- a/pkg/controller/migplan/migplan_controller_test.go
+++ b/pkg/controller/migplan/migplan_controller_test.go
@@ -23,15 +23,15 @@ import (
 	"time"
 
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	miganalyticctl "github.com/konveyor/mig-controller/pkg/controller/miganalytic"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -528,6 +528,161 @@ func Test(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("checkIfMigAnalyticsReady() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReconcileMigPlan_processProposedPVCapacities(t *testing.T) {
+	type args struct {
+		plan     *migapi.MigPlan
+		analytic *migapi.MigAnalytic
+	}
+	tests := []struct {
+		name               string
+		args               args
+		wantConditions     []migapi.Condition
+		dontWantConditions []migapi.Condition
+		// determines whether or not to assert the message of the condition
+		// when enabled, the test case will also assert whether the message in the conditions are equal
+		assertMessage bool
+	}{
+		{
+			name: "When MigAnaylitic has a ExtendedPVAnalysisFailed condition, MigPlan should show that condition",
+			args: args{
+				analytic: &migapi.MigAnalytic{
+					Status: migapi.MigAnalyticStatus{
+						Analytics: migapi.MigAnalyticPlan{
+							Namespaces: []migapi.MigAnalyticNamespace{
+								{
+									Namespace: "test-ns",
+									PersistentVolumes: []migapi.MigAnalyticPersistentVolumeClaim{
+										{
+											Name: "pvc-0",
+										},
+									},
+								},
+							},
+						},
+						Conditions: migapi.Conditions{
+							List: []migapi.Condition{
+								{
+									Type:     miganalyticctl.ExtendedPVAnalysisFailed,
+									Category: Warn,
+								}},
+						},
+					},
+				},
+				plan: &migapi.MigPlan{
+					Spec: migapi.MigPlanSpec{
+						PersistentVolumes: migapi.PersistentVolumes{
+							List: []migapi.PV{
+								{PVC: migapi.PVC{Namespace: "test-ns", Name: "pvc-0"}, Name: "pv-0"}},
+						},
+					},
+				},
+			},
+			wantConditions: []migapi.Condition{
+				{
+					Type:     miganalyticctl.ExtendedPVAnalysisFailed,
+					Category: Warn,
+				},
+			},
+			dontWantConditions: []migapi.Condition{},
+		},
+		{
+			name: "When MigAnaylitic doesn't have a ExtendedPVAnalysisFailed condition, MigPlan should not show that condition",
+			args: args{
+				analytic: &migapi.MigAnalytic{
+					Status: migapi.MigAnalyticStatus{
+						Analytics: migapi.MigAnalyticPlan{
+							Namespaces: []migapi.MigAnalyticNamespace{
+								{
+									Namespace: "test-ns",
+									PersistentVolumes: []migapi.MigAnalyticPersistentVolumeClaim{
+										{
+											Name: "pvc-0",
+										},
+									},
+								},
+							},
+						},
+						Conditions: migapi.Conditions{
+							List: []migapi.Condition{},
+						},
+					},
+				},
+				plan: &migapi.MigPlan{
+					Spec: migapi.MigPlanSpec{
+						PersistentVolumes: migapi.PersistentVolumes{
+							List: []migapi.PV{
+								{PVC: migapi.PVC{Namespace: "test-ns", Name: "pvc-0"}, Name: "pv-0"}},
+						},
+					},
+				},
+			},
+			wantConditions: []migapi.Condition{},
+			dontWantConditions: []migapi.Condition{
+				{
+					Type:     miganalyticctl.ExtendedPVAnalysisFailed,
+					Category: Warn,
+				},
+			},
+		},
+		{
+			name: "When MigAnalytic failed to get PV data from a volume because it was probably not attached to a Pod, MigPlan should show appropriate condition",
+			args: args{
+				analytic: &migapi.MigAnalytic{
+					Status: migapi.MigAnalyticStatus{
+						Analytics: migapi.MigAnalyticPlan{
+							Namespaces: []migapi.MigAnalyticNamespace{
+								{
+									Namespace:         "test-ns",
+									PersistentVolumes: []migapi.MigAnalyticPersistentVolumeClaim{},
+								},
+							},
+						},
+						Conditions: migapi.Conditions{
+							List: []migapi.Condition{},
+						},
+					},
+				},
+				plan: &migapi.MigPlan{
+					Spec: migapi.MigPlanSpec{
+						PersistentVolumes: migapi.PersistentVolumes{
+							List: []migapi.PV{
+								{PVC: migapi.PVC{Namespace: "test-ns", Name: "pvc-0"}, Name: "pv-0"},
+							},
+						},
+					},
+				},
+			},
+			wantConditions: []migapi.Condition{{
+				Type:     PvUsageAnalysisFailed,
+				Category: Warn,
+				Message:  "MigPlan failed to compute PV resizing data for following volumes. Please make sure that the volumes are attached to one or more Running pods: [pv-0]",
+			}},
+			dontWantConditions: []migapi.Condition{},
+			assertMessage:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ReconcileMigPlan{}
+			r.processProposedPVCapacities(context.TODO(), tt.args.plan, tt.args.analytic)
+			for _, want := range tt.wantConditions {
+				got := tt.args.plan.Status.FindCondition(want.Type)
+				if got == nil {
+					t.Errorf("processProposedPVCapacities() didn't find expected condition %v on MigPlan", want)
+				}
+				if got != nil && tt.assertMessage && got.Message != want.Message {
+					t.Errorf("processProposedPVCapacities() found expected condition on MigPlan but the message was incorrect; want %s got %s", want.Message, got.Message)
+				}
+			}
+			for _, dontWant := range tt.dontWantConditions {
+				if got := tt.args.plan.Status.FindCondition(dontWant.Type); got != nil {
+					t.Errorf("processProposedPVCapacities() found unexpected condition %v on MigPlan", dontWant)
+				}
 			}
 		})
 	}

--- a/pkg/controller/migplan/predicate.go
+++ b/pkg/controller/migplan/predicate.go
@@ -1,10 +1,10 @@
 package migplan
 
 import (
-	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
-	migctl "github.com/konveyor/mig-controller/pkg/controller/migmigration"
-	migref "github.com/konveyor/mig-controller/pkg/reference"
 	"reflect"
+
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	migref "github.com/konveyor/mig-controller/pkg/reference"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -178,10 +178,10 @@ func (r MigrationPredicate) Update(e event.UpdateEvent) bool {
 	if !cast {
 		return false
 	}
-	started := !old.Status.HasCondition(migctl.Running) &&
-		new.Status.HasCondition(migctl.Running)
-	stopped := old.Status.HasCondition(migctl.Running) &&
-		!new.Status.HasCondition(migctl.Running)
+	started := !old.Status.HasCondition(migapi.Running) &&
+		new.Status.HasCondition(migapi.Running)
+	stopped := old.Status.HasCondition(migapi.Running) &&
+		!new.Status.HasCondition(migapi.Running)
 	if started || stopped {
 		return true
 	}


### PR DESCRIPTION
This PR adds the ability to warn users when MigAnalytic fails to gather PV usage data when they are not attached to any Pods. Previously, a warning was only present when MigAnalytic fails to gather data from PVs attached to Pods. But when they were not attached to Pods, MigAnalytic doesn't even enter the loop which makes those volumes to be completely absent from the Status fields. Also adds some tests to assert different warnings on the MigPlan.

pvc-0 in following example is not attached to a Pod, pvc-1 is attached to app-1. 
```sh
[pranav@dragonfly ~]$ oc get pods
NAME                     READY   STATUS    RESTARTS   AGE
app-1-5689b9f4bd-wrbv2   2/2     Running   0          22h

[pranav@dragonfly ~]$ oc get pvc
NAME    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
pvc-0   Bound    pvc-92c57df4-9bb2-11eb-9435-06d7fc742b14   6Gi        RWO            glusterfs-storage   15d
pvc-1   Bound    pvc-a648591e-a6cc-11eb-9435-06d7fc742b14   6Gi        RWO            glusterfs-storage   22h
```

![Screenshot from 2021-04-27 14-58-35](https://user-images.githubusercontent.com/9839757/116297266-17584e80-a769-11eb-8eec-e382662800d1.png)

