### PR TITLE
Bug 2043654: Fix rollback for storage conversion

### DIFF
--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -277,6 +277,7 @@ var RollbackItinerary = Itinerary{
 		{Name: DeleteRegistries, Step: StepCleanupHelpers},
 		{Name: EnsureStagePodsDeleted, Step: StepCleanupHelpers},
 		{Name: EnsureAnnotationsDeleted, Step: StepCleanupHelpers, any: HasPVs | HasISs},
+		{Name: SwapPVCReferences, Step: StepCleanupMigrated, all: StorageConversion},
 		{Name: DeleteMigrated, Step: StepCleanupMigrated},
 		{Name: EnsureMigratedDeleted, Step: StepCleanupMigrated},
 		{Name: UnQuiesceSrcApplications, Step: StepCleanupUnquiesce},
@@ -1553,7 +1554,7 @@ func (t *Task) isStorageConversionMigration() (bool, error) {
 	if err != nil {
 		return false, liberr.Wrap(err)
 	}
-	if isIntraCluster && t.migrateState() {
+	if isIntraCluster && (t.migrateState() || t.rollback()) {
 		for srcNs, destNs := range t.PlanResources.MigPlan.GetNamespaceMapping() {
 			if srcNs != destNs {
 				return false, nil


### PR DESCRIPTION
- Passes correct mapping of Destination -> Source names of PVCs to rollback operation
- Adds swap function to Rollback itinerary
- Fixes minor issue with ReplicaSet swapping owned by higher level resources preventing double updates