### PR TITLE
Bug 1997127: Fix rsync retry bug causing wrong status to be reported

### DIFF
--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -362,6 +362,10 @@ func (t *Task) createRsyncTransferClients(srcClient compat.Client,
 				newOperation.CurrentAttempt, _ = strconv.Atoi(pod.Labels[RsyncAttemptLabel])
 				updateOperationStatus(&currentStatus, pod)
 				if currentStatus.failed && currentStatus.operation.CurrentAttempt < GetRsyncPodBackOffLimit(*t.Owner) {
+					// since we have not yet attempted all retries,
+					// reset the failed status and set the pending status
+					currentStatus.failed = false
+					currentStatus.pending = true
 					labels[RsyncAttemptLabel] = fmt.Sprintf("%d", currentStatus.operation.CurrentAttempt+1)
 					rsyncOptions = append(rsyncOptions, rsynctransfer.WithSourcePodLabels(labels))
 					transfer, err := rsynctransfer.NewTransfer(


### PR DESCRIPTION
Rsync network warning "must" be triggered when all of the Rsync attempts are exhausted. Status.Failed() check returns when any of the Rsync operations have completely failed (all retries exhausted). In 1.6, we changed the retry logic (removed threads) and removed a function that handled the resetting of Rsync Operation Status. This PR fixes that issue. The Rsync failed status needs to be set only when all retries are exhausted and not before that.