### PR TITLE
Bug 2005438: sleep between checks for rsync completion

### DIFF
--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -1808,7 +1808,9 @@ func (req rsyncClientPodRequirements) getRsyncClientPodTemplate() corev1.Pod {
          do test -f /usr/share/rsync-stunnel-mgmt/rsync-client-container-done
          if [ $? -eq 0 ]
          then
-         break
+                break
+         else
+                sleep 1
          fi
          done
          exit 0`,


### PR DESCRIPTION
@alaypatel07 , 1.5.z backport of your crane-lib ([pull/74](https://github.com/konveyor/crane-lib/pull/74)) change for 1.5.2 release.  Let me know if anything else is needed.  Thanks!