### PR TITLE
Bug 2022017: Restrict controller watches to watch in migration ns only

### DIFF
--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -39,7 +39,6 @@ import (
 	"github.com/openshift/library-go/pkg/image/reference"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	appv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	kapi "k8s.io/api/core/v1"
 	storageapi "k8s.io/api/storage/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
@@ -278,8 +277,8 @@ func (m *MigCluster) GetClient(c k8sclient.Client) (compat.Client, error) {
 	return compatClient, nil
 }
 
-func (m *MigCluster) GetClusterConfigMap(c k8sclient.Client) (*corev1.ConfigMap, error) {
-	clusterConfig := &corev1.ConfigMap{}
+func (m *MigCluster) GetClusterConfigMap(c k8sclient.Client) (*kapi.ConfigMap, error) {
+	clusterConfig := &kapi.ConfigMap{}
 	clusterConfigRef := types.NamespacedName{Name: ClusterConfigMapName, Namespace: VeleroNamespace}
 	err := c.Get(context.TODO(), clusterConfigRef, clusterConfig)
 	if err != nil {

--- a/pkg/apis/migration/v1alpha1/model.go
+++ b/pkg/apis/migration/v1alpha1/model.go
@@ -2,9 +2,10 @@ package v1alpha1
 
 import (
 	"context"
+	"strconv"
+
 	liberr "github.com/konveyor/controller/pkg/error"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strconv"
 
 	imagev1 "github.com/openshift/api/image/v1"
 	kapi "k8s.io/api/core/v1"
@@ -28,7 +29,8 @@ const (
 func ListPlans(client k8sclient.Client) ([]MigPlan, error) {
 	list := MigPlanList{}
 	options := k8sclient.MatchingFields{ClosedIndexField: strconv.FormatBool(false)}
-	err := client.List(context.TODO(), &list, options)
+	inNamespace := k8sclient.InNamespace(OpenshiftMigrationNamespace)
+	err := client.List(context.TODO(), &list, inNamespace, options)
 	if err != nil {
 		return nil, err
 	}
@@ -40,9 +42,11 @@ func ListPlans(client k8sclient.Client) ([]MigPlan, error) {
 // Returns and empty list when none found.
 func ListPlansWithLabels(client k8sclient.Client, labels map[string]string) ([]MigPlan, error) {
 	list := MigPlanList{}
+	inNamespace := k8sclient.InNamespace(OpenshiftMigrationNamespace)
 	err := client.List(
 		context.TODO(),
 		&list,
+		inNamespace,
 		&k8sclient.ListOptions{
 			LabelSelector: k8sLabels.SelectorFromSet(labels),
 		},
@@ -54,7 +58,8 @@ func ListPlansWithLabels(client k8sclient.Client, labels map[string]string) ([]M
 // Returns and empty list when none found.
 func ListClusters(client k8sclient.Client) ([]MigCluster, error) {
 	list := MigClusterList{}
-	err := client.List(context.TODO(), &list)
+	inNamespace := k8sclient.InNamespace(OpenshiftMigrationNamespace)
+	err := client.List(context.TODO(), &list, inNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +171,8 @@ func GetMigrationForDVM(client k8sclient.Client, owners []metav1.OwnerReference)
 // Returns and empty list when none found.
 func ListStorage(client k8sclient.Client) ([]MigStorage, error) {
 	list := MigStorageList{}
-	err := client.List(context.TODO(), &list)
+	inNamespace := k8sclient.InNamespace(OpenshiftMigrationNamespace)
+	err := client.List(context.TODO(), &list, inNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +184,8 @@ func ListStorage(client k8sclient.Client) ([]MigStorage, error) {
 // Returns and empty list when none found.
 func ListHook(client k8sclient.Client) ([]MigHook, error) {
 	list := MigHookList{}
-	err := client.List(context.TODO(), &list)
+	inNamespace := k8sclient.InNamespace(OpenshiftMigrationNamespace)
+	err := client.List(context.TODO(), &list, inNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +197,8 @@ func ListHook(client k8sclient.Client) ([]MigHook, error) {
 // Returns and empty list when none found.
 func ListMigrations(client k8sclient.Client) ([]MigMigration, error) {
 	list := MigMigrationList{}
-	err := client.List(context.TODO(), &list)
+	inNamespace := k8sclient.InNamespace(OpenshiftMigrationNamespace)
+	err := client.List(context.TODO(), &list, inNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -33,9 +33,13 @@ import (
 )
 
 //
-// Function provided by controller packages to add
-// them self to the manager.
-type AddFunction func(manager.Manager) error
+// Function provided by controller packages to add them selves to provider
+// It takes two managers - first is used to watch the  resources owned by
+// the controllers and is scoped to the migration namespace
+// second is unscoped and provides cache, client to list resources not
+// necessarily owned by the controller but involved in the migration which
+// are outside of the migration namespace
+type AddFunction func(manager.Manager, manager.Manager) error
 
 //
 // List of controller add functions for the CAM role.
@@ -60,14 +64,14 @@ var DiscoveryControllers = []AddFunction{
 
 //
 // Add controllers to the manager based on role.
-func AddToManager(m manager.Manager) error {
+func AddToManager(m manager.Manager, unscopedMgr manager.Manager) error {
 	err := settings.Settings.Load()
 	if err != nil {
 		return err
 	}
 	load := func(functions []AddFunction) error {
 		for _, f := range functions {
-			if err := f(m); err != nil {
+			if err := f(m, unscopedMgr); err != nil {
 				return err
 			}
 		}

--- a/pkg/controller/directimagemigration/directimagemigration_controller_test.go
+++ b/pkg/controller/directimagemigration/directimagemigration_controller_test.go
@@ -47,7 +47,7 @@ func TestReconcile(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
-	recFn, requests := SetupTestReconcile(newReconciler(mgr))
+	recFn, requests := SetupTestReconcile(newReconciler(mgr, mgr))
 	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
 
 	stopFunc := StartTestManager(mgr, g)

--- a/pkg/controller/directimagestreammigration/directimagestreammigration_controller_test.go
+++ b/pkg/controller/directimagestreammigration/directimagestreammigration_controller_test.go
@@ -47,7 +47,7 @@ func TestReconcile(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
-	recFn, requests := SetupTestReconcile(newReconciler(mgr))
+	recFn, requests := SetupTestReconcile(newReconciler(mgr, mgr))
 	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
 
 	stopFunc := StartTestManager(mgr, g)

--- a/pkg/controller/directvolumemigration/directvolumemigration_controller_test.go
+++ b/pkg/controller/directvolumemigration/directvolumemigration_controller_test.go
@@ -48,7 +48,7 @@ func TestReconcile(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
-	recFn, requests := SetupTestReconcile(newReconciler(mgr))
+	recFn, requests := SetupTestReconcile(newReconciler(mgr, mgr))
 	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
 
 	stopFunc := StartTestManager(mgr, g)

--- a/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller_test.go
+++ b/pkg/controller/directvolumemigrationprogress/directvolumemigrationprogress_controller_test.go
@@ -59,7 +59,7 @@ func TestReconcile(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
-	recFn, requests := SetupTestReconcile(newReconciler(mgr))
+	recFn, requests := SetupTestReconcile(newReconciler(mgr, mgr))
 	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
 
 	stopFunc := StartTestManager(mgr, g)

--- a/pkg/controller/discovery/controller.go
+++ b/pkg/controller/discovery/controller.go
@@ -52,8 +52,8 @@ func init() {
 	web.Log = logging.WithName("discovery")
 }
 
-func Add(mgr manager.Manager) error {
-	return add(mgr, newReconciler(mgr))
+func Add(mgr manager.Manager, unscopedMgr manager.Manager) error {
+	return add(mgr, newReconciler(unscopedMgr))
 }
 
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {


### PR DESCRIPTION
This fix separates our previous manager used by the controllers into two managers:

1. Manager scoped in migration ns: This manager is used to trigger watch events on Migration resources  

2. Cluster scoped manager: This manager is used in 3 places:
     a. MigCluster controller uses it to watch the Secret resources in `openshift-config` namespace
     b. MigStorage controller uses it to watch the Secret resources in `openshift-config` namespace
     c. Host MigCluster uses its cached client to list resources involved in a migration