### PR TITLE
Fix discovery event collection

### DIFF
--- a/pkg/controller/discovery/container/event.go
+++ b/pkg/controller/discovery/container/event.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/konveyor/controller/pkg/logging"
 	"github.com/konveyor/mig-controller/pkg/controller/discovery/model"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -59,7 +60,7 @@ func (r *Event) Reconcile() error {
 func (r *Event) GetDiscovered() ([]model.Model, error) {
 	models := []model.Model{}
 	onCluster := v1.EventList{}
-	err := r.ds.Client.List(context.TODO(), nil, &onCluster)
+	err := r.ds.Client.List(context.TODO(), &onCluster)
 	if err != nil {
 		Log.Trace(err)
 		return nil, err
@@ -102,7 +103,7 @@ func (r *Event) GetStored() ([]model.Model, error) {
 //
 
 func (r *Event) Create(e event.CreateEvent) bool {
-	Log.Reset()
+	Log = logging.WithName("discovery")
 	object, cast := e.Object.(*v1.Event)
 	if !cast {
 		return false
@@ -119,7 +120,7 @@ func (r *Event) Create(e event.CreateEvent) bool {
 }
 
 func (r *Event) Update(e event.UpdateEvent) bool {
-	Log.Reset()
+	Log = logging.WithName("discovery")
 	object, cast := e.ObjectNew.(*v1.Event)
 	if !cast {
 		return false
@@ -136,7 +137,7 @@ func (r *Event) Update(e event.UpdateEvent) bool {
 }
 
 func (r *Event) Delete(e event.DeleteEvent) bool {
-	Log.Reset()
+	Log = logging.WithName("discovery")
 	object, cast := e.Object.(*v1.Event)
 	if !cast {
 		return false


### PR DESCRIPTION
Needed to rebase after  the Velero 1.6 /  controller-runtime version bump PR, but didn't, so a few things broke upon merge of https://github.com/konveyor/mig-controller/pull/1084. This PR fixes them.