### PR TITLE
Bug 1972903: Fail DVM when itinerary is failed

### DIFF
--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -175,6 +175,9 @@ func (t *Task) init() error {
 	} else {
 		t.Itinerary = VolumeMigration
 	}
+	if t.Itinerary.Name != t.Owner.Status.Itinerary {
+		t.Phase = t.Itinerary.Steps[0].phase
+	}
 	return nil
 }
 


### PR DESCRIPTION
In first reconcile, DVM errors out and calls t.fail()  This function does not update dvm.Status.Phase it only adds errors to the CR and returns. Now next reconcile takes place, it sees that the CR has errors so it initiates the FailedItinerary but there is nothing that sets t.Phase it needs to be set to the first phase of the itinerary as done in MigMigration [here](https://github.com/konveyor/mig-controller/blob/5f498badbfc11c9345db0598c6d7094e9f2b3a72/pkg/controller/migmigration/task.go#L1132-L1134)