### PR TITLE
removing default move option for glusterfs pvcs

### DIFF
--- a/pkg/controller/migplan/pvlist.go
+++ b/pkg/controller/migplan/pvlist.go
@@ -278,7 +278,6 @@ func (r *ReconcileMigPlan) getSupportedActions(pv core.PersistentVolume, claim m
 	}
 	// TODO: Consider adding Cinder to this default list
 	if pv.Spec.NFS != nil ||
-		pv.Spec.Glusterfs != nil ||
 		pv.Spec.AWSElasticBlockStore != nil {
 		return append(supportedActions,
 			migapi.PvCopyAction,


### PR DESCRIPTION
Disabling default "move" option for glusterfs storage-class PVCs.