### PR TITLE
Bug 1970338: Fix lookup for migmigration by UID so it returns true when exists

### DIFF
--- a/pkg/apis/migration/v1alpha1/labels.go
+++ b/pkg/apis/migration/v1alpha1/labels.go
@@ -48,6 +48,11 @@ const (
 	// for easy search or application rollback.
 	// The value is the Task.UID().
 	MigMigrationLabel = "migration.openshift.io/migrated-by-migmigration" // (migmigration UID)
+	// Mirrors the UID on a migmigration to the labels
+	// field for easy search. Distinct from migrated-by-migmigration
+	// since this shouldn't be used for rollback.
+	// The value is the migration.UID().
+	MigMigrationUIDLabel = "migration.openshift.io/migration-uid" // (migmigration UID)
 	// Identifies associated migmigration
 	// to assist manual debugging
 	// The value is Task.Owner.Name

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -529,15 +529,13 @@ func (t *Task) deleteStaleRestoresOnCluster(cluster *migapi.MigCluster) (int, in
 			continue
 		}
 		// Skip if missing a migmigration correlation label (only delete our own CRs)
-		// Example 'migmigration: 4c9d317f-f410-430b-af8f-4ecd7d17a7de'
-		corrKey, _ := t.Owner.GetCorrelationLabel()
-		migMigrationUID, ok := restore.ObjectMeta.Labels[corrKey]
+		migMigrationUID, ok := restore.ObjectMeta.Labels[migapi.MigMigrationLabel]
 		if !ok {
 			t.Log.V(4).Info("Restore does not have an attached label "+
 				"associating it with a MigMigration. Skipping deletion.",
 				"restore", path.Join(restore.Namespace, restore.Name),
 				"restorePhase", restore.Status.Phase,
-				"associationLabel", corrKey)
+				"associationLabel", migapi.MigMigrationLabel)
 			continue
 		}
 		// Skip if correlation label points to an existing, running migration
@@ -624,14 +622,13 @@ func (t *Task) deleteStalePVRsOnCluster(cluster *migapi.MigCluster) (int, error)
 			}
 			// Skip delete if missing a migmigration correlation label (only delete our own CRs)
 			// Example 'migmigration: 4c9d317f-f410-430b-af8f-4ecd7d17a7de'
-			corrKey, _ := t.Owner.GetCorrelationLabel()
-			migMigrationUID, ok := restore.ObjectMeta.Labels[corrKey]
+			migMigrationUID, ok := restore.ObjectMeta.Labels[migapi.MigMigrationLabel]
 			if !ok {
 				t.Log.V(4).Info("PodVolumeRestore does not have an attached label "+
 					"associating it with a MigMigration. Skipping deletion.",
 					"podVolumeRestore", path.Join(pvr.Namespace, pvr.Name),
 					"podVolumeRestoreStatus", pvr.Status.Phase,
-					"associationLabel", corrKey)
+					"associationLabel", migapi.MigMigrationLabel)
 				continue
 			}
 			isRunning, err := t.migrationUIDisRunning(migMigrationUID)


### PR DESCRIPTION
**Background info on fix:**

At the beginning of the migration process we try to clean up old Velero CRs to unblock the system.
We use various tests to determine if a backup is "stale" and worthy of deletion. One of those tests is to check if there is another running migration linked with an in-progress Backup. If we find this, we won't delete the Backup.

The function responsible for checking whether a migration is associated with the backup was always returning false because it was doing a lookup on migmigrations with an invalid labelSelector that would never return any results.
This means that when two migrations are running, one of them in the BackupCreated phase, one of them in the CleanStaleBackups phase, the second migration will clobber the first migrations active  backup

To resolve this, I added a usable label to the migmigration so we can lookup by UID, then used that label in the faulty function. I am no longer seeing failures when running parallel migrations.