### PR TITLE
Add clusterType to discovery tree output

### DIFF
--- a/pkg/controller/discovery/web/plan.go
+++ b/pkg/controller/discovery/web/plan.go
@@ -628,10 +628,11 @@ func (t *PlanTree) addDirectVolumes(migration *model.Migration, parent *TreeNode
 	}
 	for _, m := range list {
 		node := TreeNode{
-			Kind:       migref.ToKind(m),
-			ObjectLink: DirectVolumeMigrationHandler{}.Link(m),
-			Namespace:  m.Namespace,
-			Name:       m.Name,
+			Kind:        migref.ToKind(m),
+			ObjectLink:  DirectVolumeMigrationHandler{}.Link(m),
+			Namespace:   m.Namespace,
+			Name:        m.Name,
+			ClusterType: clusterTypeHost,
 		}
 		err := t.addDirectVolumeProgresses(m, &node)
 		if err != nil {


### PR DESCRIPTION
Merge with https://github.com/konveyor/mig-ui/pull/1188

This will make it possible for the tree view in UI to present the user with the cluster each resource lives on.

```
AUTH_OPTIONAL=1 make run-fast
curl http://localhost:8080/namespaces/openshift-migration/plans/plan-hog/tree | jq
```

```
{
          "kind": "DirectImageMigration",
          "namespace": "openshift-migration",
          "name": "36a1a0f0-a770-11eb-a3e9-cd44f11c96ef-g6lpb",
          "clusterType": "host",
          "objectLink": "/namespaces/openshift-migration/directimagemigrations/36a1a0f0-a770-11eb-a3e9-cd44f11c96ef-g6lpb"
        }
```

![image](https://user-images.githubusercontent.com/7576968/116478576-44316200-a84c-11eb-8797-f26195386004.png)
