### PR TITLE
Swap v1beta1 for v1 crds in preparation for OCP 4.9 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ deploy: manifests
 	kubectl apply -f config/crds
 	kustomize build config/default | kubectl apply -f -
 
-# Provide CRDs that work back to k8s 1.11
-CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
+
+CRD_OPTIONS ?= "crd:crdVersions=v1,trivialVersions=true,preserveUnknownFields=false"
 
 # Generate manifests e.g. CRD, Webhooks
 manifests:

--- a/config/crds/migration.openshift.io_directimagemigrations.yaml
+++ b/config/crds/migration.openshift.io_directimagemigrations.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -16,623 +16,632 @@ spec:
     shortNames:
     - dim
     singular: directimagemigration
-  preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: DirectImageMigration is the Schema for the directimagemigrations
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: DirectImageMigrationSpec defines the desired state of DirectImageMigration
-          properties:
-            destMigClusterRef:
-              description: 'ObjectReference contains enough information to let you
-                inspect or modify the referred object. --- New uses of this type are
-                discouraged because of difficulty describing its usage when embedded
-                in APIs.  1. Ignored fields.  It includes many fields which are not
-                generally honored.  For instance, ResourceVersion and FieldPath are
-                both very rarely valid in actual usage.  2. Invalid usage help.  It
-                is impossible to add specific help for individual usage.  In most
-                embedded usages, there are particular     restrictions like, "must
-                refer only to types A and B" or "UID not honored" or "name must be
-                restricted".     Those cannot be well described when embedded.  3.
-                Inconsistent validation.  Because the usages are different, the validation
-                rules are different by usage, which makes it hard for users to predict
-                what will happen.  4. The fields are both imprecise and overly precise.  Kind
-                is not a precise mapping to a URL. This can produce ambiguity     during
-                interpretation and require a REST mapping.  In most cases, the dependency
-                is on the group,resource tuple     and the version of the actual struct
-                is irrelevant.  5. We cannot easily change it.  Because this type
-                is embedded in many locations, updates to this type     will affect
-                numerous schemas.  Don''t make new APIs embed an underspecified API
-                type they do not control. Instead of using this type, create a locally
-                provided and used type that is well-focused on your reference. For
-                example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                .'
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            namespaces:
-              description: Holds names of all namespaces to run DIM to get all the
-                imagestreams in these namespaces.
-              items:
-                type: string
-              type: array
-            srcMigClusterRef:
-              description: 'ObjectReference contains enough information to let you
-                inspect or modify the referred object. --- New uses of this type are
-                discouraged because of difficulty describing its usage when embedded
-                in APIs.  1. Ignored fields.  It includes many fields which are not
-                generally honored.  For instance, ResourceVersion and FieldPath are
-                both very rarely valid in actual usage.  2. Invalid usage help.  It
-                is impossible to add specific help for individual usage.  In most
-                embedded usages, there are particular     restrictions like, "must
-                refer only to types A and B" or "UID not honored" or "name must be
-                restricted".     Those cannot be well described when embedded.  3.
-                Inconsistent validation.  Because the usages are different, the validation
-                rules are different by usage, which makes it hard for users to predict
-                what will happen.  4. The fields are both imprecise and overly precise.  Kind
-                is not a precise mapping to a URL. This can produce ambiguity     during
-                interpretation and require a REST mapping.  In most cases, the dependency
-                is on the group,resource tuple     and the version of the actual struct
-                is irrelevant.  5. We cannot easily change it.  Because this type
-                is embedded in many locations, updates to this type     will affect
-                numerous schemas.  Don''t make new APIs embed an underspecified API
-                type they do not control. Instead of using this type, create a locally
-                provided and used type that is well-focused on your reference. For
-                example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                .'
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-          type: object
-        status:
-          description: DirectImageMigrationStatus defines the observed state of DirectImageMigration
-          properties:
-            conditions:
-              items:
-                description: Condition Type - The condition type. Status - The condition
-                  status. Reason - The reason for the condition. Message - The human
-                  readable description of the condition. Durable - The condition is
-                  not un-staged. Items - A list of `items` associated with the condition
-                  used to replace [] in `Message`. staging - A condition has been
-                  explicitly set/updated.
-                properties:
-                  category:
-                    type: string
-                  durable:
-                    type: boolean
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                required:
-                - category
-                - lastTransitionTime
-                - status
-                - type
-                type: object
-              type: array
-            deletedISs:
-              items:
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  destNamespace:
-                    type: string
-                  directMigration:
-                    description: 'ObjectReference contains enough information to let
-                      you inspect or modify the referred object. --- New uses of this
-                      type are discouraged because of difficulty describing its usage
-                      when embedded in APIs.  1. Ignored fields.  It includes many
-                      fields which are not generally honored.  For instance, ResourceVersion
-                      and FieldPath are both very rarely valid in actual usage.  2.
-                      Invalid usage help.  It is impossible to add specific help for
-                      individual usage.  In most embedded usages, there are particular     restrictions
-                      like, "must refer only to types A and B" or "UID not honored"
-                      or "name must be restricted".     Those cannot be well described
-                      when embedded.  3. Inconsistent validation.  Because the usages
-                      are different, the validation rules are different by usage,
-                      which makes it hard for users to predict what will happen.  4.
-                      The fields are both imprecise and overly precise.  Kind is not
-                      a precise mapping to a URL. This can produce ambiguity     during
-                      interpretation and require a REST mapping.  In most cases, the
-                      dependency is on the group,resource tuple     and the version
-                      of the actual struct is irrelevant.  5. We cannot easily change
-                      it.  Because this type is embedded in many locations, updates
-                      to this type     will affect numerous schemas.  Don''t make
-                      new APIs embed an underspecified API type they do not control.
-                      Instead of using this type, create a locally provided and used
-                      type that is well-focused on your reference. For example, ServiceReferences
-                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                      .'
-                    properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
-                        type: string
-                      kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                        type: string
-                      resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                        type: string
-                      uid:
-                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                        type: string
-                    type: object
-                  errors:
-                    items:
-                      type: string
-                    type: array
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  notFound:
-                    type: boolean
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              type: array
-            errors:
-              items:
-                type: string
-              type: array
-            failedISs:
-              items:
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  destNamespace:
-                    type: string
-                  directMigration:
-                    description: 'ObjectReference contains enough information to let
-                      you inspect or modify the referred object. --- New uses of this
-                      type are discouraged because of difficulty describing its usage
-                      when embedded in APIs.  1. Ignored fields.  It includes many
-                      fields which are not generally honored.  For instance, ResourceVersion
-                      and FieldPath are both very rarely valid in actual usage.  2.
-                      Invalid usage help.  It is impossible to add specific help for
-                      individual usage.  In most embedded usages, there are particular     restrictions
-                      like, "must refer only to types A and B" or "UID not honored"
-                      or "name must be restricted".     Those cannot be well described
-                      when embedded.  3. Inconsistent validation.  Because the usages
-                      are different, the validation rules are different by usage,
-                      which makes it hard for users to predict what will happen.  4.
-                      The fields are both imprecise and overly precise.  Kind is not
-                      a precise mapping to a URL. This can produce ambiguity     during
-                      interpretation and require a REST mapping.  In most cases, the
-                      dependency is on the group,resource tuple     and the version
-                      of the actual struct is irrelevant.  5. We cannot easily change
-                      it.  Because this type is embedded in many locations, updates
-                      to this type     will affect numerous schemas.  Don''t make
-                      new APIs embed an underspecified API type they do not control.
-                      Instead of using this type, create a locally provided and used
-                      type that is well-focused on your reference. For example, ServiceReferences
-                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                      .'
-                    properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
-                        type: string
-                      kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                        type: string
-                      resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                        type: string
-                      uid:
-                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                        type: string
-                    type: object
-                  errors:
-                    items:
-                      type: string
-                    type: array
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  notFound:
-                    type: boolean
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              type: array
-            itinerary:
-              type: string
-            newISs:
-              items:
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  destNamespace:
-                    type: string
-                  directMigration:
-                    description: 'ObjectReference contains enough information to let
-                      you inspect or modify the referred object. --- New uses of this
-                      type are discouraged because of difficulty describing its usage
-                      when embedded in APIs.  1. Ignored fields.  It includes many
-                      fields which are not generally honored.  For instance, ResourceVersion
-                      and FieldPath are both very rarely valid in actual usage.  2.
-                      Invalid usage help.  It is impossible to add specific help for
-                      individual usage.  In most embedded usages, there are particular     restrictions
-                      like, "must refer only to types A and B" or "UID not honored"
-                      or "name must be restricted".     Those cannot be well described
-                      when embedded.  3. Inconsistent validation.  Because the usages
-                      are different, the validation rules are different by usage,
-                      which makes it hard for users to predict what will happen.  4.
-                      The fields are both imprecise and overly precise.  Kind is not
-                      a precise mapping to a URL. This can produce ambiguity     during
-                      interpretation and require a REST mapping.  In most cases, the
-                      dependency is on the group,resource tuple     and the version
-                      of the actual struct is irrelevant.  5. We cannot easily change
-                      it.  Because this type is embedded in many locations, updates
-                      to this type     will affect numerous schemas.  Don''t make
-                      new APIs embed an underspecified API type they do not control.
-                      Instead of using this type, create a locally provided and used
-                      type that is well-focused on your reference. For example, ServiceReferences
-                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                      .'
-                    properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
-                        type: string
-                      kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                        type: string
-                      resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                        type: string
-                      uid:
-                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                        type: string
-                    type: object
-                  errors:
-                    items:
-                      type: string
-                    type: array
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  notFound:
-                    type: boolean
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              type: array
-            observedDigest:
-              type: string
-            phase:
-              type: string
-            startTimestamp:
-              format: date-time
-              type: string
-            successfulISs:
-              items:
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  destNamespace:
-                    type: string
-                  directMigration:
-                    description: 'ObjectReference contains enough information to let
-                      you inspect or modify the referred object. --- New uses of this
-                      type are discouraged because of difficulty describing its usage
-                      when embedded in APIs.  1. Ignored fields.  It includes many
-                      fields which are not generally honored.  For instance, ResourceVersion
-                      and FieldPath are both very rarely valid in actual usage.  2.
-                      Invalid usage help.  It is impossible to add specific help for
-                      individual usage.  In most embedded usages, there are particular     restrictions
-                      like, "must refer only to types A and B" or "UID not honored"
-                      or "name must be restricted".     Those cannot be well described
-                      when embedded.  3. Inconsistent validation.  Because the usages
-                      are different, the validation rules are different by usage,
-                      which makes it hard for users to predict what will happen.  4.
-                      The fields are both imprecise and overly precise.  Kind is not
-                      a precise mapping to a URL. This can produce ambiguity     during
-                      interpretation and require a REST mapping.  In most cases, the
-                      dependency is on the group,resource tuple     and the version
-                      of the actual struct is irrelevant.  5. We cannot easily change
-                      it.  Because this type is embedded in many locations, updates
-                      to this type     will affect numerous schemas.  Don''t make
-                      new APIs embed an underspecified API type they do not control.
-                      Instead of using this type, create a locally provided and used
-                      type that is well-focused on your reference. For example, ServiceReferences
-                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                      .'
-                    properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
-                        type: string
-                      kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                        type: string
-                      resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                        type: string
-                      uid:
-                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                        type: string
-                    type: object
-                  errors:
-                    items:
-                      type: string
-                    type: array
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  notFound:
-                    type: boolean
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DirectImageMigration is the Schema for the directimagemigrations
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DirectImageMigrationSpec defines the desired state of DirectImageMigration
+            properties:
+              destMigClusterRef:
+                description: 'ObjectReference contains enough information to let you
+                  inspect or modify the referred object. --- New uses of this type
+                  are discouraged because of difficulty describing its usage when
+                  embedded in APIs.  1. Ignored fields.  It includes many fields which
+                  are not generally honored.  For instance, ResourceVersion and FieldPath
+                  are both very rarely valid in actual usage.  2. Invalid usage help.  It
+                  is impossible to add specific help for individual usage.  In most
+                  embedded usages, there are particular     restrictions like, "must
+                  refer only to types A and B" or "UID not honored" or "name must
+                  be restricted".     Those cannot be well described when embedded.  3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen.  4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity     during interpretation and require a REST
+                  mapping.  In most cases, the dependency is on the group,resource
+                  tuple     and the version of the actual struct is irrelevant.  5.
+                  We cannot easily change it.  Because this type is embedded in many
+                  locations, updates to this type     will affect numerous schemas.  Don''t
+                  make new APIs embed an underspecified API type they do not control.
+                  Instead of using this type, create a locally provided and used type
+                  that is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  .'
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              namespaces:
+                description: Holds names of all namespaces to run DIM to get all the
+                  imagestreams in these namespaces.
+                items:
+                  type: string
+                type: array
+              srcMigClusterRef:
+                description: 'ObjectReference contains enough information to let you
+                  inspect or modify the referred object. --- New uses of this type
+                  are discouraged because of difficulty describing its usage when
+                  embedded in APIs.  1. Ignored fields.  It includes many fields which
+                  are not generally honored.  For instance, ResourceVersion and FieldPath
+                  are both very rarely valid in actual usage.  2. Invalid usage help.  It
+                  is impossible to add specific help for individual usage.  In most
+                  embedded usages, there are particular     restrictions like, "must
+                  refer only to types A and B" or "UID not honored" or "name must
+                  be restricted".     Those cannot be well described when embedded.  3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen.  4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity     during interpretation and require a REST
+                  mapping.  In most cases, the dependency is on the group,resource
+                  tuple     and the version of the actual struct is irrelevant.  5.
+                  We cannot easily change it.  Because this type is embedded in many
+                  locations, updates to this type     will affect numerous schemas.  Don''t
+                  make new APIs embed an underspecified API type they do not control.
+                  Instead of using this type, create a locally provided and used type
+                  that is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  .'
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+            type: object
+          status:
+            description: DirectImageMigrationStatus defines the observed state of
+              DirectImageMigration
+            properties:
+              conditions:
+                items:
+                  description: Condition Type - The condition type. Status - The condition
+                    status. Reason - The reason for the condition. Message - The human
+                    readable description of the condition. Durable - The condition
+                    is not un-staged. Items - A list of `items` associated with the
+                    condition used to replace [] in `Message`. staging - A condition
+                    has been explicitly set/updated.
+                  properties:
+                    category:
+                      type: string
+                    durable:
+                      type: boolean
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              deletedISs:
+                items:
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    destNamespace:
+                      type: string
+                    directMigration:
+                      description: 'ObjectReference contains enough information to
+                        let you inspect or modify the referred object. --- New uses
+                        of this type are discouraged because of difficulty describing
+                        its usage when embedded in APIs.  1. Ignored fields.  It includes
+                        many fields which are not generally honored.  For instance,
+                        ResourceVersion and FieldPath are both very rarely valid in
+                        actual usage.  2. Invalid usage help.  It is impossible to
+                        add specific help for individual usage.  In most embedded
+                        usages, there are particular     restrictions like, "must
+                        refer only to types A and B" or "UID not honored" or "name
+                        must be restricted".     Those cannot be well described when
+                        embedded.  3. Inconsistent validation.  Because the usages
+                        are different, the validation rules are different by usage,
+                        which makes it hard for users to predict what will happen.  4.
+                        The fields are both imprecise and overly precise.  Kind is
+                        not a precise mapping to a URL. This can produce ambiguity     during
+                        interpretation and require a REST mapping.  In most cases,
+                        the dependency is on the group,resource tuple     and the
+                        version of the actual struct is irrelevant.  5. We cannot
+                        easily change it.  Because this type is embedded in many locations,
+                        updates to this type     will affect numerous schemas.  Don''t
+                        make new APIs embed an underspecified API type they do not
+                        control. Instead of using this type, create a locally provided
+                        and used type that is well-focused on your reference. For
+                        example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                        .'
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                    errors:
+                      items:
+                        type: string
+                      type: array
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    notFound:
+                      type: boolean
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              errors:
+                items:
+                  type: string
+                type: array
+              failedISs:
+                items:
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    destNamespace:
+                      type: string
+                    directMigration:
+                      description: 'ObjectReference contains enough information to
+                        let you inspect or modify the referred object. --- New uses
+                        of this type are discouraged because of difficulty describing
+                        its usage when embedded in APIs.  1. Ignored fields.  It includes
+                        many fields which are not generally honored.  For instance,
+                        ResourceVersion and FieldPath are both very rarely valid in
+                        actual usage.  2. Invalid usage help.  It is impossible to
+                        add specific help for individual usage.  In most embedded
+                        usages, there are particular     restrictions like, "must
+                        refer only to types A and B" or "UID not honored" or "name
+                        must be restricted".     Those cannot be well described when
+                        embedded.  3. Inconsistent validation.  Because the usages
+                        are different, the validation rules are different by usage,
+                        which makes it hard for users to predict what will happen.  4.
+                        The fields are both imprecise and overly precise.  Kind is
+                        not a precise mapping to a URL. This can produce ambiguity     during
+                        interpretation and require a REST mapping.  In most cases,
+                        the dependency is on the group,resource tuple     and the
+                        version of the actual struct is irrelevant.  5. We cannot
+                        easily change it.  Because this type is embedded in many locations,
+                        updates to this type     will affect numerous schemas.  Don''t
+                        make new APIs embed an underspecified API type they do not
+                        control. Instead of using this type, create a locally provided
+                        and used type that is well-focused on your reference. For
+                        example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                        .'
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                    errors:
+                      items:
+                        type: string
+                      type: array
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    notFound:
+                      type: boolean
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              itinerary:
+                type: string
+              newISs:
+                items:
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    destNamespace:
+                      type: string
+                    directMigration:
+                      description: 'ObjectReference contains enough information to
+                        let you inspect or modify the referred object. --- New uses
+                        of this type are discouraged because of difficulty describing
+                        its usage when embedded in APIs.  1. Ignored fields.  It includes
+                        many fields which are not generally honored.  For instance,
+                        ResourceVersion and FieldPath are both very rarely valid in
+                        actual usage.  2. Invalid usage help.  It is impossible to
+                        add specific help for individual usage.  In most embedded
+                        usages, there are particular     restrictions like, "must
+                        refer only to types A and B" or "UID not honored" or "name
+                        must be restricted".     Those cannot be well described when
+                        embedded.  3. Inconsistent validation.  Because the usages
+                        are different, the validation rules are different by usage,
+                        which makes it hard for users to predict what will happen.  4.
+                        The fields are both imprecise and overly precise.  Kind is
+                        not a precise mapping to a URL. This can produce ambiguity     during
+                        interpretation and require a REST mapping.  In most cases,
+                        the dependency is on the group,resource tuple     and the
+                        version of the actual struct is irrelevant.  5. We cannot
+                        easily change it.  Because this type is embedded in many locations,
+                        updates to this type     will affect numerous schemas.  Don''t
+                        make new APIs embed an underspecified API type they do not
+                        control. Instead of using this type, create a locally provided
+                        and used type that is well-focused on your reference. For
+                        example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                        .'
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                    errors:
+                      items:
+                        type: string
+                      type: array
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    notFound:
+                      type: boolean
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              observedDigest:
+                type: string
+              phase:
+                type: string
+              startTimestamp:
+                format: date-time
+                type: string
+              successfulISs:
+                items:
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    destNamespace:
+                      type: string
+                    directMigration:
+                      description: 'ObjectReference contains enough information to
+                        let you inspect or modify the referred object. --- New uses
+                        of this type are discouraged because of difficulty describing
+                        its usage when embedded in APIs.  1. Ignored fields.  It includes
+                        many fields which are not generally honored.  For instance,
+                        ResourceVersion and FieldPath are both very rarely valid in
+                        actual usage.  2. Invalid usage help.  It is impossible to
+                        add specific help for individual usage.  In most embedded
+                        usages, there are particular     restrictions like, "must
+                        refer only to types A and B" or "UID not honored" or "name
+                        must be restricted".     Those cannot be well described when
+                        embedded.  3. Inconsistent validation.  Because the usages
+                        are different, the validation rules are different by usage,
+                        which makes it hard for users to predict what will happen.  4.
+                        The fields are both imprecise and overly precise.  Kind is
+                        not a precise mapping to a URL. This can produce ambiguity     during
+                        interpretation and require a REST mapping.  In most cases,
+                        the dependency is on the group,resource tuple     and the
+                        version of the actual struct is irrelevant.  5. We cannot
+                        easily change it.  Because this type is embedded in many locations,
+                        updates to this type     will affect numerous schemas.  Don''t
+                        make new APIs embed an underspecified API type they do not
+                        control. Instead of using this type, create a locally provided
+                        and used type that is well-focused on your reference. For
+                        example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                        .'
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                    errors:
+                      items:
+                        type: string
+                      type: array
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    notFound:
+                      type: boolean
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
     served: true
     storage: true
 status:

--- a/config/crds/migration.openshift.io_directimagestreammigrations.yaml
+++ b/config/crds/migration.openshift.io_directimagestreammigrations.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -16,261 +16,262 @@ spec:
     shortNames:
     - dism
     singular: directimagestreammigration
-  preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: DirectImageStreamMigration is the Schema for the directimagestreammigrations
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: DirectImageStreamMigrationSpec defines the desired state of
-            DirectImageStreamMigration
-          properties:
-            destMigClusterRef:
-              description: 'ObjectReference contains enough information to let you
-                inspect or modify the referred object. --- New uses of this type are
-                discouraged because of difficulty describing its usage when embedded
-                in APIs.  1. Ignored fields.  It includes many fields which are not
-                generally honored.  For instance, ResourceVersion and FieldPath are
-                both very rarely valid in actual usage.  2. Invalid usage help.  It
-                is impossible to add specific help for individual usage.  In most
-                embedded usages, there are particular     restrictions like, "must
-                refer only to types A and B" or "UID not honored" or "name must be
-                restricted".     Those cannot be well described when embedded.  3.
-                Inconsistent validation.  Because the usages are different, the validation
-                rules are different by usage, which makes it hard for users to predict
-                what will happen.  4. The fields are both imprecise and overly precise.  Kind
-                is not a precise mapping to a URL. This can produce ambiguity     during
-                interpretation and require a REST mapping.  In most cases, the dependency
-                is on the group,resource tuple     and the version of the actual struct
-                is irrelevant.  5. We cannot easily change it.  Because this type
-                is embedded in many locations, updates to this type     will affect
-                numerous schemas.  Don''t make new APIs embed an underspecified API
-                type they do not control. Instead of using this type, create a locally
-                provided and used type that is well-focused on your reference. For
-                example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                .'
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            destNamespace:
-              description: ' Holds the name of the namespace on destination cluster
-                where imagestreams should be migrated.'
-              type: string
-            imageStreamRef:
-              description: 'ObjectReference contains enough information to let you
-                inspect or modify the referred object. --- New uses of this type are
-                discouraged because of difficulty describing its usage when embedded
-                in APIs.  1. Ignored fields.  It includes many fields which are not
-                generally honored.  For instance, ResourceVersion and FieldPath are
-                both very rarely valid in actual usage.  2. Invalid usage help.  It
-                is impossible to add specific help for individual usage.  In most
-                embedded usages, there are particular     restrictions like, "must
-                refer only to types A and B" or "UID not honored" or "name must be
-                restricted".     Those cannot be well described when embedded.  3.
-                Inconsistent validation.  Because the usages are different, the validation
-                rules are different by usage, which makes it hard for users to predict
-                what will happen.  4. The fields are both imprecise and overly precise.  Kind
-                is not a precise mapping to a URL. This can produce ambiguity     during
-                interpretation and require a REST mapping.  In most cases, the dependency
-                is on the group,resource tuple     and the version of the actual struct
-                is irrelevant.  5. We cannot easily change it.  Because this type
-                is embedded in many locations, updates to this type     will affect
-                numerous schemas.  Don''t make new APIs embed an underspecified API
-                type they do not control. Instead of using this type, create a locally
-                provided and used type that is well-focused on your reference. For
-                example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                .'
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            srcMigClusterRef:
-              description: 'ObjectReference contains enough information to let you
-                inspect or modify the referred object. --- New uses of this type are
-                discouraged because of difficulty describing its usage when embedded
-                in APIs.  1. Ignored fields.  It includes many fields which are not
-                generally honored.  For instance, ResourceVersion and FieldPath are
-                both very rarely valid in actual usage.  2. Invalid usage help.  It
-                is impossible to add specific help for individual usage.  In most
-                embedded usages, there are particular     restrictions like, "must
-                refer only to types A and B" or "UID not honored" or "name must be
-                restricted".     Those cannot be well described when embedded.  3.
-                Inconsistent validation.  Because the usages are different, the validation
-                rules are different by usage, which makes it hard for users to predict
-                what will happen.  4. The fields are both imprecise and overly precise.  Kind
-                is not a precise mapping to a URL. This can produce ambiguity     during
-                interpretation and require a REST mapping.  In most cases, the dependency
-                is on the group,resource tuple     and the version of the actual struct
-                is irrelevant.  5. We cannot easily change it.  Because this type
-                is embedded in many locations, updates to this type     will affect
-                numerous schemas.  Don''t make new APIs embed an underspecified API
-                type they do not control. Instead of using this type, create a locally
-                provided and used type that is well-focused on your reference. For
-                example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                .'
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-          type: object
-        status:
-          description: DirectImageStreamMigrationStatus defines the observed state
-            of DirectImageStreamMigration
-          properties:
-            conditions:
-              items:
-                description: Condition Type - The condition type. Status - The condition
-                  status. Reason - The reason for the condition. Message - The human
-                  readable description of the condition. Durable - The condition is
-                  not un-staged. Items - A list of `items` associated with the condition
-                  used to replace [] in `Message`. staging - A condition has been
-                  explicitly set/updated.
-                properties:
-                  category:
-                    type: string
-                  durable:
-                    type: boolean
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                required:
-                - category
-                - lastTransitionTime
-                - status
-                - type
-                type: object
-              type: array
-            errors:
-              items:
-                type: string
-              type: array
-            itinerary:
-              type: string
-            observedDigest:
-              type: string
-            phase:
-              type: string
-            startTimestamp:
-              format: date-time
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DirectImageStreamMigration is the Schema for the directimagestreammigrations
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DirectImageStreamMigrationSpec defines the desired state
+              of DirectImageStreamMigration
+            properties:
+              destMigClusterRef:
+                description: 'ObjectReference contains enough information to let you
+                  inspect or modify the referred object. --- New uses of this type
+                  are discouraged because of difficulty describing its usage when
+                  embedded in APIs.  1. Ignored fields.  It includes many fields which
+                  are not generally honored.  For instance, ResourceVersion and FieldPath
+                  are both very rarely valid in actual usage.  2. Invalid usage help.  It
+                  is impossible to add specific help for individual usage.  In most
+                  embedded usages, there are particular     restrictions like, "must
+                  refer only to types A and B" or "UID not honored" or "name must
+                  be restricted".     Those cannot be well described when embedded.  3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen.  4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity     during interpretation and require a REST
+                  mapping.  In most cases, the dependency is on the group,resource
+                  tuple     and the version of the actual struct is irrelevant.  5.
+                  We cannot easily change it.  Because this type is embedded in many
+                  locations, updates to this type     will affect numerous schemas.  Don''t
+                  make new APIs embed an underspecified API type they do not control.
+                  Instead of using this type, create a locally provided and used type
+                  that is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  .'
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              destNamespace:
+                description: ' Holds the name of the namespace on destination cluster
+                  where imagestreams should be migrated.'
+                type: string
+              imageStreamRef:
+                description: 'ObjectReference contains enough information to let you
+                  inspect or modify the referred object. --- New uses of this type
+                  are discouraged because of difficulty describing its usage when
+                  embedded in APIs.  1. Ignored fields.  It includes many fields which
+                  are not generally honored.  For instance, ResourceVersion and FieldPath
+                  are both very rarely valid in actual usage.  2. Invalid usage help.  It
+                  is impossible to add specific help for individual usage.  In most
+                  embedded usages, there are particular     restrictions like, "must
+                  refer only to types A and B" or "UID not honored" or "name must
+                  be restricted".     Those cannot be well described when embedded.  3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen.  4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity     during interpretation and require a REST
+                  mapping.  In most cases, the dependency is on the group,resource
+                  tuple     and the version of the actual struct is irrelevant.  5.
+                  We cannot easily change it.  Because this type is embedded in many
+                  locations, updates to this type     will affect numerous schemas.  Don''t
+                  make new APIs embed an underspecified API type they do not control.
+                  Instead of using this type, create a locally provided and used type
+                  that is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  .'
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              srcMigClusterRef:
+                description: 'ObjectReference contains enough information to let you
+                  inspect or modify the referred object. --- New uses of this type
+                  are discouraged because of difficulty describing its usage when
+                  embedded in APIs.  1. Ignored fields.  It includes many fields which
+                  are not generally honored.  For instance, ResourceVersion and FieldPath
+                  are both very rarely valid in actual usage.  2. Invalid usage help.  It
+                  is impossible to add specific help for individual usage.  In most
+                  embedded usages, there are particular     restrictions like, "must
+                  refer only to types A and B" or "UID not honored" or "name must
+                  be restricted".     Those cannot be well described when embedded.  3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen.  4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity     during interpretation and require a REST
+                  mapping.  In most cases, the dependency is on the group,resource
+                  tuple     and the version of the actual struct is irrelevant.  5.
+                  We cannot easily change it.  Because this type is embedded in many
+                  locations, updates to this type     will affect numerous schemas.  Don''t
+                  make new APIs embed an underspecified API type they do not control.
+                  Instead of using this type, create a locally provided and used type
+                  that is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  .'
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+            type: object
+          status:
+            description: DirectImageStreamMigrationStatus defines the observed state
+              of DirectImageStreamMigration
+            properties:
+              conditions:
+                items:
+                  description: Condition Type - The condition type. Status - The condition
+                    status. Reason - The reason for the condition. Message - The human
+                    readable description of the condition. Durable - The condition
+                    is not un-staged. Items - A list of `items` associated with the
+                    condition used to replace [] in `Message`. staging - A condition
+                    has been explicitly set/updated.
+                  properties:
+                    category:
+                      type: string
+                    durable:
+                      type: boolean
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              errors:
+                items:
+                  type: string
+                type: array
+              itinerary:
+                type: string
+              observedDigest:
+                type: string
+              phase:
+                type: string
+              startTimestamp:
+                format: date-time
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
 status:

--- a/config/crds/migration.openshift.io_directvolumemigrationprogresses.yaml
+++ b/config/crds/migration.openshift.io_directvolumemigrationprogresses.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,25 +8,6 @@ metadata:
   creationTimestamp: null
   name: directvolumemigrationprogresses.migration.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.clusterRef.name
-    name: Cluster
-    type: string
-  - JSONPath: .status.podName
-    name: Pod Name
-    type: string
-  - JSONPath: .spec.podNamespace
-    name: Pod Namespace
-    type: string
-  - JSONPath: .status.totalProgressPercentage
-    name: Progress Percent
-    type: string
-  - JSONPath: .status.lastObservedTransferRate
-    name: Transfer Rate
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: migration.openshift.io
   names:
     kind: DirectVolumeMigrationProgress
@@ -35,265 +16,285 @@ spec:
     shortNames:
     - dvmp
     singular: directvolumemigrationprogress
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: DirectVolumeMigrationProgress is the Schema for the directvolumemigrationprogresses
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: DirectVolumeMigrationProgressSpec defines the desired state
-            of DirectVolumeMigrationProgress
-          properties:
-            clusterRef:
-              description: 'ObjectReference contains enough information to let you
-                inspect or modify the referred object. --- New uses of this type are
-                discouraged because of difficulty describing its usage when embedded
-                in APIs.  1. Ignored fields.  It includes many fields which are not
-                generally honored.  For instance, ResourceVersion and FieldPath are
-                both very rarely valid in actual usage.  2. Invalid usage help.  It
-                is impossible to add specific help for individual usage.  In most
-                embedded usages, there are particular     restrictions like, "must
-                refer only to types A and B" or "UID not honored" or "name must be
-                restricted".     Those cannot be well described when embedded.  3.
-                Inconsistent validation.  Because the usages are different, the validation
-                rules are different by usage, which makes it hard for users to predict
-                what will happen.  4. The fields are both imprecise and overly precise.  Kind
-                is not a precise mapping to a URL. This can produce ambiguity     during
-                interpretation and require a REST mapping.  In most cases, the dependency
-                is on the group,resource tuple     and the version of the actual struct
-                is irrelevant.  5. We cannot easily change it.  Because this type
-                is embedded in many locations, updates to this type     will affect
-                numerous schemas.  Don''t make new APIs embed an underspecified API
-                type they do not control. Instead of using this type, create a locally
-                provided and used type that is well-focused on your reference. For
-                example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                .'
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            podNamespace:
-              type: string
-            podRef:
-              description: 'ObjectReference contains enough information to let you
-                inspect or modify the referred object. --- New uses of this type are
-                discouraged because of difficulty describing its usage when embedded
-                in APIs.  1. Ignored fields.  It includes many fields which are not
-                generally honored.  For instance, ResourceVersion and FieldPath are
-                both very rarely valid in actual usage.  2. Invalid usage help.  It
-                is impossible to add specific help for individual usage.  In most
-                embedded usages, there are particular     restrictions like, "must
-                refer only to types A and B" or "UID not honored" or "name must be
-                restricted".     Those cannot be well described when embedded.  3.
-                Inconsistent validation.  Because the usages are different, the validation
-                rules are different by usage, which makes it hard for users to predict
-                what will happen.  4. The fields are both imprecise and overly precise.  Kind
-                is not a precise mapping to a URL. This can produce ambiguity     during
-                interpretation and require a REST mapping.  In most cases, the dependency
-                is on the group,resource tuple     and the version of the actual struct
-                is irrelevant.  5. We cannot easily change it.  Because this type
-                is embedded in many locations, updates to this type     will affect
-                numerous schemas.  Don''t make new APIs embed an underspecified API
-                type they do not control. Instead of using this type, create a locally
-                provided and used type that is well-focused on your reference. For
-                example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                .'
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            podSelector:
-              additionalProperties:
-                type: string
-              type: object
-          type: object
-        status:
-          description: DirectVolumeMigrationProgressStatus defines the observed state
-            of DirectVolumeMigrationProgress
-          properties:
-            conditions:
-              items:
-                description: Condition Type - The condition type. Status - The condition
-                  status. Reason - The reason for the condition. Message - The human
-                  readable description of the condition. Durable - The condition is
-                  not un-staged. Items - A list of `items` associated with the condition
-                  used to replace [] in `Message`. staging - A condition has been
-                  explicitly set/updated.
-                properties:
-                  category:
-                    type: string
-                  durable:
-                    type: boolean
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                required:
-                - category
-                - lastTransitionTime
-                - status
-                - type
-                type: object
-              type: array
-            containerElapsedTime:
-              description: ContainerElapsedTime total execution time of Rsync Pod
-              type: string
-            creationTimestamp:
-              description: CreationTimestamp pod creation time
-              format: date-time
-              type: string
-            exitCode:
-              description: ExitCode exit code of terminated Rsync Pod
-              format: int32
-              type: integer
-            lastObservedProgressPercent:
-              description: LastObservedProgressPercent progress of Rsync in percentage
-              type: string
-            lastObservedTransferRate:
-              description: LastObservedTransferRate rate of transfer of Rsync
-              type: string
-            logMessage:
-              description: LogMessage few lines of tailed log of the Rsync Pod
-              type: string
-            observedDigest:
-              type: string
-            phase:
-              description: PodPhase phase of the Rsync Pod
-              type: string
-            podName:
-              description: PodName name of the Rsync Pod
-              type: string
-            rsyncElapsedTime:
-              description: RsyncElapsedTime total elapsed time of Rsync operation
-              type: string
-            rsyncPodStatuses:
-              description: RsyncPodStatuses history of all Rsync attempts
-              items:
-                description: RsyncPodStatus defines observed state of an Rsync attempt
-                properties:
-                  containerElapsedTime:
-                    description: ContainerElapsedTime total execution time of Rsync
-                      Pod
-                    type: string
-                  creationTimestamp:
-                    description: CreationTimestamp pod creation time
-                    format: date-time
-                    type: string
-                  exitCode:
-                    description: ExitCode exit code of terminated Rsync Pod
-                    format: int32
-                    type: integer
-                  lastObservedProgressPercent:
-                    description: LastObservedProgressPercent progress of Rsync in
-                      percentage
-                    type: string
-                  lastObservedTransferRate:
-                    description: LastObservedTransferRate rate of transfer of Rsync
-                    type: string
-                  logMessage:
-                    description: LogMessage few lines of tailed log of the Rsync Pod
-                    type: string
-                  phase:
-                    description: PodPhase phase of the Rsync Pod
-                    type: string
-                  podName:
-                    description: PodName name of the Rsync Pod
-                    type: string
-                type: object
-              type: array
-            totalProgressPercentage:
-              description: TotalProgressPercentage cumulative percentage of all Rsync
-                attempts
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.clusterRef.name
+      name: Cluster
+      type: string
+    - jsonPath: .status.podName
+      name: Pod Name
+      type: string
+    - jsonPath: .spec.podNamespace
+      name: Pod Namespace
+      type: string
+    - jsonPath: .status.totalProgressPercentage
+      name: Progress Percent
+      type: string
+    - jsonPath: .status.lastObservedTransferRate
+      name: Transfer Rate
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DirectVolumeMigrationProgress is the Schema for the directvolumemigrationprogresses
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DirectVolumeMigrationProgressSpec defines the desired state
+              of DirectVolumeMigrationProgress
+            properties:
+              clusterRef:
+                description: 'ObjectReference contains enough information to let you
+                  inspect or modify the referred object. --- New uses of this type
+                  are discouraged because of difficulty describing its usage when
+                  embedded in APIs.  1. Ignored fields.  It includes many fields which
+                  are not generally honored.  For instance, ResourceVersion and FieldPath
+                  are both very rarely valid in actual usage.  2. Invalid usage help.  It
+                  is impossible to add specific help for individual usage.  In most
+                  embedded usages, there are particular     restrictions like, "must
+                  refer only to types A and B" or "UID not honored" or "name must
+                  be restricted".     Those cannot be well described when embedded.  3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen.  4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity     during interpretation and require a REST
+                  mapping.  In most cases, the dependency is on the group,resource
+                  tuple     and the version of the actual struct is irrelevant.  5.
+                  We cannot easily change it.  Because this type is embedded in many
+                  locations, updates to this type     will affect numerous schemas.  Don''t
+                  make new APIs embed an underspecified API type they do not control.
+                  Instead of using this type, create a locally provided and used type
+                  that is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  .'
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              podNamespace:
+                type: string
+              podRef:
+                description: 'ObjectReference contains enough information to let you
+                  inspect or modify the referred object. --- New uses of this type
+                  are discouraged because of difficulty describing its usage when
+                  embedded in APIs.  1. Ignored fields.  It includes many fields which
+                  are not generally honored.  For instance, ResourceVersion and FieldPath
+                  are both very rarely valid in actual usage.  2. Invalid usage help.  It
+                  is impossible to add specific help for individual usage.  In most
+                  embedded usages, there are particular     restrictions like, "must
+                  refer only to types A and B" or "UID not honored" or "name must
+                  be restricted".     Those cannot be well described when embedded.  3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen.  4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity     during interpretation and require a REST
+                  mapping.  In most cases, the dependency is on the group,resource
+                  tuple     and the version of the actual struct is irrelevant.  5.
+                  We cannot easily change it.  Because this type is embedded in many
+                  locations, updates to this type     will affect numerous schemas.  Don''t
+                  make new APIs embed an underspecified API type they do not control.
+                  Instead of using this type, create a locally provided and used type
+                  that is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  .'
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              podSelector:
+                additionalProperties:
+                  type: string
+                type: object
+            type: object
+          status:
+            description: DirectVolumeMigrationProgressStatus defines the observed
+              state of DirectVolumeMigrationProgress
+            properties:
+              conditions:
+                items:
+                  description: Condition Type - The condition type. Status - The condition
+                    status. Reason - The reason for the condition. Message - The human
+                    readable description of the condition. Durable - The condition
+                    is not un-staged. Items - A list of `items` associated with the
+                    condition used to replace [] in `Message`. staging - A condition
+                    has been explicitly set/updated.
+                  properties:
+                    category:
+                      type: string
+                    durable:
+                      type: boolean
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              containerElapsedTime:
+                description: ContainerElapsedTime total execution time of Rsync Pod
+                type: string
+              creationTimestamp:
+                description: CreationTimestamp pod creation time
+                format: date-time
+                type: string
+              exitCode:
+                description: ExitCode exit code of terminated Rsync Pod
+                format: int32
+                type: integer
+              lastObservedProgressPercent:
+                description: LastObservedProgressPercent progress of Rsync in percentage
+                type: string
+              lastObservedTransferRate:
+                description: LastObservedTransferRate rate of transfer of Rsync
+                type: string
+              logMessage:
+                description: LogMessage few lines of tailed log of the Rsync Pod
+                type: string
+              observedDigest:
+                type: string
+              phase:
+                description: PodPhase phase of the Rsync Pod
+                type: string
+              podName:
+                description: PodName name of the Rsync Pod
+                type: string
+              rsyncElapsedTime:
+                description: RsyncElapsedTime total elapsed time of Rsync operation
+                type: string
+              rsyncPodStatuses:
+                description: RsyncPodStatuses history of all Rsync attempts
+                items:
+                  description: RsyncPodStatus defines observed state of an Rsync attempt
+                  properties:
+                    containerElapsedTime:
+                      description: ContainerElapsedTime total execution time of Rsync
+                        Pod
+                      type: string
+                    creationTimestamp:
+                      description: CreationTimestamp pod creation time
+                      format: date-time
+                      type: string
+                    exitCode:
+                      description: ExitCode exit code of terminated Rsync Pod
+                      format: int32
+                      type: integer
+                    lastObservedProgressPercent:
+                      description: LastObservedProgressPercent progress of Rsync in
+                        percentage
+                      type: string
+                    lastObservedTransferRate:
+                      description: LastObservedTransferRate rate of transfer of Rsync
+                      type: string
+                    logMessage:
+                      description: LogMessage few lines of tailed log of the Rsync
+                        Pod
+                      type: string
+                    phase:
+                      description: PodPhase phase of the Rsync Pod
+                      type: string
+                    podName:
+                      description: PodName name of the Rsync Pod
+                      type: string
+                  type: object
+                type: array
+              totalProgressPercentage:
+                description: TotalProgressPercentage cumulative percentage of all
+                  Rsync attempts
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crds/migration.openshift.io_directvolumemigrations.yaml
+++ b/config/crds/migration.openshift.io_directvolumemigrations.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -16,741 +16,751 @@ spec:
     shortNames:
     - dvm
     singular: directvolumemigration
-  preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: DirectVolumeMigration is the Schema for the direct pv migration
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: DirectVolumeMigrationSpec defines the desired state of DirectVolumeMigration
-          properties:
-            backOffLimit:
-              description: BackOffLimit retry limit on Rsync pods
-              type: integer
-            createDestinationNamespaces:
-              description: Set true to create namespaces in destination cluster
-              type: boolean
-            deleteProgressReportingCRs:
-              description: Specifies if progress reporting CRs needs to be deleted
-                or not
-              type: boolean
-            destMigClusterRef:
-              description: 'ObjectReference contains enough information to let you
-                inspect or modify the referred object. --- New uses of this type are
-                discouraged because of difficulty describing its usage when embedded
-                in APIs.  1. Ignored fields.  It includes many fields which are not
-                generally honored.  For instance, ResourceVersion and FieldPath are
-                both very rarely valid in actual usage.  2. Invalid usage help.  It
-                is impossible to add specific help for individual usage.  In most
-                embedded usages, there are particular     restrictions like, "must
-                refer only to types A and B" or "UID not honored" or "name must be
-                restricted".     Those cannot be well described when embedded.  3.
-                Inconsistent validation.  Because the usages are different, the validation
-                rules are different by usage, which makes it hard for users to predict
-                what will happen.  4. The fields are both imprecise and overly precise.  Kind
-                is not a precise mapping to a URL. This can produce ambiguity     during
-                interpretation and require a REST mapping.  In most cases, the dependency
-                is on the group,resource tuple     and the version of the actual struct
-                is irrelevant.  5. We cannot easily change it.  Because this type
-                is embedded in many locations, updates to this type     will affect
-                numerous schemas.  Don''t make new APIs embed an underspecified API
-                type they do not control. Instead of using this type, create a locally
-                provided and used type that is well-focused on your reference. For
-                example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                .'
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            persistentVolumeClaims:
-              description: ' Holds all the PVCs that are to be migrated with direct
-                volume migration'
-              items:
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  targetAccessModes:
-                    description: TargetAccessModes access modes of the migrated PVC
-                      in the target cluster
-                    items:
-                      type: string
-                    type: array
-                  targetName:
-                    description: TargetName name of the migrated PVC in the target
-                      cluster
-                    type: string
-                  targetNamespace:
-                    description: TargetNamespace namespace of the migrated PVC in
-                      the target cluster
-                    type: string
-                  targetStorageClass:
-                    description: TargetStorageClass storage class of the migrated
-                      PVC in the target cluster
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                  verify:
-                    description: Verify set true to verify integrity of the data post
-                      migration
-                    type: boolean
-                required:
-                - targetAccessModes
-                - targetStorageClass
-                type: object
-              type: array
-            srcMigClusterRef:
-              description: 'ObjectReference contains enough information to let you
-                inspect or modify the referred object. --- New uses of this type are
-                discouraged because of difficulty describing its usage when embedded
-                in APIs.  1. Ignored fields.  It includes many fields which are not
-                generally honored.  For instance, ResourceVersion and FieldPath are
-                both very rarely valid in actual usage.  2. Invalid usage help.  It
-                is impossible to add specific help for individual usage.  In most
-                embedded usages, there are particular     restrictions like, "must
-                refer only to types A and B" or "UID not honored" or "name must be
-                restricted".     Those cannot be well described when embedded.  3.
-                Inconsistent validation.  Because the usages are different, the validation
-                rules are different by usage, which makes it hard for users to predict
-                what will happen.  4. The fields are both imprecise and overly precise.  Kind
-                is not a precise mapping to a URL. This can produce ambiguity     during
-                interpretation and require a REST mapping.  In most cases, the dependency
-                is on the group,resource tuple     and the version of the actual struct
-                is irrelevant.  5. We cannot easily change it.  Because this type
-                is embedded in many locations, updates to this type     will affect
-                numerous schemas.  Don''t make new APIs embed an underspecified API
-                type they do not control. Instead of using this type, create a locally
-                provided and used type that is well-focused on your reference. For
-                example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                .'
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-          type: object
-        status:
-          description: DirectVolumeMigrationStatus defines the observed state of DirectVolumeMigration
-          properties:
-            conditions:
-              items:
-                description: Condition Type - The condition type. Status - The condition
-                  status. Reason - The reason for the condition. Message - The human
-                  readable description of the condition. Durable - The condition is
-                  not un-staged. Items - A list of `items` associated with the condition
-                  used to replace [] in `Message`. staging - A condition has been
-                  explicitly set/updated.
-                properties:
-                  category:
-                    type: string
-                  durable:
-                    type: boolean
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                required:
-                - category
-                - lastTransitionTime
-                - status
-                - type
-                type: object
-              type: array
-            errors:
-              items:
-                type: string
-              type: array
-            failedPods:
-              items:
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  lastObservedProgressPercent:
-                    type: string
-                  lastObservedTransferRate:
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  pvcRef:
-                    description: 'ObjectReference contains enough information to let
-                      you inspect or modify the referred object. --- New uses of this
-                      type are discouraged because of difficulty describing its usage
-                      when embedded in APIs.  1. Ignored fields.  It includes many
-                      fields which are not generally honored.  For instance, ResourceVersion
-                      and FieldPath are both very rarely valid in actual usage.  2.
-                      Invalid usage help.  It is impossible to add specific help for
-                      individual usage.  In most embedded usages, there are particular     restrictions
-                      like, "must refer only to types A and B" or "UID not honored"
-                      or "name must be restricted".     Those cannot be well described
-                      when embedded.  3. Inconsistent validation.  Because the usages
-                      are different, the validation rules are different by usage,
-                      which makes it hard for users to predict what will happen.  4.
-                      The fields are both imprecise and overly precise.  Kind is not
-                      a precise mapping to a URL. This can produce ambiguity     during
-                      interpretation and require a REST mapping.  In most cases, the
-                      dependency is on the group,resource tuple     and the version
-                      of the actual struct is irrelevant.  5. We cannot easily change
-                      it.  Because this type is embedded in many locations, updates
-                      to this type     will affect numerous schemas.  Don''t make
-                      new APIs embed an underspecified API type they do not control.
-                      Instead of using this type, create a locally provided and used
-                      type that is well-focused on your reference. For example, ServiceReferences
-                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                      .'
-                    properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
-                        type: string
-                      kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                        type: string
-                      resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                        type: string
-                      uid:
-                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                        type: string
-                    type: object
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  totalElapsedTime:
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              type: array
-            itinerary:
-              type: string
-            observedDigest:
-              type: string
-            pendingPods:
-              items:
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  lastObservedProgressPercent:
-                    type: string
-                  lastObservedTransferRate:
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  pvcRef:
-                    description: 'ObjectReference contains enough information to let
-                      you inspect or modify the referred object. --- New uses of this
-                      type are discouraged because of difficulty describing its usage
-                      when embedded in APIs.  1. Ignored fields.  It includes many
-                      fields which are not generally honored.  For instance, ResourceVersion
-                      and FieldPath are both very rarely valid in actual usage.  2.
-                      Invalid usage help.  It is impossible to add specific help for
-                      individual usage.  In most embedded usages, there are particular     restrictions
-                      like, "must refer only to types A and B" or "UID not honored"
-                      or "name must be restricted".     Those cannot be well described
-                      when embedded.  3. Inconsistent validation.  Because the usages
-                      are different, the validation rules are different by usage,
-                      which makes it hard for users to predict what will happen.  4.
-                      The fields are both imprecise and overly precise.  Kind is not
-                      a precise mapping to a URL. This can produce ambiguity     during
-                      interpretation and require a REST mapping.  In most cases, the
-                      dependency is on the group,resource tuple     and the version
-                      of the actual struct is irrelevant.  5. We cannot easily change
-                      it.  Because this type is embedded in many locations, updates
-                      to this type     will affect numerous schemas.  Don''t make
-                      new APIs embed an underspecified API type they do not control.
-                      Instead of using this type, create a locally provided and used
-                      type that is well-focused on your reference. For example, ServiceReferences
-                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                      .'
-                    properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
-                        type: string
-                      kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                        type: string
-                      resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                        type: string
-                      uid:
-                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                        type: string
-                    type: object
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  totalElapsedTime:
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              type: array
-            phase:
-              type: string
-            phaseDescription:
-              type: string
-            rsyncOperations:
-              items:
-                description: RsyncOperation defines observed state of an Rsync Operation
-                properties:
-                  currentAttempt:
-                    description: CurrentAttempt current ongoing attempt of an Rsync
-                      operation
-                    type: integer
-                  failed:
-                    description: Failed whether operation as a whole failed
-                    type: boolean
-                  pvcReference:
-                    description: PVCReference pvc to which this Rsync operation corresponds
-                      to
-                    properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
-                        type: string
-                      kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                        type: string
-                      resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                        type: string
-                      uid:
-                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                        type: string
-                    type: object
-                  succeeded:
-                    description: Succeeded whether operation as a whole succeded
-                    type: boolean
-                type: object
-              type: array
-            runningPods:
-              items:
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  lastObservedProgressPercent:
-                    type: string
-                  lastObservedTransferRate:
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  pvcRef:
-                    description: 'ObjectReference contains enough information to let
-                      you inspect or modify the referred object. --- New uses of this
-                      type are discouraged because of difficulty describing its usage
-                      when embedded in APIs.  1. Ignored fields.  It includes many
-                      fields which are not generally honored.  For instance, ResourceVersion
-                      and FieldPath are both very rarely valid in actual usage.  2.
-                      Invalid usage help.  It is impossible to add specific help for
-                      individual usage.  In most embedded usages, there are particular     restrictions
-                      like, "must refer only to types A and B" or "UID not honored"
-                      or "name must be restricted".     Those cannot be well described
-                      when embedded.  3. Inconsistent validation.  Because the usages
-                      are different, the validation rules are different by usage,
-                      which makes it hard for users to predict what will happen.  4.
-                      The fields are both imprecise and overly precise.  Kind is not
-                      a precise mapping to a URL. This can produce ambiguity     during
-                      interpretation and require a REST mapping.  In most cases, the
-                      dependency is on the group,resource tuple     and the version
-                      of the actual struct is irrelevant.  5. We cannot easily change
-                      it.  Because this type is embedded in many locations, updates
-                      to this type     will affect numerous schemas.  Don''t make
-                      new APIs embed an underspecified API type they do not control.
-                      Instead of using this type, create a locally provided and used
-                      type that is well-focused on your reference. For example, ServiceReferences
-                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                      .'
-                    properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
-                        type: string
-                      kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                        type: string
-                      resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                        type: string
-                      uid:
-                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                        type: string
-                    type: object
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  totalElapsedTime:
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              type: array
-            startTimestamp:
-              format: date-time
-              type: string
-            successfulPods:
-              items:
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  lastObservedProgressPercent:
-                    type: string
-                  lastObservedTransferRate:
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  pvcRef:
-                    description: 'ObjectReference contains enough information to let
-                      you inspect or modify the referred object. --- New uses of this
-                      type are discouraged because of difficulty describing its usage
-                      when embedded in APIs.  1. Ignored fields.  It includes many
-                      fields which are not generally honored.  For instance, ResourceVersion
-                      and FieldPath are both very rarely valid in actual usage.  2.
-                      Invalid usage help.  It is impossible to add specific help for
-                      individual usage.  In most embedded usages, there are particular     restrictions
-                      like, "must refer only to types A and B" or "UID not honored"
-                      or "name must be restricted".     Those cannot be well described
-                      when embedded.  3. Inconsistent validation.  Because the usages
-                      are different, the validation rules are different by usage,
-                      which makes it hard for users to predict what will happen.  4.
-                      The fields are both imprecise and overly precise.  Kind is not
-                      a precise mapping to a URL. This can produce ambiguity     during
-                      interpretation and require a REST mapping.  In most cases, the
-                      dependency is on the group,resource tuple     and the version
-                      of the actual struct is irrelevant.  5. We cannot easily change
-                      it.  Because this type is embedded in many locations, updates
-                      to this type     will affect numerous schemas.  Don''t make
-                      new APIs embed an underspecified API type they do not control.
-                      Instead of using this type, create a locally provided and used
-                      type that is well-focused on your reference. For example, ServiceReferences
-                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                      .'
-                    properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
-                        type: string
-                      kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                        type: string
-                      resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                        type: string
-                      uid:
-                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                        type: string
-                    type: object
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  totalElapsedTime:
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-              type: array
-          required:
-          - observedDigest
-          - phaseDescription
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DirectVolumeMigration is the Schema for the direct pv migration
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DirectVolumeMigrationSpec defines the desired state of DirectVolumeMigration
+            properties:
+              backOffLimit:
+                description: BackOffLimit retry limit on Rsync pods
+                type: integer
+              createDestinationNamespaces:
+                description: Set true to create namespaces in destination cluster
+                type: boolean
+              deleteProgressReportingCRs:
+                description: Specifies if progress reporting CRs needs to be deleted
+                  or not
+                type: boolean
+              destMigClusterRef:
+                description: 'ObjectReference contains enough information to let you
+                  inspect or modify the referred object. --- New uses of this type
+                  are discouraged because of difficulty describing its usage when
+                  embedded in APIs.  1. Ignored fields.  It includes many fields which
+                  are not generally honored.  For instance, ResourceVersion and FieldPath
+                  are both very rarely valid in actual usage.  2. Invalid usage help.  It
+                  is impossible to add specific help for individual usage.  In most
+                  embedded usages, there are particular     restrictions like, "must
+                  refer only to types A and B" or "UID not honored" or "name must
+                  be restricted".     Those cannot be well described when embedded.  3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen.  4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity     during interpretation and require a REST
+                  mapping.  In most cases, the dependency is on the group,resource
+                  tuple     and the version of the actual struct is irrelevant.  5.
+                  We cannot easily change it.  Because this type is embedded in many
+                  locations, updates to this type     will affect numerous schemas.  Don''t
+                  make new APIs embed an underspecified API type they do not control.
+                  Instead of using this type, create a locally provided and used type
+                  that is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  .'
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              persistentVolumeClaims:
+                description: ' Holds all the PVCs that are to be migrated with direct
+                  volume migration'
+                items:
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    targetAccessModes:
+                      description: TargetAccessModes access modes of the migrated
+                        PVC in the target cluster
+                      items:
+                        type: string
+                      type: array
+                    targetName:
+                      description: TargetName name of the migrated PVC in the target
+                        cluster
+                      type: string
+                    targetNamespace:
+                      description: TargetNamespace namespace of the migrated PVC in
+                        the target cluster
+                      type: string
+                    targetStorageClass:
+                      description: TargetStorageClass storage class of the migrated
+                        PVC in the target cluster
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                    verify:
+                      description: Verify set true to verify integrity of the data
+                        post migration
+                      type: boolean
+                  required:
+                  - targetAccessModes
+                  - targetStorageClass
+                  type: object
+                type: array
+              srcMigClusterRef:
+                description: 'ObjectReference contains enough information to let you
+                  inspect or modify the referred object. --- New uses of this type
+                  are discouraged because of difficulty describing its usage when
+                  embedded in APIs.  1. Ignored fields.  It includes many fields which
+                  are not generally honored.  For instance, ResourceVersion and FieldPath
+                  are both very rarely valid in actual usage.  2. Invalid usage help.  It
+                  is impossible to add specific help for individual usage.  In most
+                  embedded usages, there are particular     restrictions like, "must
+                  refer only to types A and B" or "UID not honored" or "name must
+                  be restricted".     Those cannot be well described when embedded.  3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen.  4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity     during interpretation and require a REST
+                  mapping.  In most cases, the dependency is on the group,resource
+                  tuple     and the version of the actual struct is irrelevant.  5.
+                  We cannot easily change it.  Because this type is embedded in many
+                  locations, updates to this type     will affect numerous schemas.  Don''t
+                  make new APIs embed an underspecified API type they do not control.
+                  Instead of using this type, create a locally provided and used type
+                  that is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  .'
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+            type: object
+          status:
+            description: DirectVolumeMigrationStatus defines the observed state of
+              DirectVolumeMigration
+            properties:
+              conditions:
+                items:
+                  description: Condition Type - The condition type. Status - The condition
+                    status. Reason - The reason for the condition. Message - The human
+                    readable description of the condition. Durable - The condition
+                    is not un-staged. Items - A list of `items` associated with the
+                    condition used to replace [] in `Message`. staging - A condition
+                    has been explicitly set/updated.
+                  properties:
+                    category:
+                      type: string
+                    durable:
+                      type: boolean
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              errors:
+                items:
+                  type: string
+                type: array
+              failedPods:
+                items:
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    lastObservedProgressPercent:
+                      type: string
+                    lastObservedTransferRate:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    pvcRef:
+                      description: 'ObjectReference contains enough information to
+                        let you inspect or modify the referred object. --- New uses
+                        of this type are discouraged because of difficulty describing
+                        its usage when embedded in APIs.  1. Ignored fields.  It includes
+                        many fields which are not generally honored.  For instance,
+                        ResourceVersion and FieldPath are both very rarely valid in
+                        actual usage.  2. Invalid usage help.  It is impossible to
+                        add specific help for individual usage.  In most embedded
+                        usages, there are particular     restrictions like, "must
+                        refer only to types A and B" or "UID not honored" or "name
+                        must be restricted".     Those cannot be well described when
+                        embedded.  3. Inconsistent validation.  Because the usages
+                        are different, the validation rules are different by usage,
+                        which makes it hard for users to predict what will happen.  4.
+                        The fields are both imprecise and overly precise.  Kind is
+                        not a precise mapping to a URL. This can produce ambiguity     during
+                        interpretation and require a REST mapping.  In most cases,
+                        the dependency is on the group,resource tuple     and the
+                        version of the actual struct is irrelevant.  5. We cannot
+                        easily change it.  Because this type is embedded in many locations,
+                        updates to this type     will affect numerous schemas.  Don''t
+                        make new APIs embed an underspecified API type they do not
+                        control. Instead of using this type, create a locally provided
+                        and used type that is well-focused on your reference. For
+                        example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                        .'
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    totalElapsedTime:
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              itinerary:
+                type: string
+              observedDigest:
+                type: string
+              pendingPods:
+                items:
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    lastObservedProgressPercent:
+                      type: string
+                    lastObservedTransferRate:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    pvcRef:
+                      description: 'ObjectReference contains enough information to
+                        let you inspect or modify the referred object. --- New uses
+                        of this type are discouraged because of difficulty describing
+                        its usage when embedded in APIs.  1. Ignored fields.  It includes
+                        many fields which are not generally honored.  For instance,
+                        ResourceVersion and FieldPath are both very rarely valid in
+                        actual usage.  2. Invalid usage help.  It is impossible to
+                        add specific help for individual usage.  In most embedded
+                        usages, there are particular     restrictions like, "must
+                        refer only to types A and B" or "UID not honored" or "name
+                        must be restricted".     Those cannot be well described when
+                        embedded.  3. Inconsistent validation.  Because the usages
+                        are different, the validation rules are different by usage,
+                        which makes it hard for users to predict what will happen.  4.
+                        The fields are both imprecise and overly precise.  Kind is
+                        not a precise mapping to a URL. This can produce ambiguity     during
+                        interpretation and require a REST mapping.  In most cases,
+                        the dependency is on the group,resource tuple     and the
+                        version of the actual struct is irrelevant.  5. We cannot
+                        easily change it.  Because this type is embedded in many locations,
+                        updates to this type     will affect numerous schemas.  Don''t
+                        make new APIs embed an underspecified API type they do not
+                        control. Instead of using this type, create a locally provided
+                        and used type that is well-focused on your reference. For
+                        example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                        .'
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    totalElapsedTime:
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              phase:
+                type: string
+              phaseDescription:
+                type: string
+              rsyncOperations:
+                items:
+                  description: RsyncOperation defines observed state of an Rsync Operation
+                  properties:
+                    currentAttempt:
+                      description: CurrentAttempt current ongoing attempt of an Rsync
+                        operation
+                      type: integer
+                    failed:
+                      description: Failed whether operation as a whole failed
+                      type: boolean
+                    pvcReference:
+                      description: PVCReference pvc to which this Rsync operation
+                        corresponds to
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                    succeeded:
+                      description: Succeeded whether operation as a whole succeded
+                      type: boolean
+                  type: object
+                type: array
+              runningPods:
+                items:
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    lastObservedProgressPercent:
+                      type: string
+                    lastObservedTransferRate:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    pvcRef:
+                      description: 'ObjectReference contains enough information to
+                        let you inspect or modify the referred object. --- New uses
+                        of this type are discouraged because of difficulty describing
+                        its usage when embedded in APIs.  1. Ignored fields.  It includes
+                        many fields which are not generally honored.  For instance,
+                        ResourceVersion and FieldPath are both very rarely valid in
+                        actual usage.  2. Invalid usage help.  It is impossible to
+                        add specific help for individual usage.  In most embedded
+                        usages, there are particular     restrictions like, "must
+                        refer only to types A and B" or "UID not honored" or "name
+                        must be restricted".     Those cannot be well described when
+                        embedded.  3. Inconsistent validation.  Because the usages
+                        are different, the validation rules are different by usage,
+                        which makes it hard for users to predict what will happen.  4.
+                        The fields are both imprecise and overly precise.  Kind is
+                        not a precise mapping to a URL. This can produce ambiguity     during
+                        interpretation and require a REST mapping.  In most cases,
+                        the dependency is on the group,resource tuple     and the
+                        version of the actual struct is irrelevant.  5. We cannot
+                        easily change it.  Because this type is embedded in many locations,
+                        updates to this type     will affect numerous schemas.  Don''t
+                        make new APIs embed an underspecified API type they do not
+                        control. Instead of using this type, create a locally provided
+                        and used type that is well-focused on your reference. For
+                        example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                        .'
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    totalElapsedTime:
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              startTimestamp:
+                format: date-time
+                type: string
+              successfulPods:
+                items:
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    lastObservedProgressPercent:
+                      type: string
+                    lastObservedTransferRate:
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    pvcRef:
+                      description: 'ObjectReference contains enough information to
+                        let you inspect or modify the referred object. --- New uses
+                        of this type are discouraged because of difficulty describing
+                        its usage when embedded in APIs.  1. Ignored fields.  It includes
+                        many fields which are not generally honored.  For instance,
+                        ResourceVersion and FieldPath are both very rarely valid in
+                        actual usage.  2. Invalid usage help.  It is impossible to
+                        add specific help for individual usage.  In most embedded
+                        usages, there are particular     restrictions like, "must
+                        refer only to types A and B" or "UID not honored" or "name
+                        must be restricted".     Those cannot be well described when
+                        embedded.  3. Inconsistent validation.  Because the usages
+                        are different, the validation rules are different by usage,
+                        which makes it hard for users to predict what will happen.  4.
+                        The fields are both imprecise and overly precise.  Kind is
+                        not a precise mapping to a URL. This can produce ambiguity     during
+                        interpretation and require a REST mapping.  In most cases,
+                        the dependency is on the group,resource tuple     and the
+                        version of the actual struct is irrelevant.  5. We cannot
+                        easily change it.  Because this type is embedded in many locations,
+                        updates to this type     will affect numerous schemas.  Don''t
+                        make new APIs embed an underspecified API type they do not
+                        control. Instead of using this type, create a locally provided
+                        and used type that is well-focused on your reference. For
+                        example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                        .'
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    totalElapsedTime:
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+            required:
+            - observedDigest
+            - phaseDescription
+            type: object
+        type: object
     served: true
     storage: true
 status:

--- a/config/crds/migration.openshift.io_miganalytics.yaml
+++ b/config/crds/migration.openshift.io_miganalytics.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,393 +8,393 @@ metadata:
   creationTimestamp: null
   name: miganalytics.migration.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .spec.migPlanRef.name
-    name: Plan
-    type: string
-  - JSONPath: .status.analytics.percentComplete
-    name: Progress
-    type: string
-  - JSONPath: .status.analytics.k8sResourceTotal
-    name: Resources
-    type: string
-  - JSONPath: .status.analytics.imageCount
-    name: Images
-    type: string
-  - JSONPath: .status.analytics.imageSizeTotal
-    name: ImageSize
-    type: string
-  - JSONPath: .status.analytics.pvCount
-    name: PVs
-    type: string
-  - JSONPath: .status.analytics.pvCapacity
-    name: PVCapacity
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: migration.openshift.io
   names:
     kind: MigAnalytic
     listKind: MigAnalyticList
     plural: miganalytics
     singular: miganalytic
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: MigAnalytic is the Schema for the miganalytics API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MigAnalyticSpec defines the desired state of MigAnalytic
-          properties:
-            analyzeExtendedPVCapacity:
-              description: Enables advanced analysis of volumes required for PV resizing
-              type: boolean
-            analyzeImageCount:
-              description: Enables analysis of image count, if set true. This is a
-                required field.
-              type: boolean
-            analyzeK8SResources:
-              description: Enables analysis of k8s resources, if set true. This is
-                a required field.
-              type: boolean
-            analyzePVCapacity:
-              description: Enables analysis of persistent volume capacity, if set
-                true. This is a required field.
-              type: boolean
-            listImages:
-              description: Enable used in analysis of image count, if set true.
-              type: boolean
-            listImagesLimit:
-              description: Represents limit on image counts
-              type: integer
-            migPlanRef:
-              description: 'ObjectReference contains enough information to let you
-                inspect or modify the referred object. --- New uses of this type are
-                discouraged because of difficulty describing its usage when embedded
-                in APIs.  1. Ignored fields.  It includes many fields which are not
-                generally honored.  For instance, ResourceVersion and FieldPath are
-                both very rarely valid in actual usage.  2. Invalid usage help.  It
-                is impossible to add specific help for individual usage.  In most
-                embedded usages, there are particular     restrictions like, "must
-                refer only to types A and B" or "UID not honored" or "name must be
-                restricted".     Those cannot be well described when embedded.  3.
-                Inconsistent validation.  Because the usages are different, the validation
-                rules are different by usage, which makes it hard for users to predict
-                what will happen.  4. The fields are both imprecise and overly precise.  Kind
-                is not a precise mapping to a URL. This can produce ambiguity     during
-                interpretation and require a REST mapping.  In most cases, the dependency
-                is on the group,resource tuple     and the version of the actual struct
-                is irrelevant.  5. We cannot easily change it.  Because this type
-                is embedded in many locations, updates to this type     will affect
-                numerous schemas.  Don''t make new APIs embed an underspecified API
-                type they do not control. Instead of using this type, create a locally
-                provided and used type that is well-focused on your reference. For
-                example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                .'
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            refresh:
-              description: Enables refreshing existing MigAnalytic
-              type: boolean
-          required:
-          - analyzeImageCount
-          - analyzeK8SResources
-          - analyzePVCapacity
-          - migPlanRef
-          type: object
-        status:
-          description: MigAnalyticStatus defines the observed state of MigAnalytic
-          properties:
-            analytics:
-              description: MigAnalyticPlan defines the observed state of MigAnalyticPlan
-              properties:
-                excludedk8sResourceTotal:
-                  type: integer
-                imageCount:
-                  type: integer
-                imageSizeTotal:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                incompatiblek8sResourceTotal:
-                  type: integer
-                k8sResourceTotal:
-                  type: integer
-                namespaces:
-                  items:
-                    description: MigAnalyticNamespace defines the observed state of
-                      MigAnalyticNamespace
-                    properties:
-                      excludedK8SResourceTotal:
-                        type: integer
-                      excludedK8SResources:
-                        items:
-                          description: MigAnalyticNamespaceResource defines the observed
-                            state of MigAnalyticNamespaceResource
-                          properties:
-                            count:
-                              type: integer
-                            group:
-                              type: string
-                            kind:
-                              type: string
-                            version:
-                              type: string
-                          required:
-                          - count
-                          - group
-                          - kind
-                          - version
-                          type: object
-                        type: array
-                      imageCount:
-                        type: integer
-                      imageSizeTotal:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      images:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            reference:
-                              type: string
-                            size:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                          required:
-                          - name
-                          - reference
-                          - size
-                          type: object
-                        type: array
-                      incompatibleK8SResourceTotal:
-                        type: integer
-                      incompatibleK8SResources:
-                        items:
-                          description: MigAnalyticNamespaceResource defines the observed
-                            state of MigAnalyticNamespaceResource
-                          properties:
-                            count:
-                              type: integer
-                            group:
-                              type: string
-                            kind:
-                              type: string
-                            version:
-                              type: string
-                          required:
-                          - count
-                          - group
-                          - kind
-                          - version
-                          type: object
-                        type: array
-                      k8sResourceTotal:
-                        type: integer
-                      k8sResources:
-                        items:
-                          description: MigAnalyticNamespaceResource defines the observed
-                            state of MigAnalyticNamespaceResource
-                          properties:
-                            count:
-                              type: integer
-                            group:
-                              type: string
-                            kind:
-                              type: string
-                            version:
-                              type: string
-                          required:
-                          - count
-                          - group
-                          - kind
-                          - version
-                          type: object
-                        type: array
-                      namespace:
-                        type: string
-                      persistentVolumes:
-                        items:
-                          description: MigAnalyticPersistentVolumeClaim represents
-                            a Kubernetes Persistent volume claim with discovered analytic
-                            properties
-                          properties:
-                            actualCapacity:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              description: Actual provisioned capacity of the volume
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            comment:
-                              description: Human readable reason for proposed adjustment
-                              type: string
-                            name:
-                              description: Name of the persistent volume claim
-                              type: string
-                            proposedCapacity:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              description: Adjusted capacity of the volume
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            requestedCapacity:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              description: Requested capacity of the claim
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            usagePercentage:
-                              description: Usage of volume in percentage
-                              type: integer
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      pvCapacity:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      pvCount:
-                        type: integer
-                    required:
-                    - excludedK8SResourceTotal
-                    - imageCount
-                    - imageSizeTotal
-                    - incompatibleK8SResourceTotal
-                    - k8sResourceTotal
-                    - namespace
-                    - pvCapacity
-                    - pvCount
-                    type: object
-                  type: array
-                percentComplete:
-                  type: integer
-                plan:
-                  type: string
-                pvCapacity:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                pvCount:
-                  type: integer
-              required:
-              - excludedk8sResourceTotal
-              - imageCount
-              - imageSizeTotal
-              - incompatiblek8sResourceTotal
-              - k8sResourceTotal
-              - percentComplete
-              - plan
-              - pvCapacity
-              - pvCount
-              type: object
-            conditions:
-              items:
-                description: Condition Type - The condition type. Status - The condition
-                  status. Reason - The reason for the condition. Message - The human
-                  readable description of the condition. Durable - The condition is
-                  not un-staged. Items - A list of `items` associated with the condition
-                  used to replace [] in `Message`. staging - A condition has been
-                  explicitly set/updated.
-                properties:
-                  category:
-                    type: string
-                  durable:
-                    type: boolean
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                required:
-                - category
-                - lastTransitionTime
-                - status
-                - type
-                type: object
-              type: array
-            observedGeneration:
-              format: int64
-              type: integer
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.migPlanRef.name
+      name: Plan
+      type: string
+    - jsonPath: .status.analytics.percentComplete
+      name: Progress
+      type: string
+    - jsonPath: .status.analytics.k8sResourceTotal
+      name: Resources
+      type: string
+    - jsonPath: .status.analytics.imageCount
+      name: Images
+      type: string
+    - jsonPath: .status.analytics.imageSizeTotal
+      name: ImageSize
+      type: string
+    - jsonPath: .status.analytics.pvCount
+      name: PVs
+      type: string
+    - jsonPath: .status.analytics.pvCapacity
+      name: PVCapacity
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MigAnalytic is the Schema for the miganalytics API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MigAnalyticSpec defines the desired state of MigAnalytic
+            properties:
+              analyzeExtendedPVCapacity:
+                description: Enables advanced analysis of volumes required for PV
+                  resizing
+                type: boolean
+              analyzeImageCount:
+                description: Enables analysis of image count, if set true. This is
+                  a required field.
+                type: boolean
+              analyzeK8SResources:
+                description: Enables analysis of k8s resources, if set true. This
+                  is a required field.
+                type: boolean
+              analyzePVCapacity:
+                description: Enables analysis of persistent volume capacity, if set
+                  true. This is a required field.
+                type: boolean
+              listImages:
+                description: Enable used in analysis of image count, if set true.
+                type: boolean
+              listImagesLimit:
+                description: Represents limit on image counts
+                type: integer
+              migPlanRef:
+                description: 'ObjectReference contains enough information to let you
+                  inspect or modify the referred object. --- New uses of this type
+                  are discouraged because of difficulty describing its usage when
+                  embedded in APIs.  1. Ignored fields.  It includes many fields which
+                  are not generally honored.  For instance, ResourceVersion and FieldPath
+                  are both very rarely valid in actual usage.  2. Invalid usage help.  It
+                  is impossible to add specific help for individual usage.  In most
+                  embedded usages, there are particular     restrictions like, "must
+                  refer only to types A and B" or "UID not honored" or "name must
+                  be restricted".     Those cannot be well described when embedded.  3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen.  4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity     during interpretation and require a REST
+                  mapping.  In most cases, the dependency is on the group,resource
+                  tuple     and the version of the actual struct is irrelevant.  5.
+                  We cannot easily change it.  Because this type is embedded in many
+                  locations, updates to this type     will affect numerous schemas.  Don''t
+                  make new APIs embed an underspecified API type they do not control.
+                  Instead of using this type, create a locally provided and used type
+                  that is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  .'
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              refresh:
+                description: Enables refreshing existing MigAnalytic
+                type: boolean
+            required:
+            - analyzeImageCount
+            - analyzeK8SResources
+            - analyzePVCapacity
+            - migPlanRef
+            type: object
+          status:
+            description: MigAnalyticStatus defines the observed state of MigAnalytic
+            properties:
+              analytics:
+                description: MigAnalyticPlan defines the observed state of MigAnalyticPlan
+                properties:
+                  excludedk8sResourceTotal:
+                    type: integer
+                  imageCount:
+                    type: integer
+                  imageSizeTotal:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  incompatiblek8sResourceTotal:
+                    type: integer
+                  k8sResourceTotal:
+                    type: integer
+                  namespaces:
+                    items:
+                      description: MigAnalyticNamespace defines the observed state
+                        of MigAnalyticNamespace
+                      properties:
+                        excludedK8SResourceTotal:
+                          type: integer
+                        excludedK8SResources:
+                          items:
+                            description: MigAnalyticNamespaceResource defines the
+                              observed state of MigAnalyticNamespaceResource
+                            properties:
+                              count:
+                                type: integer
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                            - count
+                            - group
+                            - kind
+                            - version
+                            type: object
+                          type: array
+                        imageCount:
+                          type: integer
+                        imageSizeTotal:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        images:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              reference:
+                                type: string
+                              size:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - name
+                            - reference
+                            - size
+                            type: object
+                          type: array
+                        incompatibleK8SResourceTotal:
+                          type: integer
+                        incompatibleK8SResources:
+                          items:
+                            description: MigAnalyticNamespaceResource defines the
+                              observed state of MigAnalyticNamespaceResource
+                            properties:
+                              count:
+                                type: integer
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                            - count
+                            - group
+                            - kind
+                            - version
+                            type: object
+                          type: array
+                        k8sResourceTotal:
+                          type: integer
+                        k8sResources:
+                          items:
+                            description: MigAnalyticNamespaceResource defines the
+                              observed state of MigAnalyticNamespaceResource
+                            properties:
+                              count:
+                                type: integer
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                            - count
+                            - group
+                            - kind
+                            - version
+                            type: object
+                          type: array
+                        namespace:
+                          type: string
+                        persistentVolumes:
+                          items:
+                            description: MigAnalyticPersistentVolumeClaim represents
+                              a Kubernetes Persistent volume claim with discovered
+                              analytic properties
+                            properties:
+                              actualCapacity:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Actual provisioned capacity of the volume
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              comment:
+                                description: Human readable reason for proposed adjustment
+                                type: string
+                              name:
+                                description: Name of the persistent volume claim
+                                type: string
+                              proposedCapacity:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Adjusted capacity of the volume
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              requestedCapacity:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Requested capacity of the claim
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              usagePercentage:
+                                description: Usage of volume in percentage
+                                type: integer
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        pvCapacity:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        pvCount:
+                          type: integer
+                      required:
+                      - excludedK8SResourceTotal
+                      - imageCount
+                      - imageSizeTotal
+                      - incompatibleK8SResourceTotal
+                      - k8sResourceTotal
+                      - namespace
+                      - pvCapacity
+                      - pvCount
+                      type: object
+                    type: array
+                  percentComplete:
+                    type: integer
+                  plan:
+                    type: string
+                  pvCapacity:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  pvCount:
+                    type: integer
+                required:
+                - excludedk8sResourceTotal
+                - imageCount
+                - imageSizeTotal
+                - incompatiblek8sResourceTotal
+                - k8sResourceTotal
+                - percentComplete
+                - plan
+                - pvCapacity
+                - pvCount
+                type: object
+              conditions:
+                items:
+                  description: Condition Type - The condition type. Status - The condition
+                    status. Reason - The reason for the condition. Message - The human
+                    readable description of the condition. Durable - The condition
+                    is not un-staged. Items - A list of `items` associated with the
+                    condition used to replace [] in `Message`. staging - A condition
+                    has been explicitly set/updated.
+                  properties:
+                    category:
+                      type: string
+                    durable:
+                      type: boolean
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crds/migration.openshift.io_migclusters.yaml
+++ b/config/crds/migration.openshift.io_migclusters.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,188 +8,187 @@ metadata:
   creationTimestamp: null
   name: migclusters.migration.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .spec.url
-    name: URL
-    type: string
-  - JSONPath: .spec.isHostCluster
-    name: Host
-    type: boolean
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: migration.openshift.io
   names:
     kind: MigCluster
     listKind: MigClusterList
     plural: migclusters
     singular: migcluster
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: MigCluster is the Schema for the migclusters API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MigClusterSpec defines the desired state of MigCluster
-          properties:
-            azureResourceGroup:
-              description: For azure clusters -- it's the resource group that in-cluster
-                volumes use.
-              type: string
-            caBundle:
-              description: If the migcluster needs SSL verification for connections
-                a user can supply a custom CA bundle. This field is required only
-                when spec.Insecure is set false
-              format: byte
-              type: string
-            exposedRegistryPath:
-              description: Stores the path of registry route when using direct migration.
-              type: string
-            insecure:
-              description: If set false, user will need to provide CA bundle for TLS
-                connection to the remote cluster.
-              type: boolean
-            isHostCluster:
-              description: Specifies if the cluster is host (where the controller
-                is installed) or not. This is a required field.
-              type: boolean
-            refresh:
-              description: If set True, forces the controller to run a full suite
-                of validations on migcluster.
-              type: boolean
-            restartRestic:
-              description: An override setting to tell the controller that the source
-                cluster restic needs to be restarted after stage pod creation.
-              type: boolean
-            serviceAccountSecretRef:
-              description: 'ObjectReference contains enough information to let you
-                inspect or modify the referred object. --- New uses of this type are
-                discouraged because of difficulty describing its usage when embedded
-                in APIs.  1. Ignored fields.  It includes many fields which are not
-                generally honored.  For instance, ResourceVersion and FieldPath are
-                both very rarely valid in actual usage.  2. Invalid usage help.  It
-                is impossible to add specific help for individual usage.  In most
-                embedded usages, there are particular     restrictions like, "must
-                refer only to types A and B" or "UID not honored" or "name must be
-                restricted".     Those cannot be well described when embedded.  3.
-                Inconsistent validation.  Because the usages are different, the validation
-                rules are different by usage, which makes it hard for users to predict
-                what will happen.  4. The fields are both imprecise and overly precise.  Kind
-                is not a precise mapping to a URL. This can produce ambiguity     during
-                interpretation and require a REST mapping.  In most cases, the dependency
-                is on the group,resource tuple     and the version of the actual struct
-                is irrelevant.  5. We cannot easily change it.  Because this type
-                is embedded in many locations, updates to this type     will affect
-                numerous schemas.  Don''t make new APIs embed an underspecified API
-                type they do not control. Instead of using this type, create a locally
-                provided and used type that is well-focused on your reference. For
-                example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                .'
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            url:
-              description: Stores the url of the remote cluster. The field is only
-                required for the source cluster object.
-              type: string
-          required:
-          - isHostCluster
-          type: object
-        status:
-          description: MigClusterStatus defines the observed state of MigCluster
-          properties:
-            conditions:
-              items:
-                description: Condition Type - The condition type. Status - The condition
-                  status. Reason - The reason for the condition. Message - The human
-                  readable description of the condition. Durable - The condition is
-                  not un-staged. Items - A list of `items` associated with the condition
-                  used to replace [] in `Message`. staging - A condition has been
-                  explicitly set/updated.
-                properties:
-                  category:
-                    type: string
-                  durable:
-                    type: boolean
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                required:
-                - category
-                - lastTransitionTime
-                - status
-                - type
-                type: object
-              type: array
-            observedDigest:
-              type: string
-            operatorVersion:
-              type: string
-            registryPath:
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .spec.isHostCluster
+      name: Host
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MigCluster is the Schema for the migclusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MigClusterSpec defines the desired state of MigCluster
+            properties:
+              azureResourceGroup:
+                description: For azure clusters -- it's the resource group that in-cluster
+                  volumes use.
+                type: string
+              caBundle:
+                description: If the migcluster needs SSL verification for connections
+                  a user can supply a custom CA bundle. This field is required only
+                  when spec.Insecure is set false
+                format: byte
+                type: string
+              exposedRegistryPath:
+                description: Stores the path of registry route when using direct migration.
+                type: string
+              insecure:
+                description: If set false, user will need to provide CA bundle for
+                  TLS connection to the remote cluster.
+                type: boolean
+              isHostCluster:
+                description: Specifies if the cluster is host (where the controller
+                  is installed) or not. This is a required field.
+                type: boolean
+              refresh:
+                description: If set True, forces the controller to run a full suite
+                  of validations on migcluster.
+                type: boolean
+              restartRestic:
+                description: An override setting to tell the controller that the source
+                  cluster restic needs to be restarted after stage pod creation.
+                type: boolean
+              serviceAccountSecretRef:
+                description: 'ObjectReference contains enough information to let you
+                  inspect or modify the referred object. --- New uses of this type
+                  are discouraged because of difficulty describing its usage when
+                  embedded in APIs.  1. Ignored fields.  It includes many fields which
+                  are not generally honored.  For instance, ResourceVersion and FieldPath
+                  are both very rarely valid in actual usage.  2. Invalid usage help.  It
+                  is impossible to add specific help for individual usage.  In most
+                  embedded usages, there are particular     restrictions like, "must
+                  refer only to types A and B" or "UID not honored" or "name must
+                  be restricted".     Those cannot be well described when embedded.  3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen.  4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity     during interpretation and require a REST
+                  mapping.  In most cases, the dependency is on the group,resource
+                  tuple     and the version of the actual struct is irrelevant.  5.
+                  We cannot easily change it.  Because this type is embedded in many
+                  locations, updates to this type     will affect numerous schemas.  Don''t
+                  make new APIs embed an underspecified API type they do not control.
+                  Instead of using this type, create a locally provided and used type
+                  that is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  .'
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              url:
+                description: Stores the url of the remote cluster. The field is only
+                  required for the source cluster object.
+                type: string
+            required:
+            - isHostCluster
+            type: object
+          status:
+            description: MigClusterStatus defines the observed state of MigCluster
+            properties:
+              conditions:
+                items:
+                  description: Condition Type - The condition type. Status - The condition
+                    status. Reason - The reason for the condition. Message - The human
+                    readable description of the condition. Durable - The condition
+                    is not un-staged. Items - A list of `items` associated with the
+                    condition used to replace [] in `Message`. staging - A condition
+                    has been explicitly set/updated.
+                  properties:
+                    category:
+                      type: string
+                    durable:
+                      type: boolean
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedDigest:
+                type: string
+              operatorVersion:
+                type: string
+              registryPath:
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crds/migration.openshift.io_mighooks.yaml
+++ b/config/crds/migration.openshift.io_mighooks.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,117 +8,116 @@ metadata:
   creationTimestamp: null
   name: mighooks.migration.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .spec.image
-    name: Image
-    type: string
-  - JSONPath: .spec.targetCluster
-    name: TargetCluster
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: migration.openshift.io
   names:
     kind: MigHook
     listKind: MigHookList
     plural: mighooks
     singular: mighook
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: MigHook is the Schema for the mighooks API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MigHookSpec defines the desired state of MigHook
-          properties:
-            activeDeadlineSeconds:
-              description: Specifies the highest amount of time for which the hook
-                will run.
-              format: int64
-              type: integer
-            custom:
-              description: Specifies whether the hook is a custom Ansible playbook
-                or a pre-built image. This is a required field.
-              type: boolean
-            image:
-              description: Specifies the image of the hook to be executed. This is
-                a required field.
-              type: string
-            playbook:
-              description: Specifies the contents of the custom Ansible playbook in
-                base64 format, it is used in conjunction with the custom boolean flag.
-              type: string
-            targetCluster:
-              description: Specifies the cluster on which the hook is to be executed.
-                This is a required field.
-              type: string
-          required:
-          - custom
-          - image
-          - targetCluster
-          type: object
-        status:
-          description: MigHookStatus defines the observed state of MigHook
-          properties:
-            conditions:
-              items:
-                description: Condition Type - The condition type. Status - The condition
-                  status. Reason - The reason for the condition. Message - The human
-                  readable description of the condition. Durable - The condition is
-                  not un-staged. Items - A list of `items` associated with the condition
-                  used to replace [] in `Message`. staging - A condition has been
-                  explicitly set/updated.
-                properties:
-                  category:
-                    type: string
-                  durable:
-                    type: boolean
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                required:
-                - category
-                - lastTransitionTime
-                - status
-                - type
-                type: object
-              type: array
-            observedGeneration:
-              format: int64
-              type: integer
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.image
+      name: Image
+      type: string
+    - jsonPath: .spec.targetCluster
+      name: TargetCluster
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MigHook is the Schema for the mighooks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MigHookSpec defines the desired state of MigHook
+            properties:
+              activeDeadlineSeconds:
+                description: Specifies the highest amount of time for which the hook
+                  will run.
+                format: int64
+                type: integer
+              custom:
+                description: Specifies whether the hook is a custom Ansible playbook
+                  or a pre-built image. This is a required field.
+                type: boolean
+              image:
+                description: Specifies the image of the hook to be executed. This
+                  is a required field.
+                type: string
+              playbook:
+                description: Specifies the contents of the custom Ansible playbook
+                  in base64 format, it is used in conjunction with the custom boolean
+                  flag.
+                type: string
+              targetCluster:
+                description: Specifies the cluster on which the hook is to be executed.
+                  This is a required field.
+                type: string
+            required:
+            - custom
+            - image
+            - targetCluster
+            type: object
+          status:
+            description: MigHookStatus defines the observed state of MigHook
+            properties:
+              conditions:
+                items:
+                  description: Condition Type - The condition type. Status - The condition
+                    status. Reason - The reason for the condition. Message - The human
+                    readable description of the condition. Durable - The condition
+                    is not un-staged. Items - A list of `items` associated with the
+                    condition used to replace [] in `Message`. staging - A condition
+                    has been explicitly set/updated.
+                  properties:
+                    category:
+                      type: string
+                    durable:
+                      type: boolean
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crds/migration.openshift.io_migmigrations.yaml
+++ b/config/crds/migration.openshift.io_migmigrations.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,254 +8,253 @@ metadata:
   creationTimestamp: null
   name: migmigrations.migration.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .spec.migPlanRef.name
-    name: Plan
-    type: string
-  - JSONPath: .spec.stage
-    name: Stage
-    type: string
-  - JSONPath: .spec.rollback
-    name: Rollback
-    type: string
-  - JSONPath: .status.itinerary
-    name: Itinerary
-    type: string
-  - JSONPath: .status.phase
-    name: Phase
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: migration.openshift.io
   names:
     kind: MigMigration
     listKind: MigMigrationList
     plural: migmigrations
     singular: migmigration
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: MigMigration is the Schema for the migmigrations API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MigMigrationSpec defines the desired state of MigMigration
-          properties:
-            canceled:
-              description: Invokes the cancel migration operation, when set to true
-                the migration controller switches to cancel itinerary. This field
-                can be used on-demand to cancel the running migration.
-              type: boolean
-            keepAnnotations:
-              description: Specifies whether to retain the annotations set by the
-                migration controller or not.
-              type: boolean
-            migPlanRef:
-              description: 'ObjectReference contains enough information to let you
-                inspect or modify the referred object. --- New uses of this type are
-                discouraged because of difficulty describing its usage when embedded
-                in APIs.  1. Ignored fields.  It includes many fields which are not
-                generally honored.  For instance, ResourceVersion and FieldPath are
-                both very rarely valid in actual usage.  2. Invalid usage help.  It
-                is impossible to add specific help for individual usage.  In most
-                embedded usages, there are particular     restrictions like, "must
-                refer only to types A and B" or "UID not honored" or "name must be
-                restricted".     Those cannot be well described when embedded.  3.
-                Inconsistent validation.  Because the usages are different, the validation
-                rules are different by usage, which makes it hard for users to predict
-                what will happen.  4. The fields are both imprecise and overly precise.  Kind
-                is not a precise mapping to a URL. This can produce ambiguity     during
-                interpretation and require a REST mapping.  In most cases, the dependency
-                is on the group,resource tuple     and the version of the actual struct
-                is irrelevant.  5. We cannot easily change it.  Because this type
-                is embedded in many locations, updates to this type     will affect
-                numerous schemas.  Don''t make new APIs embed an underspecified API
-                type they do not control. Instead of using this type, create a locally
-                provided and used type that is well-focused on your reference. For
-                example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                .'
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            quiescePods:
-              description: Specifies whether to quiesce the application Pods before
-                migrating Persistent Volume data.
-              type: boolean
-            rollback:
-              description: Invokes the rollback migration operation, when set to true
-                the migration controller switches to rollback itinerary. This field
-                needs to be set prior to creation of a MigMigration.
-              type: boolean
-            stage:
-              description: Invokes the stage operation, when set to true the migration
-                controller switches to stage itinerary. This is a required field.
-              type: boolean
-            verify:
-              description: Specifies whether to verify the health of the migrated
-                pods or not.
-              type: boolean
-          required:
-          - stage
-          type: object
-        status:
-          description: MigMigrationStatus defines the observed state of MigMigration
-          properties:
-            conditions:
-              items:
-                description: Condition Type - The condition type. Status - The condition
-                  status. Reason - The reason for the condition. Message - The human
-                  readable description of the condition. Durable - The condition is
-                  not un-staged. Items - A list of `items` associated with the condition
-                  used to replace [] in `Message`. staging - A condition has been
-                  explicitly set/updated.
-                properties:
-                  category:
-                    type: string
-                  durable:
-                    type: boolean
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                required:
-                - category
-                - lastTransitionTime
-                - status
-                - type
-                type: object
-              type: array
-            errors:
-              items:
-                type: string
-              type: array
-            itinerary:
-              type: string
-            namespaces:
-              items:
-                description: UnhealthyNamespace is a store for unhealthy resources
-                  in a namespace
-                properties:
-                  name:
-                    type: string
-                  workloads:
-                    items:
-                      description: Workload is a store for unhealthy resource and
-                        it's dependents
-                      properties:
-                        name:
-                          type: string
-                        resources:
-                          items:
-                            type: string
-                          type: array
-                      required:
-                      - name
-                      type: object
-                    type: array
-                required:
-                - name
-                - workloads
-                type: object
-              type: array
-            observedDigest:
-              type: string
-            phase:
-              type: string
-            pipeline:
-              items:
-                description: Step defines a task in a step of migration
-                properties:
-                  completed:
-                    description: Completed timestamp.
-                    format: date-time
-                    type: string
-                  failed:
-                    type: boolean
-                  message:
-                    type: string
-                  name:
-                    type: string
-                  phase:
-                    type: string
-                  progress:
-                    items:
-                      type: string
-                    type: array
-                  skipped:
-                    type: boolean
-                  started:
-                    description: Started timestamp.
-                    format: date-time
-                    type: string
-                required:
-                - name
-                type: object
-              type: array
-            startTimestamp:
-              format: date-time
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.migPlanRef.name
+      name: Plan
+      type: string
+    - jsonPath: .spec.stage
+      name: Stage
+      type: string
+    - jsonPath: .spec.rollback
+      name: Rollback
+      type: string
+    - jsonPath: .status.itinerary
+      name: Itinerary
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MigMigration is the Schema for the migmigrations API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MigMigrationSpec defines the desired state of MigMigration
+            properties:
+              canceled:
+                description: Invokes the cancel migration operation, when set to true
+                  the migration controller switches to cancel itinerary. This field
+                  can be used on-demand to cancel the running migration.
+                type: boolean
+              keepAnnotations:
+                description: Specifies whether to retain the annotations set by the
+                  migration controller or not.
+                type: boolean
+              migPlanRef:
+                description: 'ObjectReference contains enough information to let you
+                  inspect or modify the referred object. --- New uses of this type
+                  are discouraged because of difficulty describing its usage when
+                  embedded in APIs.  1. Ignored fields.  It includes many fields which
+                  are not generally honored.  For instance, ResourceVersion and FieldPath
+                  are both very rarely valid in actual usage.  2. Invalid usage help.  It
+                  is impossible to add specific help for individual usage.  In most
+                  embedded usages, there are particular     restrictions like, "must
+                  refer only to types A and B" or "UID not honored" or "name must
+                  be restricted".     Those cannot be well described when embedded.  3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen.  4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity     during interpretation and require a REST
+                  mapping.  In most cases, the dependency is on the group,resource
+                  tuple     and the version of the actual struct is irrelevant.  5.
+                  We cannot easily change it.  Because this type is embedded in many
+                  locations, updates to this type     will affect numerous schemas.  Don''t
+                  make new APIs embed an underspecified API type they do not control.
+                  Instead of using this type, create a locally provided and used type
+                  that is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  .'
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              quiescePods:
+                description: Specifies whether to quiesce the application Pods before
+                  migrating Persistent Volume data.
+                type: boolean
+              rollback:
+                description: Invokes the rollback migration operation, when set to
+                  true the migration controller switches to rollback itinerary. This
+                  field needs to be set prior to creation of a MigMigration.
+                type: boolean
+              stage:
+                description: Invokes the stage operation, when set to true the migration
+                  controller switches to stage itinerary. This is a required field.
+                type: boolean
+              verify:
+                description: Specifies whether to verify the health of the migrated
+                  pods or not.
+                type: boolean
+            required:
+            - stage
+            type: object
+          status:
+            description: MigMigrationStatus defines the observed state of MigMigration
+            properties:
+              conditions:
+                items:
+                  description: Condition Type - The condition type. Status - The condition
+                    status. Reason - The reason for the condition. Message - The human
+                    readable description of the condition. Durable - The condition
+                    is not un-staged. Items - A list of `items` associated with the
+                    condition used to replace [] in `Message`. staging - A condition
+                    has been explicitly set/updated.
+                  properties:
+                    category:
+                      type: string
+                    durable:
+                      type: boolean
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              errors:
+                items:
+                  type: string
+                type: array
+              itinerary:
+                type: string
+              namespaces:
+                items:
+                  description: UnhealthyNamespace is a store for unhealthy resources
+                    in a namespace
+                  properties:
+                    name:
+                      type: string
+                    workloads:
+                      items:
+                        description: Workload is a store for unhealthy resource and
+                          it's dependents
+                        properties:
+                          name:
+                            type: string
+                          resources:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  - workloads
+                  type: object
+                type: array
+              observedDigest:
+                type: string
+              phase:
+                type: string
+              pipeline:
+                items:
+                  description: Step defines a task in a step of migration
+                  properties:
+                    completed:
+                      description: Completed timestamp.
+                      format: date-time
+                      type: string
+                    failed:
+                      type: boolean
+                    message:
+                      type: string
+                    name:
+                      type: string
+                    phase:
+                      type: string
+                    progress:
+                      items:
+                        type: string
+                      type: array
+                    skipped:
+                      type: boolean
+                    started:
+                      description: Started timestamp.
+                      format: date-time
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              startTimestamp:
+                format: date-time
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crds/migration.openshift.io_migplans.yaml
+++ b/config/crds/migration.openshift.io_migplans.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,616 +8,622 @@ metadata:
   creationTimestamp: null
   name: migplans.migration.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .spec.srcMigClusterRef.name
-    name: Source
-    type: string
-  - JSONPath: .spec.destMigClusterRef.name
-    name: Target
-    type: string
-  - JSONPath: .spec.migStorageRef.name
-    name: Storage
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: migration.openshift.io
   names:
     kind: MigPlan
     listKind: MigPlanList
     plural: migplans
     singular: migplan
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: MigPlan is the Schema for the migplans API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MigPlanSpec defines the desired state of MigPlan
-          properties:
-            closed:
-              description: If the migration was successful for a migplan, this value
-                can be set True indicating that after one successful migration no
-                new migrations can be carried out for this migplan.
-              type: boolean
-            destMigClusterRef:
-              description: 'ObjectReference contains enough information to let you
-                inspect or modify the referred object. --- New uses of this type are
-                discouraged because of difficulty describing its usage when embedded
-                in APIs.  1. Ignored fields.  It includes many fields which are not
-                generally honored.  For instance, ResourceVersion and FieldPath are
-                both very rarely valid in actual usage.  2. Invalid usage help.  It
-                is impossible to add specific help for individual usage.  In most
-                embedded usages, there are particular     restrictions like, "must
-                refer only to types A and B" or "UID not honored" or "name must be
-                restricted".     Those cannot be well described when embedded.  3.
-                Inconsistent validation.  Because the usages are different, the validation
-                rules are different by usage, which makes it hard for users to predict
-                what will happen.  4. The fields are both imprecise and overly precise.  Kind
-                is not a precise mapping to a URL. This can produce ambiguity     during
-                interpretation and require a REST mapping.  In most cases, the dependency
-                is on the group,resource tuple     and the version of the actual struct
-                is irrelevant.  5. We cannot easily change it.  Because this type
-                is embedded in many locations, updates to this type     will affect
-                numerous schemas.  Don''t make new APIs embed an underspecified API
-                type they do not control. Instead of using this type, create a locally
-                provided and used type that is well-focused on your reference. For
-                example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                .'
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            hooks:
-              description: Holds a reference to a MigHook along with the desired phase
-                to run it in.
-              items:
-                description: MigPlanHook hold a reference to a MigHook along with
-                  the desired phase to run it in
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.srcMigClusterRef.name
+      name: Source
+      type: string
+    - jsonPath: .spec.destMigClusterRef.name
+      name: Target
+      type: string
+    - jsonPath: .spec.migStorageRef.name
+      name: Storage
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MigPlan is the Schema for the migplans API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MigPlanSpec defines the desired state of MigPlan
+            properties:
+              closed:
+                description: If the migration was successful for a migplan, this value
+                  can be set True indicating that after one successful migration no
+                  new migrations can be carried out for this migplan.
+                type: boolean
+              destMigClusterRef:
+                description: 'ObjectReference contains enough information to let you
+                  inspect or modify the referred object. --- New uses of this type
+                  are discouraged because of difficulty describing its usage when
+                  embedded in APIs.  1. Ignored fields.  It includes many fields which
+                  are not generally honored.  For instance, ResourceVersion and FieldPath
+                  are both very rarely valid in actual usage.  2. Invalid usage help.  It
+                  is impossible to add specific help for individual usage.  In most
+                  embedded usages, there are particular     restrictions like, "must
+                  refer only to types A and B" or "UID not honored" or "name must
+                  be restricted".     Those cannot be well described when embedded.  3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen.  4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity     during interpretation and require a REST
+                  mapping.  In most cases, the dependency is on the group,resource
+                  tuple     and the version of the actual struct is irrelevant.  5.
+                  We cannot easily change it.  Because this type is embedded in many
+                  locations, updates to this type     will affect numerous schemas.  Don''t
+                  make new APIs embed an underspecified API type they do not control.
+                  Instead of using this type, create a locally provided and used type
+                  that is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  .'
                 properties:
-                  executionNamespace:
-                    description: Holds the name of the namespace where hooks should
-                      be implemented.
+                  apiVersion:
+                    description: API version of the referent.
                     type: string
-                  phase:
-                    description: 'Indicates the phase when the hooks will be executed.
-                      Acceptable values are: PreBackup, PostBackup, PreRestore, and
-                      PostRestore.'
-                    type: string
-                  reference:
-                    description: 'ObjectReference contains enough information to let
-                      you inspect or modify the referred object. --- New uses of this
-                      type are discouraged because of difficulty describing its usage
-                      when embedded in APIs.  1. Ignored fields.  It includes many
-                      fields which are not generally honored.  For instance, ResourceVersion
-                      and FieldPath are both very rarely valid in actual usage.  2.
-                      Invalid usage help.  It is impossible to add specific help for
-                      individual usage.  In most embedded usages, there are particular     restrictions
-                      like, "must refer only to types A and B" or "UID not honored"
-                      or "name must be restricted".     Those cannot be well described
-                      when embedded.  3. Inconsistent validation.  Because the usages
-                      are different, the validation rules are different by usage,
-                      which makes it hard for users to predict what will happen.  4.
-                      The fields are both imprecise and overly precise.  Kind is not
-                      a precise mapping to a URL. This can produce ambiguity     during
-                      interpretation and require a REST mapping.  In most cases, the
-                      dependency is on the group,resource tuple     and the version
-                      of the actual struct is irrelevant.  5. We cannot easily change
-                      it.  Because this type is embedded in many locations, updates
-                      to this type     will affect numerous schemas.  Don''t make
-                      new APIs embed an underspecified API type they do not control.
-                      Instead of using this type, create a locally provided and used
-                      type that is well-focused on your reference. For example, ServiceReferences
-                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                      .'
-                    properties:
-                      apiVersion:
-                        description: API version of the referent.
-                        type: string
-                      fieldPath:
-                        description: 'If referring to a piece of an object instead
-                          of an entire object, this string should contain a valid
-                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                          For example, if the object reference is to a container within
-                          a pod, this would take on a value like: "spec.containers{name}"
-                          (where "name" refers to the name of the container that triggered
-                          the event) or if no container name is specified "spec.containers[2]"
-                          (container with index 2 in this pod). This syntax is chosen
-                          only to have some well-defined way of referencing a part
-                          of an object. TODO: this design is not final and this field
-                          is subject to change in the future.'
-                        type: string
-                      kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      namespace:
-                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                        type: string
-                      resourceVersion:
-                        description: 'Specific resourceVersion to which this reference
-                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                        type: string
-                      uid:
-                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                        type: string
-                    type: object
-                  serviceAccount:
-                    description: Holds the name of the service account to be used
-                      for running hooks.
-                    type: string
-                required:
-                - executionNamespace
-                - phase
-                - reference
-                - serviceAccount
-                type: object
-              type: array
-            includedResources:
-              description: IncludedResources optional list of included resources in
-                Velero Backup
-              items:
-                description: GroupKind specifies a Group and a Kind, but does not
-                  force a version.  This is useful for identifying concepts during
-                  lookup stages without having partially valid types
-                properties:
-                  group:
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
                     type: string
                   kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
-                required:
-                - group
-                - kind
-                type: object
-              type: array
-            indirectImageMigration:
-              description: If set True, disables direct image migrations.
-              type: boolean
-            indirectVolumeMigration:
-              description: If set True, disables direct volume migrations.
-              type: boolean
-            labelSelector:
-              description: LabelSelector optional label selector on the included resources
-                in Velero Backup
-              properties:
-                matchExpressions:
-                  description: matchExpressions is a list of label selector requirements.
-                    The requirements are ANDed.
-                  items:
-                    description: A label selector requirement is a selector that contains
-                      values, a key, and an operator that relates the key and values.
-                    properties:
-                      key:
-                        description: key is the label key that the selector applies
-                          to.
-                        type: string
-                      operator:
-                        description: operator represents a key's relationship to a
-                          set of values. Valid operators are In, NotIn, Exists and
-                          DoesNotExist.
-                        type: string
-                      values:
-                        description: values is an array of string values. If the operator
-                          is In or NotIn, the values array must be non-empty. If the
-                          operator is Exists or DoesNotExist, the values array must
-                          be empty. This array is replaced during a strategic merge
-                          patch.
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - key
-                    - operator
-                    type: object
-                  type: array
-                matchLabels:
-                  additionalProperties:
-                    type: string
-                  description: matchLabels is a map of {key,value} pairs. A single
-                    {key,value} in the matchLabels map is equivalent to an element
-                    of matchExpressions, whose key field is "key", the operator is
-                    "In", and the values array contains only "value". The requirements
-                    are ANDed.
-                  type: object
-              type: object
-            migStorageRef:
-              description: 'ObjectReference contains enough information to let you
-                inspect or modify the referred object. --- New uses of this type are
-                discouraged because of difficulty describing its usage when embedded
-                in APIs.  1. Ignored fields.  It includes many fields which are not
-                generally honored.  For instance, ResourceVersion and FieldPath are
-                both very rarely valid in actual usage.  2. Invalid usage help.  It
-                is impossible to add specific help for individual usage.  In most
-                embedded usages, there are particular     restrictions like, "must
-                refer only to types A and B" or "UID not honored" or "name must be
-                restricted".     Those cannot be well described when embedded.  3.
-                Inconsistent validation.  Because the usages are different, the validation
-                rules are different by usage, which makes it hard for users to predict
-                what will happen.  4. The fields are both imprecise and overly precise.  Kind
-                is not a precise mapping to a URL. This can produce ambiguity     during
-                interpretation and require a REST mapping.  In most cases, the dependency
-                is on the group,resource tuple     and the version of the actual struct
-                is irrelevant.  5. We cannot easily change it.  Because this type
-                is embedded in many locations, updates to this type     will affect
-                numerous schemas.  Don''t make new APIs embed an underspecified API
-                type they do not control. Instead of using this type, create a locally
-                provided and used type that is well-focused on your reference. For
-                example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                .'
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            namespaces:
-              description: Holds names of all the namespaces to be included in migration.
-              items:
-                type: string
-              type: array
-            persistentVolumes:
-              items:
-                description: Name - The PV name. Capacity - The PV storage capacity.
-                  StorageClass - The PV storage class name. Supported - Lists of what
-                  is supported. Selection - Choices made from supported. PVC - Associated
-                  PVC. NFS - NFS properties. staged - A PV has been explicitly added/updated.
-                properties:
-                  capacity:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  capacityConfirmed:
-                    type: boolean
                   name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
-                  proposedCapacity:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  pvc:
-                    description: PVC
-                    properties:
-                      accessModes:
-                        items:
-                          type: string
-                        type: array
-                      hasReference:
-                        type: boolean
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    type: object
-                  selection:
-                    description: Selection Action - The PV migration action (move|copy|skip)
-                      StorageClass - The PV storage class name to use in the destination
-                      cluster. AccessMode   - The PV access mode to use in the destination
-                      cluster, if different from src PVC AccessMode CopyMethod   -
-                      The PV copy method to use ('filesystem' for restic copy, or
-                      'snapshot' for velero snapshot plugin) Verify       - Whether
-                      or not to verify copied volume data if CopyMethod is 'filesystem'
-                    properties:
-                      accessMode:
-                        type: string
-                      action:
-                        type: string
-                      copyMethod:
-                        type: string
-                      storageClass:
-                        type: string
-                      verify:
-                        type: boolean
-                    type: object
-                  storageClass:
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                     type: string
-                  supported:
-                    description: Supported Actions     - The list of supported actions
-                      CopyMethods - The list of supported copy methods
-                    properties:
-                      actions:
-                        items:
-                          type: string
-                        type: array
-                      copyMethods:
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - actions
-                    - copyMethods
-                    type: object
-                required:
-                - selection
-                - supported
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
                 type: object
-              type: array
-            refresh:
-              description: If set True, the controller is forced to check if the migplan
-                is in Ready state or not.
-              type: boolean
-            srcMigClusterRef:
-              description: 'ObjectReference contains enough information to let you
-                inspect or modify the referred object. --- New uses of this type are
-                discouraged because of difficulty describing its usage when embedded
-                in APIs.  1. Ignored fields.  It includes many fields which are not
-                generally honored.  For instance, ResourceVersion and FieldPath are
-                both very rarely valid in actual usage.  2. Invalid usage help.  It
-                is impossible to add specific help for individual usage.  In most
-                embedded usages, there are particular     restrictions like, "must
-                refer only to types A and B" or "UID not honored" or "name must be
-                restricted".     Those cannot be well described when embedded.  3.
-                Inconsistent validation.  Because the usages are different, the validation
-                rules are different by usage, which makes it hard for users to predict
-                what will happen.  4. The fields are both imprecise and overly precise.  Kind
-                is not a precise mapping to a URL. This can produce ambiguity     during
-                interpretation and require a REST mapping.  In most cases, the dependency
-                is on the group,resource tuple     and the version of the actual struct
-                is irrelevant.  5. We cannot easily change it.  Because this type
-                is embedded in many locations, updates to this type     will affect
-                numerous schemas.  Don''t make new APIs embed an underspecified API
-                type they do not control. Instead of using this type, create a locally
-                provided and used type that is well-focused on your reference. For
-                example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                .'
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-          type: object
-        status:
-          description: MigPlanStatus defines the observed state of MigPlan
-          properties:
-            conditions:
-              items:
-                description: Condition Type - The condition type. Status - The condition
-                  status. Reason - The reason for the condition. Message - The human
-                  readable description of the condition. Durable - The condition is
-                  not un-staged. Items - A list of `items` associated with the condition
-                  used to replace [] in `Message`. staging - A condition has been
-                  explicitly set/updated.
-                properties:
-                  category:
-                    type: string
-                  durable:
-                    type: boolean
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                required:
-                - category
-                - lastTransitionTime
-                - status
-                - type
-                type: object
-              type: array
-            destStorageClasses:
-              items:
-                description: StorageClass is an available storage class in the cluster
-                  Name - the storage class name Provisioner - the dynamic provisioner
-                  for the storage class Default - whether or not this storage class
-                  is the default AccessModes - access modes supported by the dynamic
-                  provisioner
-                properties:
-                  accessModes:
-                    items:
+              hooks:
+                description: Holds a reference to a MigHook along with the desired
+                  phase to run it in.
+                items:
+                  description: MigPlanHook hold a reference to a MigHook along with
+                    the desired phase to run it in
+                  properties:
+                    executionNamespace:
+                      description: Holds the name of the namespace where hooks should
+                        be implemented.
                       type: string
-                    type: array
-                  default:
-                    type: boolean
-                  name:
-                    type: string
-                  provisioner:
-                    type: string
-                type: object
-              type: array
-            excludedResources:
-              items:
-                type: string
-              type: array
-            incompatibleNamespaces:
-              items:
-                description: IncompatibleNamespace - namespace, which is noticed to
-                  contain resources incompatible by the migration
-                properties:
-                  gvks:
-                    items:
-                      description: IncompatibleGVK - custom structure for printing
-                        GVKs lowercase
+                    phase:
+                      description: 'Indicates the phase when the hooks will be executed.
+                        Acceptable values are: PreBackup, PostBackup, PreRestore,
+                        and PostRestore.'
+                      type: string
+                    reference:
+                      description: 'ObjectReference contains enough information to
+                        let you inspect or modify the referred object. --- New uses
+                        of this type are discouraged because of difficulty describing
+                        its usage when embedded in APIs.  1. Ignored fields.  It includes
+                        many fields which are not generally honored.  For instance,
+                        ResourceVersion and FieldPath are both very rarely valid in
+                        actual usage.  2. Invalid usage help.  It is impossible to
+                        add specific help for individual usage.  In most embedded
+                        usages, there are particular     restrictions like, "must
+                        refer only to types A and B" or "UID not honored" or "name
+                        must be restricted".     Those cannot be well described when
+                        embedded.  3. Inconsistent validation.  Because the usages
+                        are different, the validation rules are different by usage,
+                        which makes it hard for users to predict what will happen.  4.
+                        The fields are both imprecise and overly precise.  Kind is
+                        not a precise mapping to a URL. This can produce ambiguity     during
+                        interpretation and require a REST mapping.  In most cases,
+                        the dependency is on the group,resource tuple     and the
+                        version of the actual struct is irrelevant.  5. We cannot
+                        easily change it.  Because this type is embedded in many locations,
+                        updates to this type     will affect numerous schemas.  Don''t
+                        make new APIs embed an underspecified API type they do not
+                        control. Instead of using this type, create a locally provided
+                        and used type that is well-focused on your reference. For
+                        example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                        .'
                       properties:
-                        group:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
                           type: string
                         kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                           type: string
-                        version:
-                          type: string
-                      required:
-                      - group
-                      - kind
-                      - version
-                      type: object
-                    type: array
-                  name:
-                    type: string
-                required:
-                - gvks
-                - name
-                type: object
-              type: array
-            namespaces:
-              items:
-                description: UnhealthyNamespace is a store for unhealthy resources
-                  in a namespace
-                properties:
-                  name:
-                    type: string
-                  workloads:
-                    items:
-                      description: Workload is a store for unhealthy resource and
-                        it's dependents
-                      properties:
                         name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
-                        resources:
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                    serviceAccount:
+                      description: Holds the name of the service account to be used
+                        for running hooks.
+                      type: string
+                  required:
+                  - executionNamespace
+                  - phase
+                  - reference
+                  - serviceAccount
+                  type: object
+                type: array
+              includedResources:
+                description: IncludedResources optional list of included resources
+                  in Velero Backup When not set, all the resources are included in
+                  the backup
+                items:
+                  description: GroupKind specifies a Group and a Kind, but does not
+                    force a version.  This is useful for identifying concepts during
+                    lookup stages without having partially valid types
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                type: array
+              indirectImageMigration:
+                description: If set True, disables direct image migrations.
+                type: boolean
+              indirectVolumeMigration:
+                description: If set True, disables direct volume migrations.
+                type: boolean
+              labelSelector:
+                description: LabelSelector optional label selector on the included
+                  resources in Velero Backup
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
                             type: string
                           type: array
                       required:
-                      - name
+                      - key
+                      - operator
                       type: object
                     type: array
-                required:
-                - name
-                - workloads
-                type: object
-              type: array
-            observedDigest:
-              type: string
-            srcStorageClasses:
-              items:
-                description: StorageClass is an available storage class in the cluster
-                  Name - the storage class name Provisioner - the dynamic provisioner
-                  for the storage class Default - whether or not this storage class
-                  is the default AccessModes - access modes supported by the dynamic
-                  provisioner
-                properties:
-                  accessModes:
-                    items:
+                  matchLabels:
+                    additionalProperties:
                       type: string
-                    type: array
-                  default:
-                    type: boolean
-                  name:
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              migStorageRef:
+                description: 'ObjectReference contains enough information to let you
+                  inspect or modify the referred object. --- New uses of this type
+                  are discouraged because of difficulty describing its usage when
+                  embedded in APIs.  1. Ignored fields.  It includes many fields which
+                  are not generally honored.  For instance, ResourceVersion and FieldPath
+                  are both very rarely valid in actual usage.  2. Invalid usage help.  It
+                  is impossible to add specific help for individual usage.  In most
+                  embedded usages, there are particular     restrictions like, "must
+                  refer only to types A and B" or "UID not honored" or "name must
+                  be restricted".     Those cannot be well described when embedded.  3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen.  4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity     during interpretation and require a REST
+                  mapping.  In most cases, the dependency is on the group,resource
+                  tuple     and the version of the actual struct is irrelevant.  5.
+                  We cannot easily change it.  Because this type is embedded in many
+                  locations, updates to this type     will affect numerous schemas.  Don''t
+                  make new APIs embed an underspecified API type they do not control.
+                  Instead of using this type, create a locally provided and used type
+                  that is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  .'
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
                     type: string
-                  provisioner:
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+              namespaces:
+                description: Holds names of all the namespaces to be included in migration.
+                items:
+                  type: string
+                type: array
+              persistentVolumes:
+                items:
+                  description: Name - The PV name. Capacity - The PV storage capacity.
+                    StorageClass - The PV storage class name. Supported - Lists of
+                    what is supported. Selection - Choices made from supported. PVC
+                    - Associated PVC. NFS - NFS properties. staged - A PV has been
+                    explicitly added/updated.
+                  properties:
+                    capacity:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    capacityConfirmed:
+                      type: boolean
+                    name:
+                      type: string
+                    proposedCapacity:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    pvc:
+                      description: PVC
+                      properties:
+                        accessModes:
+                          items:
+                            type: string
+                          type: array
+                        hasReference:
+                          type: boolean
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                    selection:
+                      description: Selection Action - The PV migration action (move|copy|skip)
+                        StorageClass - The PV storage class name to use in the destination
+                        cluster. AccessMode   - The PV access mode to use in the destination
+                        cluster, if different from src PVC AccessMode CopyMethod   -
+                        The PV copy method to use ('filesystem' for restic copy, or
+                        'snapshot' for velero snapshot plugin) Verify       - Whether
+                        or not to verify copied volume data if CopyMethod is 'filesystem'
+                      properties:
+                        accessMode:
+                          type: string
+                        action:
+                          type: string
+                        copyMethod:
+                          type: string
+                        storageClass:
+                          type: string
+                        verify:
+                          type: boolean
+                      type: object
+                    storageClass:
+                      type: string
+                    supported:
+                      description: Supported Actions     - The list of supported actions
+                        CopyMethods - The list of supported copy methods
+                      properties:
+                        actions:
+                          items:
+                            type: string
+                          type: array
+                        copyMethods:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - actions
+                      - copyMethods
+                      type: object
+                  required:
+                  - selection
+                  - supported
+                  type: object
+                type: array
+              refresh:
+                description: If set True, the controller is forced to check if the
+                  migplan is in Ready state or not.
+                type: boolean
+              srcMigClusterRef:
+                description: 'ObjectReference contains enough information to let you
+                  inspect or modify the referred object. --- New uses of this type
+                  are discouraged because of difficulty describing its usage when
+                  embedded in APIs.  1. Ignored fields.  It includes many fields which
+                  are not generally honored.  For instance, ResourceVersion and FieldPath
+                  are both very rarely valid in actual usage.  2. Invalid usage help.  It
+                  is impossible to add specific help for individual usage.  In most
+                  embedded usages, there are particular     restrictions like, "must
+                  refer only to types A and B" or "UID not honored" or "name must
+                  be restricted".     Those cannot be well described when embedded.  3.
+                  Inconsistent validation.  Because the usages are different, the
+                  validation rules are different by usage, which makes it hard for
+                  users to predict what will happen.  4. The fields are both imprecise
+                  and overly precise.  Kind is not a precise mapping to a URL. This
+                  can produce ambiguity     during interpretation and require a REST
+                  mapping.  In most cases, the dependency is on the group,resource
+                  tuple     and the version of the actual struct is irrelevant.  5.
+                  We cannot easily change it.  Because this type is embedded in many
+                  locations, updates to this type     will affect numerous schemas.  Don''t
+                  make new APIs embed an underspecified API type they do not control.
+                  Instead of using this type, create a locally provided and used type
+                  that is well-focused on your reference. For example, ServiceReferences
+                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  .'
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+            type: object
+          status:
+            description: MigPlanStatus defines the observed state of MigPlan
+            properties:
+              conditions:
+                items:
+                  description: Condition Type - The condition type. Status - The condition
+                    status. Reason - The reason for the condition. Message - The human
+                    readable description of the condition. Durable - The condition
+                    is not un-staged. Items - A list of `items` associated with the
+                    condition used to replace [] in `Message`. staging - A condition
+                    has been explicitly set/updated.
+                  properties:
+                    category:
+                      type: string
+                    durable:
+                      type: boolean
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              destStorageClasses:
+                items:
+                  description: StorageClass is an available storage class in the cluster
+                    Name - the storage class name Provisioner - the dynamic provisioner
+                    for the storage class Default - whether or not this storage class
+                    is the default AccessModes - access modes supported by the dynamic
+                    provisioner
+                  properties:
+                    accessModes:
+                      items:
+                        type: string
+                      type: array
+                    default:
+                      type: boolean
+                    name:
+                      type: string
+                    provisioner:
+                      type: string
+                  type: object
+                type: array
+              excludedResources:
+                items:
+                  type: string
+                type: array
+              incompatibleNamespaces:
+                items:
+                  description: IncompatibleNamespace - namespace, which is noticed
+                    to contain resources incompatible by the migration
+                  properties:
+                    gvks:
+                      items:
+                        description: IncompatibleGVK - custom structure for printing
+                          GVKs lowercase
+                        properties:
+                          group:
+                            type: string
+                          kind:
+                            type: string
+                          version:
+                            type: string
+                        required:
+                        - group
+                        - kind
+                        - version
+                        type: object
+                      type: array
+                    name:
+                      type: string
+                  required:
+                  - gvks
+                  - name
+                  type: object
+                type: array
+              namespaces:
+                items:
+                  description: UnhealthyNamespace is a store for unhealthy resources
+                    in a namespace
+                  properties:
+                    name:
+                      type: string
+                    workloads:
+                      items:
+                        description: Workload is a store for unhealthy resource and
+                          it's dependents
+                        properties:
+                          name:
+                            type: string
+                          resources:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  - workloads
+                  type: object
+                type: array
+              observedDigest:
+                type: string
+              srcStorageClasses:
+                items:
+                  description: StorageClass is an available storage class in the cluster
+                    Name - the storage class name Provisioner - the dynamic provisioner
+                    for the storage class Default - whether or not this storage class
+                    is the default AccessModes - access modes supported by the dynamic
+                    provisioner
+                  properties:
+                    accessModes:
+                      items:
+                        type: string
+                      type: array
+                    default:
+                      type: boolean
+                    name:
+                      type: string
+                    provisioner:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crds/migration.openshift.io_migstorages.yaml
+++ b/config/crds/migration.openshift.io_migstorages.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,269 +8,267 @@ metadata:
   creationTimestamp: null
   name: migstorages.migration.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .spec.backupStorageProvider
-    name: BackupStorageProvider
-    type: string
-  - JSONPath: .spec.volumeSnapshotProvider
-    name: VolumeSnapshotProvider
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: migration.openshift.io
   names:
     kind: MigStorage
     listKind: MigStorageList
     plural: migstorages
     singular: migstorage
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: MigStorage is the Schema for the migstorages API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MigStorageSpec defines the desired state of MigStorage
-          properties:
-            backupStorageConfig:
-              description: Defines config for creating and storing Backups. This is
-                a required field.
-              properties:
-                awsBucketName:
-                  type: string
-                awsKmsKeyId:
-                  type: string
-                awsPublicUrl:
-                  type: string
-                awsRegion:
-                  type: string
-                awsS3ForcePathStyle:
-                  type: boolean
-                awsS3Url:
-                  type: string
-                awsSignatureVersion:
-                  type: string
-                azureResourceGroup:
-                  type: string
-                azureStorageAccount:
-                  type: string
-                azureStorageContainer:
-                  type: string
-                credsSecretRef:
-                  description: 'ObjectReference contains enough information to let
-                    you inspect or modify the referred object. --- New uses of this
-                    type are discouraged because of difficulty describing its usage
-                    when embedded in APIs.  1. Ignored fields.  It includes many fields
-                    which are not generally honored.  For instance, ResourceVersion
-                    and FieldPath are both very rarely valid in actual usage.  2.
-                    Invalid usage help.  It is impossible to add specific help for
-                    individual usage.  In most embedded usages, there are particular     restrictions
-                    like, "must refer only to types A and B" or "UID not honored"
-                    or "name must be restricted".     Those cannot be well described
-                    when embedded.  3. Inconsistent validation.  Because the usages
-                    are different, the validation rules are different by usage, which
-                    makes it hard for users to predict what will happen.  4. The fields
-                    are both imprecise and overly precise.  Kind is not a precise
-                    mapping to a URL. This can produce ambiguity     during interpretation
-                    and require a REST mapping.  In most cases, the dependency is
-                    on the group,resource tuple     and the version of the actual
-                    struct is irrelevant.  5. We cannot easily change it.  Because
-                    this type is embedded in many locations, updates to this type     will
-                    affect numerous schemas.  Don''t make new APIs embed an underspecified
-                    API type they do not control. Instead of using this type, create
-                    a locally provided and used type that is well-focused on your
-                    reference. For example, ServiceReferences for admission registration:
-                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                    .'
-                  properties:
-                    apiVersion:
-                      description: API version of the referent.
-                      type: string
-                    fieldPath:
-                      description: 'If referring to a piece of an object instead of
-                        an entire object, this string should contain a valid JSON/Go
-                        field access statement, such as desiredState.manifest.containers[2].
-                        For example, if the object reference is to a container within
-                        a pod, this would take on a value like: "spec.containers{name}"
-                        (where "name" refers to the name of the container that triggered
-                        the event) or if no container name is specified "spec.containers[2]"
-                        (container with index 2 in this pod). This syntax is chosen
-                        only to have some well-defined way of referencing a part of
-                        an object. TODO: this design is not final and this field is
-                        subject to change in the future.'
-                      type: string
-                    kind:
-                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                      type: string
-                    namespace:
-                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                      type: string
-                    resourceVersion:
-                      description: 'Specific resourceVersion to which this reference
-                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                      type: string
-                    uid:
-                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                      type: string
-                  type: object
-                gcpBucket:
-                  type: string
-                insecure:
-                  type: boolean
-                s3CustomCABundle:
-                  format: byte
-                  type: string
-              type: object
-            backupStorageProvider:
-              description: Holds the provider name whose object storage is used for
-                backup storage location. This is a required field.
-              type: string
-            refresh:
-              description: Triggers a reconcile for the MigStorage CRD.
-              type: boolean
-            volumeSnapshotConfig:
-              description: Defines config for taking Volume Snapshots.
-              properties:
-                awsRegion:
-                  type: string
-                azureApiTimeout:
-                  type: string
-                azureResourceGroup:
-                  type: string
-                credsSecretRef:
-                  description: 'ObjectReference contains enough information to let
-                    you inspect or modify the referred object. --- New uses of this
-                    type are discouraged because of difficulty describing its usage
-                    when embedded in APIs.  1. Ignored fields.  It includes many fields
-                    which are not generally honored.  For instance, ResourceVersion
-                    and FieldPath are both very rarely valid in actual usage.  2.
-                    Invalid usage help.  It is impossible to add specific help for
-                    individual usage.  In most embedded usages, there are particular     restrictions
-                    like, "must refer only to types A and B" or "UID not honored"
-                    or "name must be restricted".     Those cannot be well described
-                    when embedded.  3. Inconsistent validation.  Because the usages
-                    are different, the validation rules are different by usage, which
-                    makes it hard for users to predict what will happen.  4. The fields
-                    are both imprecise and overly precise.  Kind is not a precise
-                    mapping to a URL. This can produce ambiguity     during interpretation
-                    and require a REST mapping.  In most cases, the dependency is
-                    on the group,resource tuple     and the version of the actual
-                    struct is irrelevant.  5. We cannot easily change it.  Because
-                    this type is embedded in many locations, updates to this type     will
-                    affect numerous schemas.  Don''t make new APIs embed an underspecified
-                    API type they do not control. Instead of using this type, create
-                    a locally provided and used type that is well-focused on your
-                    reference. For example, ServiceReferences for admission registration:
-                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                    .'
-                  properties:
-                    apiVersion:
-                      description: API version of the referent.
-                      type: string
-                    fieldPath:
-                      description: 'If referring to a piece of an object instead of
-                        an entire object, this string should contain a valid JSON/Go
-                        field access statement, such as desiredState.manifest.containers[2].
-                        For example, if the object reference is to a container within
-                        a pod, this would take on a value like: "spec.containers{name}"
-                        (where "name" refers to the name of the container that triggered
-                        the event) or if no container name is specified "spec.containers[2]"
-                        (container with index 2 in this pod). This syntax is chosen
-                        only to have some well-defined way of referencing a part of
-                        an object. TODO: this design is not final and this field is
-                        subject to change in the future.'
-                      type: string
-                    kind:
-                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                      type: string
-                    namespace:
-                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                      type: string
-                    resourceVersion:
-                      description: 'Specific resourceVersion to which this reference
-                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                      type: string
-                    uid:
-                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                      type: string
-                  type: object
-                snapshotCreationTimeout:
-                  type: string
-              type: object
-            volumeSnapshotProvider:
-              description: Holds the provider name whose object storage is used for
-                backup storage location.
-              type: string
-          required:
-          - backupStorageConfig
-          - backupStorageProvider
-          type: object
-        status:
-          description: MigStorageStatus defines the observed state of MigStorage
-          properties:
-            conditions:
-              items:
-                description: Condition Type - The condition type. Status - The condition
-                  status. Reason - The reason for the condition. Message - The human
-                  readable description of the condition. Durable - The condition is
-                  not un-staged. Items - A list of `items` associated with the condition
-                  used to replace [] in `Message`. staging - A condition has been
-                  explicitly set/updated.
-                properties:
-                  category:
-                    type: string
-                  durable:
-                    type: boolean
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                required:
-                - category
-                - lastTransitionTime
-                - status
-                - type
-                type: object
-              type: array
-            observedDigest:
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.backupStorageProvider
+      name: BackupStorageProvider
+      type: string
+    - jsonPath: .spec.volumeSnapshotProvider
+      name: VolumeSnapshotProvider
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MigStorage is the Schema for the migstorages API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MigStorageSpec defines the desired state of MigStorage
+            properties:
+              backupStorageConfig:
+                description: Defines config for creating and storing Backups. This
+                  is a required field.
+                properties:
+                  awsBucketName:
+                    type: string
+                  awsKmsKeyId:
+                    type: string
+                  awsPublicUrl:
+                    type: string
+                  awsRegion:
+                    type: string
+                  awsS3ForcePathStyle:
+                    type: boolean
+                  awsS3Url:
+                    type: string
+                  awsSignatureVersion:
+                    type: string
+                  azureResourceGroup:
+                    type: string
+                  azureStorageAccount:
+                    type: string
+                  azureStorageContainer:
+                    type: string
+                  credsSecretRef:
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  gcpBucket:
+                    type: string
+                  insecure:
+                    type: boolean
+                  s3CustomCABundle:
+                    format: byte
+                    type: string
+                type: object
+              backupStorageProvider:
+                description: Holds the provider name whose object storage is used
+                  for backup storage location. This is a required field.
+                type: string
+              refresh:
+                description: Triggers a reconcile for the MigStorage CRD.
+                type: boolean
+              volumeSnapshotConfig:
+                description: Defines config for taking Volume Snapshots.
+                properties:
+                  awsRegion:
+                    type: string
+                  azureApiTimeout:
+                    type: string
+                  azureResourceGroup:
+                    type: string
+                  credsSecretRef:
+                    description: 'ObjectReference contains enough information to let
+                      you inspect or modify the referred object. --- New uses of this
+                      type are discouraged because of difficulty describing its usage
+                      when embedded in APIs.  1. Ignored fields.  It includes many
+                      fields which are not generally honored.  For instance, ResourceVersion
+                      and FieldPath are both very rarely valid in actual usage.  2.
+                      Invalid usage help.  It is impossible to add specific help for
+                      individual usage.  In most embedded usages, there are particular     restrictions
+                      like, "must refer only to types A and B" or "UID not honored"
+                      or "name must be restricted".     Those cannot be well described
+                      when embedded.  3. Inconsistent validation.  Because the usages
+                      are different, the validation rules are different by usage,
+                      which makes it hard for users to predict what will happen.  4.
+                      The fields are both imprecise and overly precise.  Kind is not
+                      a precise mapping to a URL. This can produce ambiguity     during
+                      interpretation and require a REST mapping.  In most cases, the
+                      dependency is on the group,resource tuple     and the version
+                      of the actual struct is irrelevant.  5. We cannot easily change
+                      it.  Because this type is embedded in many locations, updates
+                      to this type     will affect numerous schemas.  Don''t make
+                      new APIs embed an underspecified API type they do not control.
+                      Instead of using this type, create a locally provided and used
+                      type that is well-focused on your reference. For example, ServiceReferences
+                      for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                      .'
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  snapshotCreationTimeout:
+                    type: string
+                type: object
+              volumeSnapshotProvider:
+                description: Holds the provider name whose object storage is used
+                  for backup storage location.
+                type: string
+            required:
+            - backupStorageConfig
+            - backupStorageProvider
+            type: object
+          status:
+            description: MigStorageStatus defines the observed state of MigStorage
+            properties:
+              conditions:
+                items:
+                  description: Condition Type - The condition type. Status - The condition
+                    status. Reason - The reason for the condition. Message - The human
+                    readable description of the condition. Durable - The condition
+                    is not un-staged. Items - A list of `items` associated with the
+                    condition used to replace [] in `Message`. staging - A condition
+                    has been explicitly set/updated.
+                  properties:
+                    category:
+                      type: string
+                    durable:
+                      type: boolean
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - category
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedDigest:
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Implementation of [dual-stream v1beta1 removal approach ](https://github.com/konveyor/enhancements/tree/master/enhancements/crane-1.x/crd-v1beta1-removal/crd-v1beta1-removal-dual-stream) 

Adds v1 CRDs, replacing v1beta1 CRDs.

Once merged, mig-controller will no longer be runnable on OCP version 4.5-, but will work on OCP 4.9.

Related mig-operator PR: https://github.com/konveyor/mig-operator/pull/722