### PR TITLE
Bug 1978561: fix pod manager bug for verify, wrap errors

### DIFF
--- a/pkg/controller/migmigration/verify.go
+++ b/pkg/controller/migmigration/verify.go
@@ -22,19 +22,19 @@ func (t *Task) VerificationCompleted() (bool, error) {
 
 	client, err := t.getDestinationClient()
 	if err != nil {
-		return false, err
+		return false, liberr.Wrap(err)
 	}
 
 	// Collect and update info about unhealthy pods
 	err = t.updateResourcesHealth(client)
 	if err != nil {
-		return false, err
+		return false, liberr.Wrap(err)
 	}
 
 	// Check that all pods are recreated
 	finished, err := t.podsRecreated(client)
 	if err != nil {
-		return false, err
+		return false, liberr.Wrap(err)
 	}
 	if !finished {
 		// Stop when unhealthy resources were confirmed
@@ -98,12 +98,12 @@ func (t *Task) podsRecreated(client k8sclient.Client) (bool, error) {
 
 		finished, err := health.DaemonSetsRecreated(client, &options)
 		if err != nil || !finished {
-			return finished, err
+			return finished, liberr.Wrap(err)
 		}
 
 		finished, err = health.PodManagersRecreated(client, &options)
 		if err != nil || !finished {
-			return finished, err
+			return finished, liberr.Wrap(err)
 		}
 	}
 

--- a/pkg/health/pods.go
+++ b/pkg/health/pods.go
@@ -3,6 +3,8 @@ package health
 import (
 	"context"
 	"fmt"
+	liberr "github.com/konveyor/controller/pkg/error"
+	"k8s.io/apimachinery/pkg/api/meta"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -21,24 +23,29 @@ const (
 
 var podManagingResources = [...]schema.GroupVersionKind{
 	schema.GroupVersionKind{
-		Group: "apps",
-		Kind:  "statefulset",
+		Group:   "apps",
+		Kind:    "statefulset",
+		Version: "v1",
 	},
 	schema.GroupVersionKind{
-		Group: "apps",
-		Kind:  "deployment",
+		Group:   "apps",
+		Kind:    "deployment",
+		Version: "v1",
 	},
 	schema.GroupVersionKind{
-		Group: "",
-		Kind:  "replicationcontroller",
+		Group:   "",
+		Kind:    "replicationcontroller",
+		Version: "v1",
 	},
 	schema.GroupVersionKind{
-		Group: "extensions",
-		Kind:  "replicaset",
+		Group:   "apps",
+		Kind:    "replicaset",
+		Version: "v1",
 	},
 	schema.GroupVersionKind{
-		Group: "apps.openshift.io",
-		Kind:  "deploymentconfig",
+		Group:   "apps.openshift.io",
+		Kind:    "deploymentconfig",
+		Version: "v1",
 	},
 }
 
@@ -51,22 +58,25 @@ func PodManagersRecreated(client k8sclient.Client, options *k8sclient.ListOption
 		podManagersList.SetGroupVersionKind(gvk)
 		err := client.List(context.TODO(), &podManagersList, options)
 		if err != nil {
-			return false, err
+			if meta.IsNoMatchError(err) {
+				continue
+			}
+			return false, liberr.Wrap(err)
 		}
 
 		for _, podManager := range podManagersList.Items {
 			expectedReplicas, found, err := unstructured.NestedFieldNoCopy(podManager.Object, "spec", "replicas")
 			if err != nil {
-				return false, err
+				return false, liberr.Wrap(err)
 			}
 			if !found {
 				err = fmt.Errorf("Replicas field was not found in %s kind", podManager.GetKind())
-				return false, err
+				return false, liberr.Wrap(err)
 			}
 			replicas, ok := expectedReplicas.(int64)
 			if !ok {
 				err = fmt.Errorf("Can't convert Replicas field to int64 for %s kind", podManager.GetKind())
-				return false, err
+				return false, liberr.Wrap(err)
 			}
 			if replicas == 0 {
 				continue
@@ -74,7 +84,7 @@ func PodManagersRecreated(client k8sclient.Client, options *k8sclient.ListOption
 
 			readyReplicas, foundReady, err := unstructured.NestedFieldNoCopy(podManager.Object, "status", "readyReplicas")
 			if err != nil {
-				return false, err
+				return false, liberr.Wrap(err)
 			}
 
 			if !foundReady || expectedReplicas != readyReplicas {
@@ -93,7 +103,7 @@ func DaemonSetsRecreated(client k8sclient.Client, options *k8sclient.ListOptions
 
 	err := client.List(context.TODO(), &daemonSetList, options)
 	if err != nil {
-		return false, err
+		return false, liberr.Wrap(err)
 	}
 
 	for _, ds := range daemonSetList.Items {


### PR DESCRIPTION
The verify logic checks for various pod controllers to see if the number of replicas is as expected. This fixes a bug where the  GVKs for the pod manager were not up-to-date. This also adds a check for NoKindFound errors and ignores them so that the migration does not fail. 

Additionally, this wraps all the errors so that the source of error is easier to find with a trace.