### PR TITLE
looking for common velero pod label to find velero pods

### DIFF
--- a/pkg/pods/velero.go
+++ b/pkg/pods/velero.go
@@ -17,7 +17,7 @@ func FindVeleroPods(client k8sclient.Client) ([]corev1.Pod, error) {
 	list := &corev1.PodList{}
 	labelSelector := labels.SelectorFromSet(
 		map[string]string{
-			"component": "velero",
+			"app.kubernetes.io/instance": "velero",
 		})
 	fieldSelector := fields.SelectorFromSet(
 		map[string]string{


### PR DESCRIPTION
In accordance with [mig-legacy-operator](https://github.com/konveyor/mig-legacy-operator/pull/19) and mig-operator velero label change.

This change is needed to resolve the issue of the controller looking for velero cloud credentials in restic pod because in 1.7 restic pods has the label `component: velero`.