### PR TITLE
Bug 2058189: Fix checksum option in Rsync command

### DIFF
--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -669,7 +669,7 @@ func (t *Task) getNamespacedPVCPairs() (map[string][]transfer.PVCPair, error) {
 }
 
 func (t *Task) getSourceSecurityGroupInfo(srcClient compat.Client, pvcPairMap map[string][]transfer.PVCPair) (pvcWithSecurityContextInfo, error) {
-	var pvcInfo pvcWithSecurityContextInfo
+	pvcInfo := make(pvcWithSecurityContextInfo)
 
 	for bothNS := range pvcPairMap {
 		srcNs := getSourceNs(bothNS)
@@ -708,8 +708,8 @@ func (t *Task) getSourceSecurityGroupInfo(srcClient compat.Client, pvcPairMap ma
 				seLinuxOptions:     nil,
 				verify:             pvc.Verify,
 			}
-			pvcInfo.Add(pvc.Name, pvc.Namespace, secInfo)
 		}
+		pvcInfo.Add(pvc.Name, pvc.Namespace, secInfo)
 	}
 	return pvcInfo, nil
 }


### PR DESCRIPTION
`--checksum` option is added to Rsync command when `pvc.Verify` field is set. In some cases, the Verify field was not set due to a no-op if branch of a conditional. This PR fixes that.