### PR TITLE
Remove distinct cluster validation to allow intra-cluster state migrations

### DIFF
--- a/pkg/controller/directvolumemigration/validation.go
+++ b/pkg/controller/directvolumemigration/validation.go
@@ -2,7 +2,6 @@ package directvolumemigration
 
 import (
 	"context"
-	"reflect"
 
 	liberr "github.com/konveyor/controller/pkg/error"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
@@ -161,18 +160,6 @@ func (r ReconcileDirectVolumeMigration) validateDestCluster(ctx context.Context,
 			Reason:   NotSet,
 			Category: Critical,
 			Message:  InvalidDestinationClusterReferenceMessage,
-		})
-		return nil
-	}
-
-	// Check if clusters are unique
-	if reflect.DeepEqual(ref, direct.Spec.SrcMigClusterRef) {
-		direct.Status.SetCondition(migapi.Condition{
-			Type:     InvalidDestinationCluster,
-			Status:   True,
-			Reason:   NotDistinct,
-			Category: Critical,
-			Message:  InvalidDestinationClusterMessage,
 		})
 		return nil
 	}

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"path"
-	"reflect"
 	"strings"
 
 	liberr "github.com/konveyor/controller/pkg/error"
@@ -506,18 +505,6 @@ func (r ReconcileMigPlan) validateDestinationCluster(ctx context.Context, plan *
 			Reason:   NotSet,
 			Category: Critical,
 			Message:  "The `dstMigClusterRef` must reference a valid `migcluster`.",
-		})
-		return nil
-	}
-
-	// NotDistinct
-	if reflect.DeepEqual(ref, plan.Spec.SrcMigClusterRef) {
-		plan.Status.SetCondition(migapi.Condition{
-			Type:     InvalidDestinationCluster,
-			Status:   True,
-			Reason:   NotDistinct,
-			Category: Critical,
-			Message:  "The `srcMigClusterRef` and `dstMigClusterRef` cannot be the same.",
 		})
 		return nil
 	}


### PR DESCRIPTION
This PR removes the same cluster validation to allow intra-cluster migrations. We will be adding more validations to add warnings on corner cases such as Namespace collision, resource collision within the same namespace etc.