### PR TITLE
ci: fix travis to retry kubebuilder install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - export os=$(go env GOOS)
   - export arch=$(go env GOARCH)
   - export BUILDTAGS="containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp exclude_graphdriver_overlay"
-  - curl -sL https://go.kubebuilder.io/dl/2.0.0-beta.0/${os}/${arch} | tar -xz -C /tmp/
+  - curl -sL --retry 5 https://go.kubebuilder.io/dl/2.0.0-beta.0/${os}/${arch} | tar -xz -C /tmp/
   - sudo mv /tmp/kubebuilder_2.0.0-beta.0_${os}_${arch} /usr/local/kubebuilder
   - export PATH=$PATH:/usr/local/kubebuilder/bin
   - export GOBIN=$GOPATH/bin


### PR DESCRIPTION
Appears there are transient failures when attempting to install
kubebuilder.