### PR TITLE
Use PVC source names wherever missing

### DIFF
--- a/pkg/controller/directvolumemigration/pvcs.go
+++ b/pkg/controller/directvolumemigration/pvcs.go
@@ -135,7 +135,7 @@ func (t *Task) findMatchingPV(plan *migapi.MigPlan, pvcName string, pvcNamespace
 	if plan != nil {
 		for i := range plan.Spec.PersistentVolumes.List {
 			planVol := &plan.Spec.PersistentVolumes.List[i]
-			if planVol.PVC.Name == pvcName && planVol.PVC.Namespace == pvcNamespace {
+			if planVol.PVC.GetSourceName() == pvcName && planVol.PVC.Namespace == pvcNamespace {
 				return planVol
 			}
 		}

--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -273,7 +273,7 @@ func (t *Task) annotatePVs(client k8sclient.Client, itemsUpdated int) (int, erro
 			context.TODO(),
 			k8sclient.ObjectKey{
 				Namespace: pv.PVC.Namespace,
-				Name:      pv.PVC.Name,
+				Name:      pv.PVC.GetSourceName(),
 			},
 			&pvcResource)
 		if err != nil {
@@ -304,7 +304,7 @@ func (t *Task) annotatePVs(client k8sclient.Client, itemsUpdated int) (int, erro
 		}
 		// Update
 		log.Info("Adding annotations/labels to source cluster PersistentVolumeClaim.",
-			"persistentVolumeClaim", path.Join(pv.PVC.Namespace, pv.PVC.Name))
+			"persistentVolumeClaim", path.Join(pv.PVC.Namespace, pv.PVC.GetSourceName()))
 		err = client.Update(context.TODO(), &pvcResource)
 		if err != nil {
 			return itemsUpdated, liberr.Wrap(err)

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -1542,7 +1542,7 @@ func (t *Task) getPVCs() map[k8sclient.ObjectKey]migapi.PV {
 	claims := map[k8sclient.ObjectKey]migapi.PV{}
 	for _, pv := range t.getStagePVs().List {
 		claimKey := k8sclient.ObjectKey{
-			Name:      pv.PVC.Name,
+			Name:      pv.PVC.GetSourceName(),
 			Namespace: pv.PVC.Namespace,
 		}
 		claims[claimKey] = pv

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -589,7 +589,7 @@ func (r *ReconcileMigPlan) processProposedPVCapacities(ctx context.Context, plan
 		for _, analyticNS := range analytic.Status.Analytics.Namespaces {
 			if planVol.PVC.Namespace == analyticNS.Namespace {
 				for _, analyticNSVol := range analyticNS.PersistentVolumes {
-					if planVol.PVC.Name == analyticNSVol.Name {
+					if planVol.PVC.GetSourceName() == analyticNSVol.Name {
 						// If new proposed capacity is greater than previous proposed capacity, set confirmed to False
 						if planVol.ProposedCapacity.Cmp(analyticNSVol.ProposedCapacity) > 0 {
 							planVol.CapacityConfirmed = false


### PR DESCRIPTION
This fixes issues arising due to the name mapping of PVC objects.