### PR TITLE
Identify sparse files and automatically set `--sparse` option if they are found 

### DIFF
--- a/config/crds/migration.openshift.io_miganalytics.yaml
+++ b/config/crds/migration.openshift.io_miganalytics.yaml
@@ -307,6 +307,10 @@ spec:
                                 description: Requested capacity of the claim
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                              sparseFilesFound:
+                                description: Indicate whether or not sparse files
+                                  were found in the volume
+                                type: boolean
                               usagePercentage:
                                 description: Usage of volume in percentage
                                 type: integer

--- a/pkg/apis/migration/v1alpha1/miganalytic_types.go
+++ b/pkg/apis/migration/v1alpha1/miganalytic_types.go
@@ -32,6 +32,7 @@ const (
 // VolumeAdjuster reasons
 const (
 	FailedRunningDf = "FailedRunningDf"
+	FailedRunningDu = "FailedRunningDu"
 )
 
 // Proposed volume size computation reasons
@@ -133,6 +134,8 @@ type MigAnalyticPersistentVolumeClaim struct {
 	ProposedCapacity resource.Quantity `json:"proposedCapacity,omitempty"`
 	// Human readable reason for proposed adjustment
 	Comment string `json:"comment,omitempty"`
+	// Indicate whether or not sparse files were found in the volume
+	SparseFilesFound bool `json:"sparseFilesFound,omitempty"`
 }
 
 // +genclient

--- a/pkg/controller/directvolumemigration/task.go
+++ b/pkg/controller/directvolumemigration/task.go
@@ -154,6 +154,7 @@ type Task struct {
 	Requeue          time.Duration
 	Itinerary        Itinerary
 	Errors           []string
+	SparseFileMap    sparseFilePVCMap
 
 	Tracer        opentracing.Tracer
 	ReconcileSpan opentracing.Span


### PR DESCRIPTION
[[MIG-861](https://issues.redhat.com/projects/MIG/issues/MIG-861)]

On every node where PVs are mounted, a new shell command `du` will be executed. The `--apparent-size` option of `du` identifies the actual size of files as opposed to `df` where it only shows the size of occupied blocks. If sparse files exist on a volume, the occupied blocks < apparent size. New logic is introduced to compare the two values returned by `df` and `du` commands. If the apparent size returned by `du` is more than what's returned by `df` then a special flag is set on MigAnalytic resource's status for every PV. For every PV, if the flag is set, the `--sparse` Rsync option is automatically set.

