### PR TITLE
Bug 1920559: (Cherry-pick) Rollback DVM created resources on target cluster (#1128)

### DIFF
--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -87,8 +87,8 @@ func (t *Task) createDestinationPVCs() error {
 		}
 
 		if migrationUID != "" && t.PlanResources != nil && t.PlanResources.MigPlan != nil {
-			pvcLabels[MigratedByMigrationLabel] = migrationUID
-			pvcLabels[MigratedByPlanLabel] = string(t.PlanResources.MigPlan.UID)
+			pvcLabels[migapi.MigMigrationLabel] = migrationUID
+			pvcLabels[migapi.MigPlanLabel] = string(t.PlanResources.MigPlan.UID)
 		} else if t.Owner.UID != "" {
 			pvcLabels[MigratedByDirectVolumeMigration] = string(t.Owner.UID)
 		}

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -63,8 +63,6 @@ const (
 	DirectVolumeMigrationRsync              = "rsync"
 	DirectVolumeMigrationRsyncClient        = "rsync-client"
 	DirectVolumeMigrationStunnel            = "stunnel"
-	MigratedByPlanLabel                     = "migration.openshift.io/migrated-by-migplan"               // (migplan UID)
-	MigratedByMigrationLabel                = "migration.openshift.io/migrated-by-migmigration"          // (migmigration UID)
 	MigratedByDirectVolumeMigration         = "migration.openshift.io/migrated-by-directvolumemigration" // (dvm UID)
 )
 
@@ -538,6 +536,12 @@ func (t *Task) buildDVMLabels() map[string]string {
 	dvmLabels["app"] = DirectVolumeMigrationRsyncTransfer
 	dvmLabels["owner"] = DirectVolumeMigration
 	dvmLabels[migapi.PartOfLabel] = migapi.Application
+	// Label resources for rollback targeting
+	if t.PlanResources != nil {
+		if t.PlanResources.MigPlan != nil {
+			dvmLabels[migapi.MigPlanLabel] = string(t.PlanResources.MigPlan.UID)
+		}
+	}
 
 	return dvmLabels
 }


### PR DESCRIPTION
* Add rollback label to DVM resources so rollback will not get stuck

(cherry picked from commit 9497d965fd6ba167cca7e5c437ded1040b26f61e)