### PR TITLE
Provide call to action in stalled message, reduce time to 3 minutes

### DIFF
--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rsa"
 	"fmt"
-	"path"
 	"strings"
 	"time"
 
@@ -362,12 +361,12 @@ func (t *Task) Run(ctx context.Context) error {
 				for _, nonRunningPod := range nonRunningPods {
 					if nonRunningPod != nil {
 						nonRunningPodStrings = append(nonRunningPodStrings,
-							fmt.Sprintf("%s", path.Join(nonRunningPod.Namespace, nonRunningPod.Name)))
+							fmt.Sprintf("oc describe pod %s -n %s", nonRunningPod.Name, nonRunningPod.Namespace))
 					}
 				}
 
 				msg := fmt.Sprintf("Rsync Transfer Pod(s) on destination cluster have not started Running within 3 minutes. "+
-					"Run 'oc describe' to check for warning events on these Pod(s): [%s]",
+					"Run these command(s) to check Pod warning events: [%s]",
 					fmt.Sprintf("%s", strings.Join(nonRunningPodStrings, ", ")))
 
 				t.Log.Info(msg)

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -362,14 +362,13 @@ func (t *Task) Run(ctx context.Context) error {
 				for _, nonRunningPod := range nonRunningPods {
 					if nonRunningPod != nil {
 						nonRunningPodStrings = append(nonRunningPodStrings,
-							fmt.Sprintf("%s ", path.Join(nonRunningPod.Namespace, nonRunningPod.Name)))
+							fmt.Sprintf("%s", path.Join(nonRunningPod.Namespace, nonRunningPod.Name)))
 					}
 				}
 
-				msg := fmt.Sprintf("Rsync Transfer Pod(s) [%s] on destination cluster have not started Running within 3 minutes. "+
-					"Run this command on the destination cluster and check the Pod events. "+
-					"oc describe pods --selector purpose=%s --all-namespaces",
-					fmt.Sprintf("%s", strings.Join(nonRunningPodStrings, ", ")), DirectVolumeMigrationRsync)
+				msg := fmt.Sprintf("Rsync Transfer Pod(s) on destination cluster have not started Running within 3 minutes. "+
+					"Run 'oc describe' to check for warning events on these Pod(s): [%s]",
+					fmt.Sprintf("%s", strings.Join(nonRunningPodStrings, ", ")))
 
 				t.Log.Info(msg)
 				t.Owner.Status.SetCondition(

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -366,8 +366,7 @@ func (t *Task) Run(ctx context.Context) error {
 					}
 				}
 
-				var msg string
-				msg = fmt.Sprintf("Rsync Transfer Pod(s) [%s] on destination cluster have not started Running within 3 minutes. "+
+				msg := fmt.Sprintf("Rsync Transfer Pod(s) [%s] on destination cluster have not started Running within 3 minutes. "+
 					"Run this command on the destination cluster and check the Pod events. "+
 					"oc describe pods --selector purpose=%s --all-namespaces",
 					fmt.Sprintf("%s", strings.Join(nonRunningPodStrings, ", ")), DirectVolumeMigrationRsync)

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -365,17 +365,12 @@ func (t *Task) Run(ctx context.Context) error {
 							fmt.Sprintf("%s ", path.Join(nonRunningPod.Namespace, nonRunningPod.Name)))
 					}
 				}
-				// ns1/pod1, ns2/pod2
-				nonRunningString := fmt.Sprintf("%s", strings.Join(nonRunningPodStrings, ", "))
 
 				var msg string
-				if nonRunningString != "" {
-					msg = fmt.Sprintf("Rsync Transfer Pod(s) [%s] on destination cluster have not started Running within 3 minutes. "+
-						"Run this command on the destination cluster and check the Pod events. "+
-						"oc describe pods --selector purpose=%s --all-namespaces", nonRunningString, DirectVolumeMigrationRsync)
-				} else {
-					msg = "Rsync Transfer Pod(s) on destination cluster have not started Running within 3 minutes."
-				}
+				msg = fmt.Sprintf("Rsync Transfer Pod(s) [%s] on destination cluster have not started Running within 3 minutes. "+
+					"Run this command on the destination cluster and check the Pod events. "+
+					"oc describe pods --selector purpose=%s --all-namespaces",
+					fmt.Sprintf("%s", strings.Join(nonRunningPodStrings, ", ")), DirectVolumeMigrationRsync)
 
 				t.Log.Info(msg)
 				t.Owner.Status.SetCondition(


### PR DESCRIPTION
 - Call to action helps the user know what to do next
 - Warning showing up sooner means that inexperienced user of the tool doesn't waste time waiting for something to happen

![image](https://user-images.githubusercontent.com/7576968/117199565-55342300-adb8-11eb-8a7f-2d8a71009009.png)