### PR TITLE
Bug 2039852: fix nil pointer when wrong cluster is provided in migplan (#1251)

### DIFF
--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -231,6 +231,9 @@ func (r ReconcileMigPlan) validateIncludedResources(ctx context.Context, plan *m
 	if err != nil {
 		return liberr.Wrap(err)
 	}
+	if srcCluster == nil || !srcCluster.Status.IsReady() {
+		return nil
+	}
 	srcClient, err := srcCluster.GetClient(r)
 	if err != nil {
 		return liberr.Wrap(err)
@@ -334,7 +337,7 @@ func (r ReconcileMigPlan) getPotentialFilePermissionConflictNamespaces(plan *mig
 	if err != nil {
 		return nil, liberr.Wrap(err)
 	}
-	if srcCluster == nil {
+	if srcCluster == nil || !srcCluster.Status.IsReady() {
 		return nil, nil
 	}
 	srcClient, err := srcCluster.GetClient(r)


### PR DESCRIPTION
(Cherry-picked from 6e020a7)