### PR TITLE
Bug 1998062: Use migration-cluster-config values for Rsync/Stunnel transfer images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/joho/godotenv v1.3.0
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/konveyor/controller v0.4.1
-	github.com/konveyor/crane-lib v0.0.0-20210811180027-d1409c9df453
+	github.com/konveyor/crane-lib v0.0.0-20210831133451-c7ce984da9ef
 	github.com/konveyor/openshift-velero-plugin v0.0.0-20210729141849-876132e34f3d
 	github.com/mattn/go-isatty v0.0.13 // indirect
 	github.com/mattn/go-sqlite3 v1.14.4

--- a/go.sum
+++ b/go.sum
@@ -493,10 +493,10 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konveyor/controller v0.4.1 h1:0LiBaAIrXScOqb6OoIGOIqpK9dxBAQotPWEhP4JX4qk=
 github.com/konveyor/controller v0.4.1/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
-github.com/konveyor/crane-lib v0.0.0-20210803165702-e077c6bf9b66 h1:mbk0ofYRUmRtp0ENLa8vn2vk9pEZM5Cc4pyNL4j9HI8=
-github.com/konveyor/crane-lib v0.0.0-20210803165702-e077c6bf9b66/go.mod h1:7xlMNVE0ZgbAThr9+R7G3zZ88TOD7d4br50URQnv5U8=
 github.com/konveyor/crane-lib v0.0.0-20210811180027-d1409c9df453 h1:Jfu9C0GUFWSZlTjsvzED3o3iCcOLUcob5iRbuHZM6yw=
 github.com/konveyor/crane-lib v0.0.0-20210811180027-d1409c9df453/go.mod h1:7xlMNVE0ZgbAThr9+R7G3zZ88TOD7d4br50URQnv5U8=
+github.com/konveyor/crane-lib v0.0.0-20210831133451-c7ce984da9ef h1:0q206/vGjmDn3b//ARL5vlf20Lfq03Mo+QlIKZOKl0Q=
+github.com/konveyor/crane-lib v0.0.0-20210831133451-c7ce984da9ef/go.mod h1:7xlMNVE0ZgbAThr9+R7G3zZ88TOD7d4br50URQnv5U8=
 github.com/konveyor/openshift-velero-plugin v0.0.0-20210729141849-876132e34f3d h1:tETgPq+JxXhVhnrcLc7rcW9BURax36VUsix8DAU0wuY=
 github.com/konveyor/openshift-velero-plugin v0.0.0-20210729141849-876132e34f3d/go.mod h1:Yk0xQ4N5rwE1+NWLSFQUQLgNT1/8p4Uor60LlgQfymg=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=

--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -132,6 +132,30 @@ func (t *Task) getRsyncTransferOptions() ([]rsynctransfer.TransferOption, error)
 		rsynctransfer.Username("root"),
 		rsynctransfer.Password(rsyncPassword),
 	}
+	srcCluster, err := t.Owner.GetSourceCluster(t.Client)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+	if srcCluster != nil {
+		srcTransferImage, err := srcCluster.GetRsyncTransferImage(t.Client)
+		if err != nil {
+			return nil, liberr.Wrap(err)
+		}
+		transferOptions = append(transferOptions,
+			rsynctransfer.RsyncClientImage(srcTransferImage))
+	}
+	destCluster, err := t.Owner.GetDestinationCluster(t.Client)
+	if err != nil {
+		return nil, liberr.Wrap(err)
+	}
+	if destCluster != nil {
+		destTransferImage, err := destCluster.GetRsyncTransferImage(t.Client)
+		if err != nil {
+			return nil, liberr.Wrap(err)
+		}
+		transferOptions = append(transferOptions,
+			rsynctransfer.RsyncServerImage(destTransferImage))
+	}
 	if o.BwLimit > 0 {
 		transferOptions = append(transferOptions,
 			RsyncBwLimit(o.BwLimit))

--- a/pkg/controller/directvolumemigration/rsync_test.go
+++ b/pkg/controller/directvolumemigration/rsync_test.go
@@ -1163,20 +1163,37 @@ func TestTask_createRsyncTransferClients(t *testing.T) {
 		}
 		deps = append(deps, route)
 		stunnelConf := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: "crane2-stunnel-config", Namespace: ns},
+			ObjectMeta: metav1.ObjectMeta{Name: "crane2-stunnel-server-config", Namespace: ns},
 		}
 		deps = append(deps, stunnelConf)
 		rsyncConf := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: "crane2-rsync-config", Namespace: ns},
+			ObjectMeta: metav1.ObjectMeta{Name: "crane2-rsync-server-config", Namespace: ns},
 		}
 		deps = append(deps, rsyncConf)
 		stunnelSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "crane2-stunnel-secret", Namespace: ns},
+			ObjectMeta: metav1.ObjectMeta{Name: "crane2-stunnel-server-secret", Namespace: ns},
 			Data:       map[string][]byte{"tls.key": []byte{}, "tls.crt": []byte{}},
 		}
 		deps = append(deps, stunnelSecret)
 		rsyncSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "crane2-rsync-secret", Namespace: ns},
+			ObjectMeta: metav1.ObjectMeta{Name: "crane2-rsync-server-secret", Namespace: ns},
+			Data:       map[string][]byte{"tls.key": []byte{}, "tls.crt": []byte{}},
+		}
+		stunnelConf = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "crane2-stunnel-client-config", Namespace: ns},
+		}
+		deps = append(deps, stunnelConf)
+		rsyncConf = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "crane2-rsync-client-config", Namespace: ns},
+		}
+		deps = append(deps, rsyncConf)
+		stunnelSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "crane2-stunnel-client-secret", Namespace: ns},
+			Data:       map[string][]byte{"tls.key": []byte{}, "tls.crt": []byte{}},
+		}
+		deps = append(deps, stunnelSecret)
+		rsyncSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "crane2-rsync-client-secret", Namespace: ns},
 			Data:       map[string][]byte{"tls.key": []byte{}, "tls.crt": []byte{}},
 		}
 		deps = append(deps, rsyncSecret)


### PR DESCRIPTION
- Uses images configured in migration-cluster-config of respective clusters for Rsync/Stunnel 
- Passes proxy configuration as Stunnel options 
- Updates crane-lib dependency to commit which has the library fix