### PR TITLE
Bug 2073496: Add logs in rsync operations function

### DIFF
--- a/pkg/controller/directvolumemigration/rsync.go
+++ b/pkg/controller/directvolumemigration/rsync.go
@@ -378,13 +378,17 @@ func (t *Task) createRsyncTransferClients(srcClient compat.Client,
 			}
 			pod, err := t.getLatestPodForOperation(srcClient, *lastObservedOperationStatus)
 			if err != nil {
+				t.Log.Error(err, "failed getting latest rsync client pod", "pvc", newOperation)
 				currentStatus.AddError(err)
+				statusList.Add(currentStatus)
 				continue
 			}
 
 			pvcList, err := transfer.NewPVCPairList(pvc)
 			if err != nil {
+				t.Log.Error(err, "failed creating PVC pair", "pvc", newOperation)
 				currentStatus.AddError(err)
+				statusList.Add(currentStatus)
 				continue
 			}
 			// Force schedule Rsync Pod on the application node
@@ -432,25 +436,30 @@ func (t *Task) createRsyncTransferClients(srcClient compat.Client,
 					transfer, err := rsynctransfer.NewTransfer(
 						stunnelTransport, endpoint, srcClient.RestConfig(), destClient.RestConfig(), pvcList, append(rsyncOptions, optionsForPvc...)...)
 					if err != nil {
+						t.Log.Error(err, "failed creating new rsync transfer", "pvc", newOperation)
 						currentStatus.AddError(err)
+						statusList.Add(currentStatus)
 						continue
 					}
 					if transfer == nil {
 						currentStatus.AddError(
 							fmt.Errorf("transfer %s/%s not found", nnPair.Source().Namespace, nnPair.Source().Name))
+						statusList.Add(currentStatus)
 						continue
 					}
 					err = transfer.CreateClient(srcClient)
 					if err != nil {
-						t.Log.Info("failed creating Rsync Pod for pvc", "pvc", newOperation, "err", err)
+						t.Log.Error(err, "failed creating rsync pod for pvc", "pvc", newOperation)
 						currentStatus.AddError(err)
+						statusList.Add(currentStatus)
 						continue
 					}
 					t.Log.Info("previous attempt of Rsync failed for pvc, created a new pod", "pvc", newOperation)
 					err = srcClient.Delete(context.TODO(), pod)
 					if err != nil {
-						t.Log.Info("failed deleting Rsync Pod of previous attempt for pvc", "pvc", newOperation)
+						t.Log.Error(err, "failed deleting rsync pod of previous attempt for pvc", "pvc", newOperation)
 						currentStatus.AddError(err)
+						statusList.Add(currentStatus)
 						continue
 					}
 				} else {
@@ -475,17 +484,22 @@ func (t *Task) createRsyncTransferClients(srcClient compat.Client,
 				transfer, err := rsynctransfer.NewTransfer(
 					stunnelTransport, endpoint, srcClient.RestConfig(), destClient.RestConfig(), pvcList, append(rsyncOptions, optionsForPvc...)...)
 				if err != nil {
+					t.Log.Error(err, "failed creating rsync transfer", "pvc", newOperation)
 					currentStatus.AddError(err)
+					statusList.Add(currentStatus)
 					continue
 				}
 				if transfer == nil {
 					currentStatus.AddError(
 						fmt.Errorf("transfer %s/%s not found", nnPair.Source().Namespace, nnPair.Source().Name))
+					statusList.Add(currentStatus)
 					continue
 				}
 				err = transfer.CreateClient(srcClient)
 				if err != nil {
+					t.Log.Error(err, "failed creating rsync client", "pvc", newOperation)
 					currentStatus.AddError(err)
+					statusList.Add(currentStatus)
 					continue
 				}
 			}


### PR DESCRIPTION
This also fixes a bug in an existing warning that is supposed to indicate a migration that may be stuck due to underlying errors:
![Screenshot from 2022-04-08 11-41-41](https://user-images.githubusercontent.com/9839757/162477038-d33ac9e8-ec5e-474f-a270-248ef87060bc.png)

