### PR TITLE
State Transfer API Changes

### DIFF
--- a/config/crds/migration.openshift.io_directvolumemigrations.yaml
+++ b/config/crds/migration.openshift.io_directvolumemigrations.yaml
@@ -141,19 +141,29 @@ spec:
                       is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                     type: string
                   targetAccessModes:
+                    description: TargetAccessModes access modes of the migrated PVC
+                      in the target cluster
                     items:
                       type: string
                     type: array
                   targetName:
+                    description: TargetName name of the migrated PVC in the target
+                      cluster
                     type: string
                   targetNamespace:
+                    description: TargetNamespace namespace of the migrated PVC in
+                      the target cluster
                     type: string
                   targetStorageClass:
+                    description: TargetStorageClass storage class of the migrated
+                      PVC in the target cluster
                     type: string
                   uid:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                   verify:
+                    description: Verify set true to verify integrity of the data post
+                      migration
                     type: boolean
                 required:
                 - targetAccessModes

--- a/config/crds/migration.openshift.io_directvolumemigrations.yaml
+++ b/config/crds/migration.openshift.io_directvolumemigrations.yaml
@@ -144,6 +144,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  targetName:
+                    type: string
                   targetNamespace:
                     type: string
                   targetStorageClass:

--- a/config/crds/migration.openshift.io_migplans.yaml
+++ b/config/crds/migration.openshift.io_migplans.yaml
@@ -202,12 +202,73 @@ spec:
                 - serviceAccount
                 type: object
               type: array
+            includedResources:
+              description: IncludedResources optional list of included resources in
+                Velero Backup
+              items:
+                description: GroupKind specifies a Group and a Kind, but does not
+                  force a version.  This is useful for identifying concepts during
+                  lookup stages without having partially valid types
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                required:
+                - group
+                - kind
+                type: object
+              type: array
             indirectImageMigration:
               description: If set True, disables direct image migrations.
               type: boolean
             indirectVolumeMigration:
               description: If set True, disables direct volume migrations.
               type: boolean
+            labelSelector:
+              description: LabelSelector optional label selector on the included resources
+                in Velero Backup
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
             migStorageRef:
               description: 'ObjectReference contains enough information to let you
                 inspect or modify the referred object. --- New uses of this type are

--- a/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
+++ b/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
@@ -26,11 +26,17 @@ import (
 
 type PVCToMigrate struct {
 	*kapi.ObjectReference `json:",inline"`
-	TargetStorageClass    string                            `json:"targetStorageClass"`
-	TargetAccessModes     []kapi.PersistentVolumeAccessMode `json:"targetAccessModes"`
-	TargetNamespace       string                            `json:"targetNamespace,omitempty"`
-	TargetName            string                            `json:"targetName,omitempty"`
-	Verify                bool                              `json:"verify,omitempty"`
+	// TargetStorageClass storage class of the migrated PVC in the target cluster
+	TargetStorageClass string `json:"targetStorageClass"`
+	// TargetAccessModes access modes of the migrated PVC in the target cluster
+	TargetAccessModes []kapi.PersistentVolumeAccessMode `json:"targetAccessModes"`
+	// TargetNamespace namespace of the migrated PVC in the target cluster
+	TargetNamespace string `json:"targetNamespace,omitempty"`
+	// TargetName name of the migrated PVC in the target cluster
+	// +kubebuilder:validation:Optional
+	TargetName string `json:"targetName,omitempty"`
+	// Verify set true to verify integrity of the data post migration
+	Verify bool `json:"verify,omitempty"`
 }
 
 // DirectVolumeMigrationSpec defines the desired state of DirectVolumeMigration

--- a/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
+++ b/pkg/apis/migration/v1alpha1/directvolumemigration_types.go
@@ -29,6 +29,7 @@ type PVCToMigrate struct {
 	TargetStorageClass    string                            `json:"targetStorageClass"`
 	TargetAccessModes     []kapi.PersistentVolumeAccessMode `json:"targetAccessModes"`
 	TargetNamespace       string                            `json:"targetNamespace,omitempty"`
+	TargetName            string                            `json:"targetName,omitempty"`
 	Verify                bool                              `json:"verify,omitempty"`
 }
 

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -90,6 +90,12 @@ type MigPlanSpec struct {
 
 	// If set True, disables direct volume migrations.
 	IndirectVolumeMigration bool `json:"indirectVolumeMigration,omitempty"`
+
+	// IncludedResources optional list of included resources in Velero Backup
+	IncludedResources []*metav1.GroupKind `json:"includedResources,omitempty"`
+
+	// LabelSelector optional label selector on the included resources in Velero Backup
+	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
 }
 
 // MigPlanStatus defines the observed state of MigPlan
@@ -760,6 +766,25 @@ type PVC struct {
 	Name         string                            `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
 	AccessModes  []kapi.PersistentVolumeAccessMode `json:"accessModes,omitempty" protobuf:"bytes,1,rep,name=accessModes,casttype=PersistentVolumeAccessMode"`
 	HasReference bool                              `json:"hasReference,omitempty"`
+}
+
+func (p PVC) GetTargetName() string {
+	names := strings.Split(p.Name, ":")
+	if len(names) > 1 {
+		return names[1]
+	}
+	if len(names) > 0 {
+		return names[0]
+	}
+	return p.Name
+}
+
+func (p PVC) GetSourceName() string {
+	names := strings.Split(p.Name, ":")
+	if len(names) > 0 {
+		return names[0]
+	}
+	return p.Name
 }
 
 // Supported

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -92,9 +92,12 @@ type MigPlanSpec struct {
 	IndirectVolumeMigration bool `json:"indirectVolumeMigration,omitempty"`
 
 	// IncludedResources optional list of included resources in Velero Backup
+	// When not set, all the resources are included in the backup
+	// +kubebuilder:validation:Optional
 	IncludedResources []*metav1.GroupKind `json:"includedResources,omitempty"`
 
 	// LabelSelector optional label selector on the included resources in Velero Backup
+	// +kubebuilder:validation:Optional
 	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
 }
 
@@ -768,6 +771,7 @@ type PVC struct {
 	HasReference bool                              `json:"hasReference,omitempty"`
 }
 
+// GetTargetName returns name of the target PVC
 func (p PVC) GetTargetName() string {
 	names := strings.Split(p.Name, ":")
 	if len(names) > 1 {
@@ -779,6 +783,7 @@ func (p PVC) GetTargetName() string {
 	return p.Name
 }
 
+// GetSourceName returns name of the source PVC
 func (p PVC) GetSourceName() string {
 	names := strings.Split(p.Name, ":")
 	if len(names) > 0 {


### PR DESCRIPTION
This PR introduces two API changes: 

1. MigPlan - Introduces new fields to provide list of included resources in the Backup and an optional Label Selector

2. DirectVolumeMigration - Introduces new fields for TargetName on each PVC