### PR TITLE
API & validation changes for identifying types of migrations through Migration Plan

### DIFF
--- a/pkg/apis/migration/v1alpha1/migmigration_types.go
+++ b/pkg/apis/migration/v1alpha1/migmigration_types.go
@@ -34,6 +34,9 @@ type MigMigrationSpec struct {
 	// Invokes the stage operation, when set to true the migration controller switches to stage itinerary. This is a required field.
 	Stage bool `json:"stage"`
 
+	// Invokes the state migration operation
+	MigrateState bool `json:"migrateState,omitempty"`
+
 	// Specifies whether to quiesce the application Pods before migrating Persistent Volume data.
 	QuiescePods bool `json:"quiescePods,omitempty"`
 

--- a/pkg/controller/migmigration/backup.go
+++ b/pkg/controller/migmigration/backup.go
@@ -144,7 +144,7 @@ func (t *Task) ensureStageBackup() (*velero.Backup, error) {
 	newBackup.Labels[migapi.MigPlanLabel] = string(t.PlanResources.MigPlan.UID)
 	var includedResources mapset.Set
 
-	if (t.indirectImageMigration() || Settings.DisImgCopy) && !t.Owner.IsStateMigration() {
+	if (t.indirectImageMigration() || Settings.DisImgCopy) && !t.Owner.Spec.MigrateState {
 		includedResources = settings.IncludedStageResources
 	} else {
 		includedResources = settings.IncludedStageResources.Difference(mapset.NewSetFromSlice([]interface{}{settings.ISResource}))

--- a/pkg/controller/migmigration/registry.go
+++ b/pkg/controller/migmigration/registry.go
@@ -76,7 +76,7 @@ func (t *Task) isIndirectImageMigrationApplicable() (bool, error) {
 	}
 	applicable := t.PlanResources.MigPlan.Spec.IndirectImageMigration &&
 		!t.PlanResources.MigPlan.IsImageMigrationDisabled() && hasImageStreams &&
-		!t.Owner.IsStateMigration()
+		!t.Owner.Spec.MigrateState
 	return applicable, nil
 }
 

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -1325,7 +1325,7 @@ func (t *Task) allFlags(phase Phase) (bool, error) {
 	if phase.all&EnableImage != 0 && t.PlanResources.MigPlan.IsImageMigrationDisabled() {
 		return false, nil
 	}
-	if phase.all&EnableImage != 0 && t.Owner.IsStateMigration() {
+	if phase.all&EnableImage != 0 && t.Owner.Spec.MigrateState {
 		return false, nil
 	}
 	if phase.all&DirectVolume != 0 && !t.directVolumeMigration() {

--- a/pkg/controller/migmigration/validation_test.go
+++ b/pkg/controller/migmigration/validation_test.go
@@ -1,0 +1,309 @@
+package migmigration
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/compat"
+	fakecompat "github.com/konveyor/mig-controller/pkg/compat/fake"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestReconcileMigMigration_validateMigrationType(t *testing.T) {
+	getFakeClientWithObjs := func(obj ...k8sclient.Object) compat.Client {
+		client, _ := fakecompat.NewFakeClient(obj...)
+		return client
+	}
+	getTestMigCluster := func(name string, url string) *migapi.MigCluster {
+		return &migapi.MigCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: migapi.OpenshiftMigrationNamespace,
+			},
+			Spec: migapi.MigClusterSpec{
+				URL: url,
+			},
+		}
+	}
+	getTestMigPlan := func(srcCluster string, destCluster string, ns []string, pvMappings []string) *migapi.MigPlan {
+		PVs := []migapi.PV{}
+		for _, pvMapping := range pvMappings {
+			mapping := strings.Split(pvMapping, "/")
+			ns := mapping[0]
+			name := mapping[1]
+			PVs = append(PVs, migapi.PV{PVC: migapi.PVC{Name: name, Namespace: ns}})
+		}
+		return &migapi.MigPlan{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "migplan",
+				Namespace: migapi.OpenshiftMigrationNamespace,
+			},
+			Spec: migapi.MigPlanSpec{
+				SrcMigClusterRef:  &v1.ObjectReference{Name: srcCluster, Namespace: migapi.OpenshiftMigrationNamespace},
+				DestMigClusterRef: &v1.ObjectReference{Name: destCluster, Namespace: migapi.OpenshiftMigrationNamespace},
+				Namespaces:        ns,
+				PersistentVolumes: migapi.PersistentVolumes{List: PVs},
+			},
+		}
+	}
+	type args struct {
+		ctx       context.Context
+		plan      *migapi.MigPlan
+		migration *migapi.MigMigration
+	}
+	tests := []struct {
+		name               string
+		client             k8sclient.Client
+		args               args
+		wantErr            bool
+		wantConditions     []migapi.Condition
+		dontWantConditions []migapi.Condition
+	}{
+		{
+			name: "given a MigMigration with only stage set to false, should not have a critical condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+			),
+			args: args{
+				ctx:  context.TODO(),
+				plan: getTestMigPlan("test-cluster", "test-cluster", []string{}, []string{}),
+				migration: &migapi.MigMigration{
+					Spec: migapi.MigMigrationSpec{
+						Stage: false,
+					},
+				},
+			},
+			wantErr: false,
+			dontWantConditions: []migapi.Condition{{
+				Type: InvalidSpec,
+			}},
+		},
+		{
+			name: "given a MigMigration with only stage set to true, should not have a critical condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+			),
+			args: args{
+				ctx:  context.TODO(),
+				plan: getTestMigPlan("test-cluster", "test-cluster", []string{}, []string{}),
+				migration: &migapi.MigMigration{
+					Spec: migapi.MigMigrationSpec{
+						Stage: true,
+					},
+				},
+			},
+			wantErr: false,
+			dontWantConditions: []migapi.Condition{{
+				Type: InvalidSpec,
+			}},
+		},
+		{
+			name: "given a MigMigration with stage set to false & rollback set to true, should not have a critical condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+			),
+			args: args{
+				ctx:  context.TODO(),
+				plan: getTestMigPlan("test-cluster", "test-cluster", []string{}, []string{}),
+				migration: &migapi.MigMigration{
+					Spec: migapi.MigMigrationSpec{
+						Stage:    false,
+						Rollback: true,
+					},
+				},
+			},
+			wantErr: false,
+			dontWantConditions: []migapi.Condition{{
+				Type: InvalidSpec,
+			}},
+		},
+		{
+			name: "given a MigMigration with stage set to false & migrateState set to true, should not have a critical condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+			),
+			args: args{
+				ctx:  context.TODO(),
+				plan: getTestMigPlan("test-cluster", "test-cluster", []string{}, []string{}),
+				migration: &migapi.MigMigration{
+					Spec: migapi.MigMigrationSpec{
+						Stage:        false,
+						MigrateState: true,
+					},
+				},
+			},
+			wantErr: false,
+			dontWantConditions: []migapi.Condition{{
+				Type: InvalidSpec,
+			}},
+		},
+		{
+			name: "given a MigMigration with stage & migrateState set to true, should have a critical condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+			),
+			args: args{
+				ctx:  context.TODO(),
+				plan: getTestMigPlan("test-cluster", "test-cluster", []string{}, []string{}),
+				migration: &migapi.MigMigration{
+					Spec: migapi.MigMigrationSpec{
+						MigrateState: true,
+						Stage:        true,
+					},
+				},
+			},
+			wantErr: false,
+			wantConditions: []migapi.Condition{{
+				Type:   InvalidSpec,
+				Reason: NotSupported,
+			}},
+		},
+		{
+			name: "given a MigMigration with stage & rollback set to true, should have a critical condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+			),
+			args: args{
+				ctx:  context.TODO(),
+				plan: getTestMigPlan("test-cluster", "test-cluster", []string{}, []string{}),
+				migration: &migapi.MigMigration{
+					Spec: migapi.MigMigrationSpec{
+						Rollback: true,
+						Stage:    true,
+					},
+				},
+			},
+			wantErr: false,
+			wantConditions: []migapi.Condition{{
+				Type:   InvalidSpec,
+				Reason: NotSupported,
+			}},
+		},
+		{
+			name: "given a MigMigration with stage & rollback & migrateState set to true, should have a critical condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+			),
+			args: args{
+				ctx:  context.TODO(),
+				plan: getTestMigPlan("test-cluster", "test-cluster", []string{}, []string{}),
+				migration: &migapi.MigMigration{
+					Spec: migapi.MigMigrationSpec{
+						Rollback:     true,
+						Stage:        true,
+						MigrateState: true,
+					},
+				},
+			},
+			wantErr: false,
+			wantConditions: []migapi.Condition{{
+				Type:   InvalidSpec,
+				Reason: NotSupported,
+			}},
+		},
+		{
+			name: "given a intra-cluster MigMigration with no conflicting PVCs, should not have a critical condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+			),
+			args: args{
+				ctx: context.TODO(),
+				plan: getTestMigPlan("test-cluster", "test-cluster", []string{
+					"ns-00:ns-00",
+					"ns-01:ns-01",
+				}, []string{
+					"ns-00/pv-00:pv-01",
+					"ns-00/pv-02:pv-03",
+					"ns-01/pv-01:pv-02",
+				}),
+				migration: &migapi.MigMigration{
+					Spec: migapi.MigMigrationSpec{
+						MigrateState: true,
+					},
+				},
+			},
+			wantErr: false,
+			dontWantConditions: []migapi.Condition{{
+				Type:   migapi.Failed,
+				Reason: PvNameConflict,
+			}},
+		},
+		{
+			name: "given a intra-cluster MigMigration with conflicting PVCs, should have a critical condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+			),
+			args: args{
+				ctx: context.TODO(),
+				plan: getTestMigPlan("test-cluster", "test-cluster", []string{
+					"ns-00:ns-00",
+				}, []string{
+					"ns-00/pv-00:pv-02",
+					"ns-00/pv-01:pv-02",
+				}),
+				migration: &migapi.MigMigration{
+					Spec: migapi.MigMigrationSpec{
+						MigrateState: true,
+					},
+				},
+			},
+			wantErr: false,
+			wantConditions: []migapi.Condition{{
+				Type:   ConflictingPVCMappings,
+				Reason: PvNameConflict,
+			}},
+		},
+		{
+			name: "given a intra-cluster final MigMigration with conflicting namespaces, should have a critical condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+			),
+			args: args{
+				ctx: context.TODO(),
+				plan: getTestMigPlan("test-cluster", "test-cluster", []string{
+					"ns-00:ns-00",
+					"ns-01:ns-01",
+				}, []string{}),
+				migration: &migapi.MigMigration{
+					Spec: migapi.MigMigrationSpec{
+						MigrateState: false,
+					},
+				},
+			},
+			wantErr: false,
+			wantConditions: []migapi.Condition{{
+				Type:   migapi.Failed,
+				Reason: NotSupported,
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := ReconcileMigMigration{
+				Client: tt.client,
+			}
+			if err := r.validateMigrationType(tt.args.ctx, tt.args.plan, tt.args.migration); (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileMigMigration.validateMigrationType() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			for _, wantCond := range tt.wantConditions {
+				foundCond := tt.args.migration.Status.FindCondition(wantCond.Type)
+				if foundCond == nil {
+					t.Errorf("ReconcileMigPlan.validatePossibleMigrationTypes() wantCondition = %s, found nil", wantCond.Type)
+				}
+				if foundCond != nil && foundCond.Reason != wantCond.Reason {
+					t.Errorf("ReconcileMigPlan.validatePossibleMigrationTypes() want reason = %s, found %s", wantCond.Reason, foundCond.Reason)
+				}
+			}
+			for _, dontWantCond := range tt.dontWantConditions {
+				foundCond := tt.args.migration.Status.FindCondition(dontWantCond.Type)
+				if foundCond != nil {
+					t.Errorf("ReconcileMigPlan.validatePossibleMigrationTypes() dontWantCondition = %s, found = %s", dontWantCond.Type, foundCond.Type)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/migplan/validation_test.go
+++ b/pkg/controller/migplan/validation_test.go
@@ -1,0 +1,256 @@
+package migplan
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/konveyor/mig-controller/pkg/compat"
+	fakecompat "github.com/konveyor/mig-controller/pkg/compat/fake"
+	"github.com/opentracing/opentracing-go/mocktracer"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestReconcileMigPlan_validatePossibleMigrationTypes(t *testing.T) {
+	getFakeClientWithObjs := func(obj ...k8sclient.Object) compat.Client {
+		client, _ := fakecompat.NewFakeClient(obj...)
+		return client
+	}
+	getTestMigCluster := func(name string, url string) *migapi.MigCluster {
+		return &migapi.MigCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: migapi.OpenshiftMigrationNamespace,
+			},
+			Spec: migapi.MigClusterSpec{
+				URL: url,
+			},
+		}
+	}
+	getTestMigPlan := func(srcCluster string, destCluster string, ns []string, conds []migapi.Condition) *migapi.MigPlan {
+		return &migapi.MigPlan{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "migplan",
+				Namespace: migapi.OpenshiftMigrationNamespace,
+			},
+			Spec: migapi.MigPlanSpec{
+				SrcMigClusterRef:  &v1.ObjectReference{Name: srcCluster, Namespace: migapi.OpenshiftMigrationNamespace},
+				DestMigClusterRef: &v1.ObjectReference{Name: destCluster, Namespace: migapi.OpenshiftMigrationNamespace},
+				Namespaces:        ns,
+			},
+			Status: migapi.MigPlanStatus{
+				Conditions: migapi.Conditions{
+					List: conds,
+				},
+			},
+		}
+	}
+	tests := []struct {
+		name               string
+		client             k8sclient.Client
+		plan               *migapi.MigPlan
+		wantErr            bool
+		wantConditions     []migapi.Condition
+		dontWantConditions []migapi.Condition
+	}{
+		{
+			name: "given a plan with zero state migrations associated, should not have any identification condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+			),
+			plan:           getTestMigPlan("test-cluster", "test-cluster", []string{}, []migapi.Condition{}),
+			wantErr:        false,
+			wantConditions: []migapi.Condition{},
+		},
+		{
+			name: "given an intra-cluster plan with one state migrations associated, should have the correct identification condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+				&migapi.MigMigration{
+					ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: migapi.OpenshiftMigrationNamespace},
+					Spec:       migapi.MigMigrationSpec{MigrateState: true},
+				},
+			),
+			plan:    getTestMigPlan("test-cluster", "test-cluster", []string{"ns-00:ns-01"}, []migapi.Condition{}),
+			wantErr: false,
+			wantConditions: []migapi.Condition{
+				{
+					Type:   MigrationTypeIdentified,
+					Reason: StateMigrationPlan,
+				},
+			},
+		},
+		{
+			name: "given a plan referencing two different clusters with one state migrations associated, should have the correct identification condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+				getTestMigCluster("test-cluster-2", "http://test-api-2.com:6444"),
+				&migapi.MigMigration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test", Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec: migapi.MigMigrationSpec{MigrateState: true},
+				},
+			),
+			plan:    getTestMigPlan("test-cluster", "test-cluster-2", []string{}, []migapi.Condition{}),
+			wantErr: false,
+			wantConditions: []migapi.Condition{
+				{
+					Type:   MigrationTypeIdentified,
+					Reason: StateMigrationPlan,
+				},
+			},
+		},
+		{
+			name: "given a plan referencing two different clusters with one state migration & a successful rollback associated with it, should not have the identification condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+				getTestMigCluster("test-cluster-2", "http://test-api-2.com:6444"),
+				&migapi.MigMigration{
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.Now(),
+						Name:              "stage-00", Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec: migapi.MigMigrationSpec{MigrateState: true},
+				},
+				&migapi.MigMigration{
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Second * 3)},
+						Name:              "rollback-01", Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec: migapi.MigMigrationSpec{Rollback: true},
+					Status: migapi.MigMigrationStatus{
+						Conditions: migapi.Conditions{
+							List: []migapi.Condition{
+								{
+									Type:   migapi.Succeeded,
+									Status: True,
+								},
+							},
+						},
+					},
+				},
+			),
+			plan: getTestMigPlan("test-cluster", "test-cluster-2", []string{}, []migapi.Condition{{
+				Type:   MigrationTypeIdentified,
+				Reason: StateMigrationPlan,
+			}}),
+			wantErr: false,
+			dontWantConditions: []migapi.Condition{
+				{
+					Type:   MigrationTypeIdentified,
+					Reason: StateMigrationPlan,
+				},
+			},
+		},
+		{
+			name: "given a plan referencing two different clusters with one state migration & a unsuccessful rollback associated with it, should have the identification condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+				getTestMigCluster("test-cluster-2", "http://test-api-2.com:6444"),
+				&migapi.MigMigration{
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.Now(),
+						Name:              "stage-00", Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec: migapi.MigMigrationSpec{MigrateState: true},
+				},
+				&migapi.MigMigration{
+					ObjectMeta: metav1.ObjectMeta{
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Second * 3)},
+						Name:              "rollback-01", Namespace: migapi.OpenshiftMigrationNamespace,
+					},
+					Spec: migapi.MigMigrationSpec{Rollback: true},
+				},
+			),
+			plan:    getTestMigPlan("test-cluster", "test-cluster-2", []string{}, []migapi.Condition{}),
+			wantErr: false,
+			wantConditions: []migapi.Condition{
+				{
+					Type:   MigrationTypeIdentified,
+					Reason: StateMigrationPlan,
+				},
+			},
+		},
+		{
+			name: "given an intra-cluster plan with some namespaces mapped & some unmapped, should have a critical condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+			),
+			plan: getTestMigPlan("test-cluster", "test-cluster", []string{
+				"ns-00:ns-00",
+				"ns-01:ns-02",
+			}, []migapi.Condition{}),
+			wantErr: false,
+			wantConditions: []migapi.Condition{
+				{
+					Type:   IntraClusterMigration,
+					Reason: ConflictingNamespaces,
+				},
+			},
+		},
+		{
+			name: "given an intra-cluster plan with zero mapped namespace, should have a storage conversion identification condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+			),
+			plan: getTestMigPlan("test-cluster", "test-cluster", []string{
+				"ns-00:ns-00",
+				"ns-01:ns-01",
+			}, []migapi.Condition{}),
+			wantErr: false,
+			wantConditions: []migapi.Condition{
+				{
+					Type:   MigrationTypeIdentified,
+					Reason: StorageConversionPlan,
+				},
+			},
+		},
+		{
+			name: "given an intra-cluster plan with all mapped namespace, should have a state migration condition",
+			client: getFakeClientWithObjs(
+				getTestMigCluster("test-cluster", "http://test-api.com:6444"),
+			),
+			plan: getTestMigPlan("test-cluster", "test-cluster", []string{
+				"ns-00:ns-03",
+				"ns-01:ns-02",
+			}, []migapi.Condition{}),
+			wantErr: false,
+			wantConditions: []migapi.Condition{
+				{
+					Type:   MigrationTypeIdentified,
+					Reason: StateMigrationPlan,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := ReconcileMigPlan{
+				Client: tt.client,
+				tracer: mocktracer.New(),
+			}
+			if err := r.validatePossibleMigrationTypes(context.TODO(), tt.plan); (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileMigPlan.validatePossibleMigrationTypes() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			for _, wantCond := range tt.wantConditions {
+				foundCond := tt.plan.Status.FindCondition(wantCond.Type)
+				if foundCond == nil {
+					t.Errorf("ReconcileMigPlan.validatePossibleMigrationTypes() wantCondition = %s, found nil", wantCond.Type)
+				}
+				if foundCond != nil && foundCond.Reason != wantCond.Reason {
+					t.Errorf("ReconcileMigPlan.validatePossibleMigrationTypes() want reason = %s, found %s", wantCond.Reason, foundCond.Reason)
+				}
+			}
+			for _, dontWantCond := range tt.dontWantConditions {
+				foundCond := tt.plan.Status.FindCondition(dontWantCond.Type)
+				if foundCond != nil {
+					t.Errorf("ReconcileMigPlan.validatePossibleMigrationTypes() dontWantCondition = %s, found = %s", dontWantCond.Type, foundCond.Type)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Adds logic to identify possible migration types for a Migration Plan based on user selections
- Adds validations on Migration Plan for different types of migrations
- Adds new Spec field on MigMigration API to identify a State Migration

Note: The conditions added on the Migration Plan which identify a particular migration type are Advisory. They do not block migrations themselves. They assist the UI to choose the right wizard. For API users, those conditions are an indication about creating a right type of migration. If they do create a wrong type of migration for a MigPlan which doesn't support it, the MigMigration controller will block such migrations.