### PR TITLE
avoiding panic if pod labels/annotations are nil

### DIFF
--- a/pkg/controller/migmigration/stage.go
+++ b/pkg/controller/migmigration/stage.go
@@ -120,7 +120,13 @@ func GetApplicationPodsWithStageLabels(labels map[string]string, pvcMapping map[
 			continue
 		}
 		if len(excludePVC) > 0 {
+			if pod.Annotations == nil {
+				pod.Annotations = map[string]string{}
+			}
 			pod.Annotations[migapi.ExcludePVCPodAnnotation] = strings.Join(excludePVC, ",")
+		}
+		if pod.Labels == nil {
+			pod.Labels = map[string]string{}
 		}
 		for key, value := range labels {
 			pod.Labels[key] = value


### PR DESCRIPTION
Make sure that there is no panic because of no application pod labels and annotations
