### PR TITLE
Bug 2048430: Remove missing registry path condition when Image migration will not be used

### DIFF
--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -274,6 +274,7 @@ func setMigrationType(plan *migapi.MigPlan, migrationType migapi.MigrationType, 
 	case migapi.StateMigrationPlan, migapi.StorageConversionPlan:
 		// state and storage migration plans do not migrate images
 		plan.Status.DeleteCondition(SourceClusterNoRegistryPath)
+		plan.Status.DeleteCondition(DestinationClusterNoRegistryPath)
 	}
 }
 


### PR DESCRIPTION
Image migration will not be used for Storage, state migrations. Remove the destination registry path missing condition