### PR TITLE
Bug 1951869: Fix nil ptr dereference when srcMigCluster is invalid

### DIFF
--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -296,6 +296,9 @@ func (r ReconcileMigPlan) getPotentialFilePermissionConflictNamespaces(plan *mig
 	if err != nil {
 		return nil, liberr.Wrap(err)
 	}
+	if srcCluster == nil {
+		return nil, nil
+	}
 	srcClient, err := srcCluster.GetClient(r)
 	if err != nil {
 		return nil, liberr.Wrap(err)
@@ -303,6 +306,9 @@ func (r ReconcileMigPlan) getPotentialFilePermissionConflictNamespaces(plan *mig
 	destCluster, err := plan.GetDestinationCluster(r)
 	if err != nil {
 		return nil, liberr.Wrap(err)
+	}
+	if destCluster == nil {
+		return nil, nil
 	}
 	destClient, err := destCluster.GetClient(r)
 	if err != nil {


### PR DESCRIPTION
In the course of testing https://bugzilla.redhat.com/show_bug.cgi?id=1951869 QE bumped into a nil pointer dereference coming from https://github.com/konveyor/mig-controller/blame/master/pkg/controller/migplan/validation.go#L299 which was merged about the same time my PR was.

This will allow the plan to go to Not Ready instead of crashing.

