### PR TITLE
Validate "auto" access/volume mode input string (#1456)

### DIFF
--- a/config/crds/migration.openshift.io_migplans.yaml
+++ b/config/crds/migration.openshift.io_migplans.yaml
@@ -384,6 +384,12 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-validations:
+                          - message: Illegal AccessMode, either use 'auto' for inferring
+                              access mode or a combination of known access modes
+                            rule: self.size() == 1 && self[0] == 'auto' || self.all(am,
+                              am in ['ReadWriteOnce', 'ReadOnlyMany', 'ReadWriteMany',
+                              'ReadWriteOncePod'])
                         hasReference:
                           type: boolean
                         name:
@@ -395,6 +401,10 @@ spec:
                         volumeMode:
                           description: PersistentVolumeMode describes how a volume
                             is intended to be consumed, either Block or Filesystem.
+                          enum:
+                          - Block
+                          - Filesystem
+                          - auto
                           type: string
                       type: object
                     selection:

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -887,12 +887,14 @@ const (
 
 // PVC
 type PVC struct {
-	Namespace    string                            `json:"namespace,omitempty" protobuf:"bytes,3,opt,name=namespace"`
-	Name         string                            `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
-	AccessModes  []kapi.PersistentVolumeAccessMode `json:"accessModes,omitempty" protobuf:"bytes,1,rep,name=accessModes,casttype=PersistentVolumeAccessMode"`
-	VolumeMode   kapi.PersistentVolumeMode         `json:"volumeMode,omitempty"`
-	HasReference bool                              `json:"hasReference,omitempty"`
-	OwnerType    OwnerType                         `json:"ownerType,omitempty"`
+	Namespace string `json:"namespace,omitempty" protobuf:"bytes,3,opt,name=namespace"`
+	Name      string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+	// +kubebuilder:validation:XValidation:rule="self.size() == 1 && self[0] == 'auto' || self.all(am, am in ['ReadWriteOnce', 'ReadOnlyMany', 'ReadWriteMany', 'ReadWriteOncePod'])", message="Illegal AccessMode, either use 'auto' for inferring access mode or a combination of known access modes"
+	AccessModes []kapi.PersistentVolumeAccessMode `json:"accessModes,omitempty" protobuf:"bytes,1,rep,name=accessModes,casttype=PersistentVolumeAccessMode"`
+	// +kubebuilder:validation:Enum="Block";"Filesystem";"auto"
+	VolumeMode   kapi.PersistentVolumeMode `json:"volumeMode,omitempty"`
+	HasReference bool                      `json:"hasReference,omitempty"`
+	OwnerType    OwnerType                 `json:"ownerType,omitempty"`
 }
 
 // GetTargetName returns name of the target PVC

--- a/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
@@ -1545,6 +1545,11 @@ func (in *MigPlanStatus) DeepCopyInto(out *MigPlanStatus) {
 	in.UnhealthyResources.DeepCopyInto(&out.UnhealthyResources)
 	in.Conditions.DeepCopyInto(&out.Conditions)
 	in.Incompatible.DeepCopyInto(&out.Incompatible)
+	if in.Suffix != nil {
+		in, out := &in.Suffix, &out.Suffix
+		*out = new(string)
+		**out = **in
+	}
 	if in.ExcludedResources != nil {
 		in, out := &in.ExcludedResources, &out.ExcludedResources
 		*out = make([]string, len(*in))
@@ -1725,6 +1730,11 @@ func (in *PVCToMigrate) DeepCopyInto(out *PVCToMigrate) {
 		in, out := &in.TargetAccessModes, &out.TargetAccessModes
 		*out = make([]v1.PersistentVolumeAccessMode, len(*in))
 		copy(*out, *in)
+	}
+	if in.TargetVolumeMode != nil {
+		in, out := &in.TargetVolumeMode, &out.TargetVolumeMode
+		*out = new(v1.PersistentVolumeMode)
+		**out = **in
 	}
 }
 


### PR DESCRIPTION
We've had consumers of the API trip over capitalization, let's validate the options we support explicitly.