### PR TITLE
Bug 2021668: Respect cluster_subdomain setting

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/konveyor/mig-controller/pkg/webhook"
 	"github.com/konveyor/mig-controller/pkg/zapmod"
 	appsv1 "github.com/openshift/api/apps/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -81,6 +82,10 @@ func main() {
 	}
 	if err := appsv1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "unable to add OpenShift apps APIs to scheme")
+		os.Exit(1)
+	}
+	if err := configv1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "unable to add OpenShift config APIs to scheme")
 		os.Exit(1)
 	}
 	if err := routev1.AddToScheme(mgr.GetScheme()); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/joho/godotenv v1.3.0
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/konveyor/controller v0.4.1
-	github.com/konveyor/crane-lib v0.0.0-20210917133823-602ae5a06b3d
+	github.com/konveyor/crane-lib v0.0.4
 	github.com/konveyor/openshift-velero-plugin v0.0.0-20210729141849-876132e34f3d
 	github.com/mattn/go-isatty v0.0.13 // indirect
 	github.com/mattn/go-sqlite3 v1.14.4

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/HdrHistogram/hdrhistogram-go v1.1.0 h1:6dpdDPTRoo78HxAJ6T1HfMiKSnqhgRRqzCuPshRkQ7I=
 github.com/HdrHistogram/hdrhistogram-go v1.1.0/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
+github.com/Luzifer/go-dhparam v1.1.0/go.mod h1:3Kuj59C67/G2EzQHjUzAryaAa70K5fqvStR2VkFLszU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
@@ -495,6 +496,8 @@ github.com/konveyor/controller v0.4.1 h1:0LiBaAIrXScOqb6OoIGOIqpK9dxBAQotPWEhP4J
 github.com/konveyor/controller v0.4.1/go.mod h1:j0DSNesS0XHmqOLcJEuwB+qIRkdJ3mSIEJFA2byC12c=
 github.com/konveyor/crane-lib v0.0.0-20210917133823-602ae5a06b3d h1:59SUIpkqWHjol7mZkTZtaSsGwdX/EQ0eXZqaWxPTCoY=
 github.com/konveyor/crane-lib v0.0.0-20210917133823-602ae5a06b3d/go.mod h1:7xlMNVE0ZgbAThr9+R7G3zZ88TOD7d4br50URQnv5U8=
+github.com/konveyor/crane-lib v0.0.4 h1:CWGBC5MTmdlrEqu1F5eBSR0HRYBlo2QV/Y/bHguJPvM=
+github.com/konveyor/crane-lib v0.0.4/go.mod h1:C0H3dr85YlsaAt1Av7zFu4IPdwG4+SW7wEBFE+1udTw=
 github.com/konveyor/openshift-velero-plugin v0.0.0-20210729141849-876132e34f3d h1:tETgPq+JxXhVhnrcLc7rcW9BURax36VUsix8DAU0wuY=
 github.com/konveyor/openshift-velero-plugin v0.0.0-20210729141849-876132e34f3d/go.mod h1:Yk0xQ4N5rwE1+NWLSFQUQLgNT1/8p4Uor60LlgQfymg=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=


### PR DESCRIPTION
There was a regression where the cluster_subdomain key was not being
used when creating dvm routes. This PR allows the cluster_subdomain to
be overridden when creating routes.

Additionally, this PR grabs the subdomain from the OpenShift's cluster
ingress config (supported since 4.3
https://docs.openshift.com/container-platform/4.3/networking/ingress-operator.html),
allowing crane-lib's endpoint functionality to handle scenarios where
the route name would be too long.

Add the config API to the manager's scheme as that is automatically used
in migration cluster client schemes.