### PR TITLE
Cherry-pick: fix adding warnings to dvm if labels are greater than 63 chars

### DIFF
--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -1842,6 +1842,7 @@ func (t *Task) processRsyncOperationStatus(status rsyncClientOperationStatusList
 	if status.AnyErrored() {
 		// check if we are seeing errors running any of the operation for over 5 minutes
 		// if yes, set a warning condition
+		t.Owner.Status.StageCondition(Running)
 		runningCondition := t.Owner.Status.Conditions.FindCondition(Running)
 		if runningCondition != nil &&
 			time.Now().Add(time.Minute*-5).After(runningCondition.LastTransitionTime.Time) {
@@ -1858,6 +1859,7 @@ func (t *Task) processRsyncOperationStatus(status rsyncClientOperationStatusList
 	if len(garbageCollectionErrors) > 0 {
 		// check if we are seeing errors running any of the operation for over 5 minutes
 		// if yes, set a warning condition
+		t.Owner.Status.StageCondition(Running)
 		runningCondition := t.Owner.Status.Conditions.FindCondition(Running)
 		if runningCondition != nil &&
 			time.Now().Add(time.Minute*-5).After(runningCondition.LastTransitionTime.Time) {
@@ -2242,7 +2244,9 @@ func (t *Task) getLatestPodForOperation(client compat.Client, operation migapi.R
 		} else if _, err := strconv.Atoi(val); err != nil {
 			continue
 		}
-		if pod.CreationTimestamp.After(mostRecentPod.CreationTimestamp.Time) {
+		if mostRecentPod == nil {
+			mostRecentPod = &pod
+		} else if pod.CreationTimestamp.After(mostRecentPod.CreationTimestamp.Time) {
 			mostRecentPod = &pod
 		}
 	}
@@ -2320,9 +2324,4 @@ func getDNSSafeName(name string) (string, error) {
 		return re.ReplaceAllString(name[:63], "-"), nil
 	}
 	return re.ReplaceAllString(name, "-"), nil
-}
-
-func wrapper(s string) (int, error) {
-	x := map[string]string{}
-	return strconv.Atoi(x["unknown-value"])
 }

--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -1176,6 +1176,7 @@ func (t *Task) hasAllProgressReportingCompleted() (bool, error) {
 	t.Owner.Status.FailedPods = []*migapi.PodProgress{}
 	t.Owner.Status.SuccessfulPods = []*migapi.PodProgress{}
 	t.Owner.Status.PendingPods = []*migapi.PodProgress{}
+	unknowns := []*migapi.PodProgress{}
 	var pendingPods []string
 	pvcMap := t.getPVCNamespaceMap()
 	for ns, vols := range pvcMap {
@@ -1217,12 +1218,15 @@ func (t *Task) hasAllProgressReportingCompleted() (bool, error) {
 			case dvmp.Status.PodPhase == corev1.PodPending:
 				t.Owner.Status.PendingPods = append(t.Owner.Status.PendingPods, podProgress)
 				pendingPods = append(pendingPods, fmt.Sprintf("%s/%s", podProgress.Namespace, podProgress.Name))
+			case dvmp.Status.PodPhase == "":
+				unknowns = append(unknowns, podProgress)
 			}
 		}
 	}
 
 	isAnyPending := len(t.Owner.Status.PendingPods) > 0
 	isAnyRunning := len(t.Owner.Status.RunningPods) > 0
+	isAnyUnknown := len(unknowns) > 0
 	if isAnyPending {
 		pendingMessage := fmt.Sprintf("Rsync Client Pods [%s] are stuck in Pending state for more than 10 mins", strings.Join(pendingPods[:], ", "))
 		t.Log.Info(pendingMessage)
@@ -1234,7 +1238,7 @@ func (t *Task) hasAllProgressReportingCompleted() (bool, error) {
 			Message:  pendingMessage,
 		})
 	}
-	return !isAnyRunning && !isAnyPending, nil
+	return !isAnyRunning && !isAnyPending && !isAnyUnknown, nil
 }
 
 func (t *Task) hasAllRsyncClientPodsTimedOut() (bool, error) {
@@ -2125,9 +2129,6 @@ func (t *Task) garbageCollectPodsForRequirements(client compat.Client, op migapi
 					// Delete the pod when the attempt label cannot be parsed as int, we never consider this pod anyway
 					shouldDelete = true
 				}
-			} else {
-				// Delete the pod when the pod attempt label is missing, we never consider this pod anyway
-				shouldDelete = true
 			}
 			if shouldDelete {
 				// Delete the pod when the pod attempt label is missing, we never consider this pod anyway
@@ -2231,20 +2232,21 @@ func (t *Task) getLatestPodForOperation(client compat.Client, operation migapi.R
 	if len(podList.Items) < 1 {
 		return nil, nil
 	}
-	var mostRecentPod corev1.Pod
-	for _, pod := range podList.Items {
+	var mostRecentPod *corev1.Pod = nil
+	for i := range podList.Items {
 		// if expected attempt label is not found on the pod or its value is not an integer,
 		// there is no way to associate this pod with an Rsync attempt we made, we skip this pod
+		pod := podList.Items[i]
 		if val, exists := pod.Labels[RsyncAttemptLabel]; !exists {
 			continue
 		} else if _, err := strconv.Atoi(val); err != nil {
 			continue
 		}
 		if pod.CreationTimestamp.After(mostRecentPod.CreationTimestamp.Time) {
-			mostRecentPod = pod
+			mostRecentPod = &pod
 		}
 	}
-	return &mostRecentPod, nil
+	return mostRecentPod, nil
 }
 
 // createNewPodForOperation creates a new pod for given RsyncOperation
@@ -2318,4 +2320,9 @@ func getDNSSafeName(name string) (string, error) {
 		return re.ReplaceAllString(name[:63], "-"), nil
 	}
 	return re.ReplaceAllString(name, "-"), nil
+}
+
+func wrapper(s string) (int, error) {
+	x := map[string]string{}
+	return strconv.Atoi(x["unknown-value"])
 }

--- a/pkg/controller/directvolumemigration/rsync_test.go
+++ b/pkg/controller/directvolumemigration/rsync_test.go
@@ -682,7 +682,7 @@ func TestTask_ensureRsyncOperations(t *testing.T) {
 			name: "when given 0 existing Rsync pods in the source namespace and 1 new pod requirement, 1 new pod should be created in the source namespace",
 			args: args{
 				podRequirements: []rsyncClientPodRequirements{
-					getRsyncClientPodRequirements("111111111111111111111111111111111.11111111111111111111111111111111111111111111111111111111111111", "ns-1"),
+					getRsyncClientPodRequirements("pvc-1", "ns-1"),
 				},
 				client: fakecompat.NewFakeClient(),
 			},
@@ -700,14 +700,14 @@ func TestTask_ensureRsyncOperations(t *testing.T) {
 				},
 			},
 			wantCRStatus: []*migapi.RsyncOperation{
-				getTestRsyncOperationStatus("111111111111111111111111111111111.11111111111111111111111111111111111111111111111111111111111111", "ns-1", 1, false, false),
+				getTestRsyncOperationStatus("pvc-1", "ns-1", 1, false, false),
 			},
 			wantPods: []*corev1.Pod{
-				getTestRsyncPodForPVC("pod-1", "111111111111111111111111111111111.11111111111111111111111111111111111111111111111111111111111111 ", "ns-1", "1", time.Now()),
+				getTestRsyncPodForPVC("pod-1", "pvc-1", "ns-1", "1", time.Now()),
 			},
 			dontWantPods: []*corev1.Pod{
-				getTestRsyncPodForPVC("pod-1", "111111111111111111111111111111111.11111111111111111111111111111111111111111111111111111111111111 ", "ns-1", "0", time.Now()),
-				getTestRsyncPodForPVC("pod-1", "111111111111111111111111111111111.11111111111111111111111111111111111111111111111111111111111111 ", "ns-1", "2", time.Now()),
+				getTestRsyncPodForPVC("pod-1", "pvc-1", "ns-1", "0", time.Now()),
+				getTestRsyncPodForPVC("pod-1", "pvc-1", "ns-1", "2", time.Now()),
 			},
 		},
 		{

--- a/pkg/controller/directvolumemigration/rsync_test.go
+++ b/pkg/controller/directvolumemigration/rsync_test.go
@@ -682,7 +682,7 @@ func TestTask_ensureRsyncOperations(t *testing.T) {
 			name: "when given 0 existing Rsync pods in the source namespace and 1 new pod requirement, 1 new pod should be created in the source namespace",
 			args: args{
 				podRequirements: []rsyncClientPodRequirements{
-					getRsyncClientPodRequirements("pvc-1", "ns-1"),
+					getRsyncClientPodRequirements("111111111111111111111111111111111.11111111111111111111111111111111111111111111111111111111111111", "ns-1"),
 				},
 				client: fakecompat.NewFakeClient(),
 			},
@@ -700,14 +700,14 @@ func TestTask_ensureRsyncOperations(t *testing.T) {
 				},
 			},
 			wantCRStatus: []*migapi.RsyncOperation{
-				getTestRsyncOperationStatus("pvc-1", "ns-1", 1, false, false),
+				getTestRsyncOperationStatus("111111111111111111111111111111111.11111111111111111111111111111111111111111111111111111111111111", "ns-1", 1, false, false),
 			},
 			wantPods: []*corev1.Pod{
-				getTestRsyncPodForPVC("pod-1", "pvc-1", "ns-1", "1", time.Now()),
+				getTestRsyncPodForPVC("pod-1", "111111111111111111111111111111111.11111111111111111111111111111111111111111111111111111111111111 ", "ns-1", "1", time.Now()),
 			},
 			dontWantPods: []*corev1.Pod{
-				getTestRsyncPodForPVC("pod-1", "pvc-1", "ns-1", "0", time.Now()),
-				getTestRsyncPodForPVC("pod-1", "pvc-1", "ns-1", "2", time.Now()),
+				getTestRsyncPodForPVC("pod-1", "111111111111111111111111111111111.11111111111111111111111111111111111111111111111111111111111111 ", "ns-1", "0", time.Now()),
+				getTestRsyncPodForPVC("pod-1", "111111111111111111111111111111111.11111111111111111111111111111111111111111111111111111111111111 ", "ns-1", "2", time.Now()),
 			},
 		},
 		{


### PR DESCRIPTION
- stage the condition before finding it, fixes warn condition for DVM
- return nil pointer if no pod is found for hasAllRsyncClientPodsTimedOut
- if dvmp.status.podPhase is empty, add it to unknown pods