### PR TITLE
when finding default SC, take into account beta annotations

### DIFF
--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -620,7 +620,12 @@ func (r *MigCluster) GetStorageClasses(client k8sclient.Client) ([]StorageClass,
 			AccessModes: r.accessModesForProvisioner(clusterStorageClass.Provisioner),
 		}
 		if clusterStorageClass.Annotations != nil {
-			storageClass.Default, _ = strconv.ParseBool(clusterStorageClass.Annotations["storageclass.kubernetes.io/is-default-class"])
+			isDefault, _ := strconv.ParseBool(clusterStorageClass.Annotations["storageclass.kubernetes.io/is-default-class"])
+			if isDefault {
+				storageClass.Default = true
+			} else {
+				storageClass.Default, _ = strconv.ParseBool(clusterStorageClass.Annotations["storageclass.beta.kubernetes.io/is-default-class"])
+			}
 		}
 		storageClasses = append(storageClasses, storageClass)
 	}


### PR DESCRIPTION
If the regular is-default-class annotation is not found,
check for storageclass.beta.kubernetes.io/is-default-class