### PR TITLE
Bug 2072684: update pvcClaimTemplates post migration

### DIFF
--- a/pkg/controller/migmigration/storage.go
+++ b/pkg/controller/migmigration/storage.go
@@ -121,8 +121,11 @@ func (t *Task) swapPVCReferences() (reasons []string, err error) {
 func (t *Task) getPVCNameMapping() pvcNameMapping {
 	mapping := make(pvcNameMapping)
 	for _, pv := range t.PlanResources.MigPlan.Spec.PersistentVolumes.List {
-		// If this is a rollback migration, the mapping of PVC names should be Destination -> Source
-		if t.rollback() {
+		if pv.Selection.Action == migapi.PvSkipAction {
+			// for skipped pvcs, there is no need to switch PVC references
+			mapping.Add(pv.PVC.Namespace, pv.PVC.GetSourceName(), pv.PVC.GetSourceName())
+		} else if t.rollback() {
+			// If this is a rollback migration, the mapping of PVC names should be Destination -> Source
 			mapping.Add(pv.PVC.Namespace, pv.PVC.GetTargetName(), pv.PVC.GetSourceName())
 		} else {
 			mapping.Add(pv.PVC.Namespace, pv.PVC.GetSourceName(), pv.PVC.GetTargetName())

--- a/pkg/controller/migmigration/storage.go
+++ b/pkg/controller/migmigration/storage.go
@@ -110,7 +110,7 @@ func (t *Task) swapPVCReferences() (reasons []string, err error) {
 			fmt.Sprintf("Failed updating PVC references on CronJobs [%s]", strings.Join(failedCronJobNames, ",")))
 	}
 	// update pvc refs on statefulsets
-	failedStatefulSetNames := t.swapStatefulSetPVCRefs(client, mapping)
+	failedStatefulSetNames := t.swapStatefulSetPVCRefs(client)
 	if len(failedStatefulSetNames) > 0 {
 		reasons = append(reasons,
 			fmt.Sprintf("Failed updating PVC references on StatefulSets [%s]", strings.Join(failedStatefulSetNames, ",")))
@@ -134,7 +134,7 @@ func (t *Task) getPVCNameMapping() pvcNameMapping {
 	return mapping
 }
 
-func (t *Task) swapStatefulSetPVCRefs(client k8sclient.Client, mapping pvcNameMapping) (failedStatefulSets []string) {
+func (t *Task) swapStatefulSetPVCRefs(client k8sclient.Client) (failedStatefulSets []string) {
 	for _, ns := range t.destinationNamespaces() {
 		list := appsv1.StatefulSetList{}
 		options := k8sclient.InNamespace(ns)

--- a/pkg/controller/migmigration/storage.go
+++ b/pkg/controller/migmigration/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -21,6 +22,11 @@ import (
 // PVCNameMapping is a mapping for source -> destination pvc names
 // used for convenience to avoid nested lookups to find migrated PVC names
 type pvcNameMapping map[string]string
+
+const (
+	statefulSetUpdateAnnotation = "migration.openshift.io/statefulset-update"
+	statefulSetTempAnnotation   = "migration.openshift.io/statefulset-temporary"
+)
 
 // Add adds a new PVC to mapping
 func (p pvcNameMapping) Add(namespace string, srcName string, destName string) {
@@ -103,6 +109,12 @@ func (t *Task) swapPVCReferences() (reasons []string, err error) {
 		reasons = append(reasons,
 			fmt.Sprintf("Failed updating PVC references on CronJobs [%s]", strings.Join(failedCronJobNames, ",")))
 	}
+	// update pvc refs on statefulsets
+	failedStatefulSetNames := t.swapStatefulSetPVCRefs(client, mapping)
+	if len(failedStatefulSetNames) > 0 {
+		reasons = append(reasons,
+			fmt.Sprintf("Failed updating PVC references on StatefulSets [%s]", strings.Join(failedStatefulSetNames, ",")))
+	}
 	return
 }
 
@@ -117,6 +129,131 @@ func (t *Task) getPVCNameMapping() pvcNameMapping {
 		}
 	}
 	return mapping
+}
+
+func (t *Task) swapStatefulSetPVCRefs(client k8sclient.Client, mapping pvcNameMapping) (failedStatefulSets []string) {
+	for _, ns := range t.destinationNamespaces() {
+		list := appsv1.StatefulSetList{}
+		options := k8sclient.InNamespace(ns)
+		err := client.List(
+			context.TODO(),
+			&list,
+			options)
+		if err != nil {
+			t.Log.Error(err, "failed listing statefulsets", "namespace", ns)
+			continue
+		}
+		for i := range list.Items {
+			set := &list.Items[i]
+			newSet := &appsv1.StatefulSet{}
+			if len(set.Name) >= 60 {
+				failedStatefulSets = append(failedStatefulSets,
+					fmt.Sprintf("%s/%s", set.Namespace, set.Name))
+				continue
+			}
+			set.ResourceVersion = ""
+			set.ManagedFields = nil
+			set.SelfLink = ""
+			newSet.Name = fmt.Sprintf("%s-%s", set.Name, migapi.StorageConversionPVCNamePrefix)
+			newSet.Namespace = set.Namespace
+			newSet.Labels = set.Labels
+			newSet.Annotations = make(map[string]string)
+			for k, v := range set.Annotations {
+				newSet.Annotations[k] = v
+			}
+			newSet.Annotations[statefulSetTempAnnotation] = migapi.True
+			newSet.Spec = *set.Spec.DeepCopy()
+			zero := int32(0)
+			newSet.Spec.Replicas = &zero
+			if set.Annotations == nil {
+				continue
+			}
+			if replicas, exist := set.Annotations[migapi.ReplicasAnnotation]; exist {
+				number, err := strconv.Atoi(replicas)
+				if err != nil {
+					t.Log.Error(err, "failed finding replica count for statefulset",
+						"namespace", set.Namespace, "statefulset", set.Name)
+					failedStatefulSets = append(failedStatefulSets,
+						fmt.Sprintf("%s/%s", set.Namespace, set.Name))
+				} else {
+					delete(set.Annotations, migapi.ReplicasAnnotation)
+					restoredReplicas := int32(number)
+					// Only change replica count if currently == 0
+					if *set.Spec.Replicas == 0 {
+						set.Spec.Replicas = &restoredReplicas
+					}
+				}
+			}
+			for i := range set.Spec.VolumeClaimTemplates {
+				volumeTemplate := &set.Spec.VolumeClaimTemplates[i]
+				formattedName := volumeTemplate.Name
+				if t.rollback() {
+					if _, exists := set.Annotations[statefulSetUpdateAnnotation]; exists {
+						delete(set.Annotations, statefulSetUpdateAnnotation)
+						matcher := regexp.MustCompile(fmt.Sprintf("-%s$", migapi.StorageConversionPVCNamePrefix))
+						if matcher.MatchString(volumeTemplate.Name) {
+							formattedName = matcher.ReplaceAllString(volumeTemplate.Name, "")
+						}
+					}
+					if _, exists := set.Annotations[statefulSetTempAnnotation]; exists {
+						t.Log.Error(fmt.Errorf("failed rolling back statefulset"),
+							"namespace", set.Namespace, "statefulset", set.Name)
+						failedStatefulSets = append(failedStatefulSets,
+							fmt.Sprintf("%s/%s", set.Namespace, set.Name))
+						continue
+					}
+				} else {
+					if set.Annotations == nil {
+						set.Annotations = make(map[string]string)
+					}
+					set.Annotations[statefulSetUpdateAnnotation] = migapi.True
+					formattedName = fmt.Sprintf("%s-%s", volumeTemplate.Name, migapi.StorageConversionPVCNamePrefix)
+				}
+				for i := range set.Spec.Template.Spec.Containers {
+					container := &set.Spec.Template.Spec.Containers[i]
+					for i := range container.VolumeMounts {
+						volumeMount := &container.VolumeMounts[i]
+						if volumeMount.Name == volumeTemplate.Name {
+							volumeMount.Name = formattedName
+						}
+					}
+				}
+				volumeTemplate.Name = formattedName
+			}
+			err = client.Create(context.TODO(), newSet)
+			if err != nil {
+				t.Log.Error(err, "failed creating temporary statefulset",
+					"namespace", newSet.Namespace, "statefulset", newSet.Name)
+				failedStatefulSets = append(failedStatefulSets,
+					fmt.Sprintf("%s/%s", set.Namespace, set.Name))
+				continue
+			}
+			err = client.Delete(context.TODO(), set)
+			if err != nil {
+				t.Log.Error(err, "failed deleting statefulset",
+					"namespace", set.Namespace, "statefulset", set.Name)
+				failedStatefulSets = append(failedStatefulSets,
+					fmt.Sprintf("%s/%s", set.Namespace, set.Name))
+				continue
+			}
+			err = client.Create(context.TODO(), set)
+			if err != nil {
+				t.Log.Error(err, "failed creating updated statefulset",
+					"namespace", set.Namespace, "statefulset", set.Name)
+				failedStatefulSets = append(failedStatefulSets,
+					fmt.Sprintf("%s/%s", set.Namespace, set.Name))
+				continue
+			}
+			err = client.Delete(context.TODO(), newSet)
+			if err != nil {
+				t.Log.Error(err, "failed deleting temporary statefulset",
+					"namespace", set.Namespace, "statefulset", set.Name)
+				failedStatefulSets = append(failedStatefulSets,
+					fmt.Sprintf("%s/%s", set.Namespace, set.Name))
+			}
+		}
+	}
+	return
 }
 
 // swapDeploymentPVCRefs

--- a/pkg/controller/migplan/pvlist.go
+++ b/pkg/controller/migplan/pvlist.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"regexp"
 	"strings"
 
 	liberr "github.com/konveyor/controller/pkg/error"
@@ -199,6 +200,26 @@ func (r *ReconcileMigPlan) getPvMap(client k8sclient.Client, plan *migapi.MigPla
 	if err != nil {
 		return nil, err
 	}
+	allPodList := core.PodList{}
+	err = client.List(context.TODO(), &allPodList, &k8sclient.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	inNamespaces := func(objNamespace string, namespaces []string) bool {
+		for _, ns := range namespaces {
+			if ns == objNamespace {
+				return true
+			}
+		}
+		return false
+	}
+	podList := []core.Pod{}
+	for _, pod := range allPodList.Items {
+		if inNamespaces(pod.Namespace, plan.GetSourceNamespaces()) {
+			podList = append(podList, pod)
+		}
+	}
+
 	for _, pv := range list.Items {
 		if pv.Status.Phase != core.VolumeBound {
 			continue
@@ -207,7 +228,7 @@ func (r *ReconcileMigPlan) getPvMap(client k8sclient.Client, plan *migapi.MigPla
 		if migref.RefSet(claim) {
 			key := k8sclient.ObjectKey{
 				Namespace: claim.Namespace,
-				Name:      getMappedNameForPVC(claim, plan),
+				Name:      getMappedNameForPVC(claim, podList, plan),
 			}
 			pvMap[key] = pv
 		}
@@ -216,7 +237,7 @@ func (r *ReconcileMigPlan) getPvMap(client k8sclient.Client, plan *migapi.MigPla
 	return pvMap, nil
 }
 
-func getMappedNameForPVC(pvcRef *core.ObjectReference, plan *migapi.MigPlan) string {
+func getMappedNameForPVC(pvcRef *core.ObjectReference, podList []core.Pod, plan *migapi.MigPlan) string {
 	pvcName := pvcRef.Name
 	existingPVC := plan.Spec.FindPVC(pvcRef.Namespace, pvcRef.Name)
 	if existingPVC != nil &&
@@ -233,6 +254,9 @@ func getMappedNameForPVC(pvcRef *core.ObjectReference, plan *migapi.MigPlan) str
 			return pvcName
 		} else {
 			destName := fmt.Sprintf("%s:%s-%s", pvcName, pvcName, migapi.StorageConversionPVCNamePrefix)
+			if isStatefulSet, setName := isStatefulSetVolume(pvcRef, podList); isStatefulSet {
+				destName = getStatefulSetVolumeName(pvcName, setName)
+			}
 			if len(destName) > 253 {
 				return destName[:253]
 			} else {
@@ -241,6 +265,41 @@ func getMappedNameForPVC(pvcRef *core.ObjectReference, plan *migapi.MigPlan) str
 		}
 	}
 	return pvcName
+}
+
+// getStatefulSetVolumeName add the storage conversion prefix between the ordeal and the pvc name string
+func getStatefulSetVolumeName(pvcName string, setName string) string {
+	formattedName := pvcName
+	matcher := regexp.MustCompile(fmt.Sprintf("(.*)?(-%s)(-\\d+)$", setName))
+	if !matcher.MatchString(pvcName) {
+		return pvcName
+	} else {
+		cols := matcher.FindStringSubmatch(pvcName)
+		if len(cols) > 3 {
+			formattedName = fmt.Sprintf("%s:%s-%s%s%s",
+				pvcName, cols[1],
+				migapi.StorageConversionPVCNamePrefix, cols[2], cols[3])
+		}
+	}
+	return formattedName
+}
+
+// isStatefulSetVolume given a volume and a list of discovered pods, returns whether the volume is used by a statefulset
+func isStatefulSetVolume(pvcRef *core.ObjectReference, podList []core.Pod) (bool, string) {
+	for _, pod := range podList {
+		for _, owner := range pod.OwnerReferences {
+			if owner.Kind == "StatefulSet" {
+				for _, vol := range pod.Spec.Volumes {
+					if vol.PersistentVolumeClaim != nil {
+						if vol.PersistentVolumeClaim.ClaimName == pvcRef.Name {
+							return true, owner.Name
+						}
+					}
+				}
+			}
+		}
+	}
+	return false, ""
 }
 
 // isStorageConversionPlan tells whether the migration plan is for storage conversion
@@ -313,7 +372,7 @@ func (r *ReconcileMigPlan) getClaims(client k8sclient.Client, plan *migapi.MigPl
 				Name: getMappedNameForPVC(&core.ObjectReference{
 					Name:      pvc.Name,
 					Namespace: pvc.Namespace,
-				}, plan),
+				}, podList, plan),
 				AccessModes:  pvc.Spec.AccessModes,
 				HasReference: pvcInPodVolumes(pvc, podList),
 			})

--- a/pkg/controller/migplan/pvlist_test.go
+++ b/pkg/controller/migplan/pvlist_test.go
@@ -1,0 +1,126 @@
+package migplan
+
+import (
+	"fmt"
+	"testing"
+
+	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_getStatefulSetVolumeName(t *testing.T) {
+	tests := []struct {
+		name    string
+		pvcName string
+		setName string
+		want    string
+	}{
+		{
+			name:    "given a statefulset volume with single ordinal value, must return correctly formatted name",
+			pvcName: "example-set-0",
+			setName: "set",
+			want:    fmt.Sprintf("example-set-0:example-%s-set-0", migapi.StorageConversionPVCNamePrefix),
+		},
+		{
+			name:    "given a statefulset volume with double ordinal value, must return correctly formatted name",
+			pvcName: "example-set-10",
+			setName: "set",
+			want:    fmt.Sprintf("example-set-10:example-%s-set-10", migapi.StorageConversionPVCNamePrefix),
+		},
+		{
+			name:    "given a volume with no ordinal, must return original name",
+			pvcName: "example-set",
+			want:    "example-set",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getStatefulSetVolumeName(tt.pvcName, tt.setName); got != tt.want {
+				t.Errorf("getStatefulSetVolumeName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isStatefulSetVolume(t *testing.T) {
+	type args struct {
+		pvcRef  *corev1.ObjectReference
+		podList []corev1.Pod
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "when none of the pods are using the volume, should return false",
+			args: args{
+				pvcRef:  &corev1.ObjectReference{Name: "test", Namespace: "test"},
+				podList: []corev1.Pod{},
+			},
+			want: false,
+		},
+		{
+			name: "when one or more pods are using the volume but are not owned by statefulsets, should return false",
+			args: args{
+				pvcRef: &corev1.ObjectReference{Name: "test", Namespace: "test"},
+				podList: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-0", Namespace: "test"},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "vol-0",
+									VolumeSource: corev1.VolumeSource{
+										PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+											ClaimName: "test",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "when one or more pods are using the volume and are not owned by statefulsets, should return true",
+			args: args{
+				pvcRef: &corev1.ObjectReference{Name: "test", Namespace: "test"},
+				podList: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-0",
+							Namespace: "test",
+							OwnerReferences: []metav1.OwnerReference{
+								{
+									Kind: "StatefulSet",
+								}}},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "vol-0",
+									VolumeSource: corev1.VolumeSource{
+										PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+											ClaimName: "test",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, _ := isStatefulSetVolume(tt.args.pvcRef, tt.args.podList); got != tt.want {
+				t.Errorf("isStatefulSetVolume() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR updates naming convention for PVCs owned by StatefulSets. The naming convention now considers multiple replicas named with integer ordinals in their names. The volumeClaimTemplates will also be updated automatically after migration.