### PR TITLE
RFE-8920: Reject internal .svc S3 endpoints in MigStorage

### DIFF
--- a/pkg/cloudprovider/aws.go
+++ b/pkg/cloudprovider/aws.go
@@ -251,7 +251,7 @@ func (p *AWSProvider) Validate(secret *kapi.Secret) []string {
 			u, err := url.Parse(p.S3URL)
 			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
 				fields = append(fields, "S3URL")
-			} else if strings.HasSuffix(u.Hostname(), ".svc") || strings.Contains(u.Hostname(), ".svc.") {
+			} else if strings.HasSuffix(u.Hostname(), ".svc") {
 				fields = append(fields, "S3URL-InternalEndpoint")
 			}
 		}
@@ -259,7 +259,7 @@ func (p *AWSProvider) Validate(secret *kapi.Secret) []string {
 			u, err := url.Parse(p.PublicURL)
 			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
 				fields = append(fields, "PublicURL")
-			} else if strings.HasSuffix(u.Hostname(), ".svc") || strings.Contains(u.Hostname(), ".svc.") {
+			} else if strings.HasSuffix(u.Hostname(), ".svc") {
 				fields = append(fields, "PublicURL-InternalEndpoint")
 			}
 		}

--- a/pkg/cloudprovider/aws.go
+++ b/pkg/cloudprovider/aws.go
@@ -251,7 +251,7 @@ func (p *AWSProvider) Validate(secret *kapi.Secret) []string {
 			u, err := url.Parse(p.S3URL)
 			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
 				fields = append(fields, "S3URL")
-			} else if strings.HasSuffix(u.Hostname(), ".svc") {
+			} else if strings.HasSuffix(u.Hostname(), ".svc") || strings.HasSuffix(u.Hostname(), ".svc.cluster.local") {
 				fields = append(fields, "S3URL-InternalEndpoint")
 			}
 		}
@@ -259,7 +259,7 @@ func (p *AWSProvider) Validate(secret *kapi.Secret) []string {
 			u, err := url.Parse(p.PublicURL)
 			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
 				fields = append(fields, "PublicURL")
-			} else if strings.HasSuffix(u.Hostname(), ".svc") {
+			} else if strings.HasSuffix(u.Hostname(), ".svc") || strings.HasSuffix(u.Hostname(), ".svc.cluster.local") {
 				fields = append(fields, "PublicURL-InternalEndpoint")
 			}
 		}

--- a/pkg/cloudprovider/aws.go
+++ b/pkg/cloudprovider/aws.go
@@ -251,7 +251,7 @@ func (p *AWSProvider) Validate(secret *kapi.Secret) []string {
 			u, err := url.Parse(p.S3URL)
 			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
 				fields = append(fields, "S3URL")
-			} else if strings.HasSuffix(u.Hostname(), ".svc") {
+			} else if strings.HasSuffix(u.Hostname(), ".svc") || strings.Contains(u.Hostname(), ".svc.") {
 				fields = append(fields, "S3URL-InternalEndpoint")
 			}
 		}
@@ -259,7 +259,7 @@ func (p *AWSProvider) Validate(secret *kapi.Secret) []string {
 			u, err := url.Parse(p.PublicURL)
 			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
 				fields = append(fields, "PublicURL")
-			} else if strings.HasSuffix(u.Hostname(), ".svc") {
+			} else if strings.HasSuffix(u.Hostname(), ".svc") || strings.Contains(u.Hostname(), ".svc.") {
 				fields = append(fields, "PublicURL-InternalEndpoint")
 			}
 		}

--- a/pkg/cloudprovider/aws.go
+++ b/pkg/cloudprovider/aws.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -250,12 +251,16 @@ func (p *AWSProvider) Validate(secret *kapi.Secret) []string {
 			u, err := url.Parse(p.S3URL)
 			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
 				fields = append(fields, "S3URL")
+			} else if strings.HasSuffix(u.Hostname(), ".svc") {
+				fields = append(fields, "S3URL-InternalEndpoint")
 			}
 		}
 		if p.PublicURL != "" {
 			u, err := url.Parse(p.PublicURL)
 			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
 				fields = append(fields, "PublicURL")
+			} else if strings.HasSuffix(u.Hostname(), ".svc") {
+				fields = append(fields, "PublicURL-InternalEndpoint")
 			}
 		}
 	case VolumeSnapshot:

--- a/pkg/cloudprovider/aws_test.go
+++ b/pkg/cloudprovider/aws_test.go
@@ -9,11 +9,11 @@ func TestValidateRejectsInternalSvcEndpoints(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	tests := []struct {
-		name          string
-		s3URL         string
-		publicURL     string
-		expectS3Svc   bool
-		expectPubSvc  bool
+		name         string
+		s3URL        string
+		publicURL    string
+		expectS3Svc  bool
+		expectPubSvc bool
 	}{
 		{
 			name:        "internal .svc S3 endpoint",

--- a/pkg/cloudprovider/aws_test.go
+++ b/pkg/cloudprovider/aws_test.go
@@ -26,16 +26,6 @@ func TestValidateRejectsInternalSvcEndpoints(t *testing.T) {
 			expectPubSvc: true,
 		},
 		{
-			name:        "internal .svc.cluster.local S3 endpoint",
-			s3URL:       "https://rook-ceph-rgw-ocs-storagecluster.openshift-storage.svc.cluster.local",
-			expectS3Svc: true,
-		},
-		{
-			name:         "internal .svc.cluster.local public endpoint",
-			publicURL:    "http://rgw.openshift-storage.svc.cluster.local",
-			expectPubSvc: true,
-		},
-		{
 			name:  "external S3 endpoint is allowed",
 			s3URL: "https://s3.example.com",
 		},

--- a/pkg/cloudprovider/aws_test.go
+++ b/pkg/cloudprovider/aws_test.go
@@ -26,6 +26,16 @@ func TestValidateRejectsInternalSvcEndpoints(t *testing.T) {
 			expectPubSvc: true,
 		},
 		{
+			name:        "internal .svc.cluster.local S3 endpoint",
+			s3URL:       "https://rook-ceph-rgw-ocs-storagecluster.openshift-storage.svc.cluster.local",
+			expectS3Svc: true,
+		},
+		{
+			name:         "internal .svc.cluster.local public endpoint",
+			publicURL:    "http://rgw.openshift-storage.svc.cluster.local",
+			expectPubSvc: true,
+		},
+		{
 			name:  "external S3 endpoint is allowed",
 			s3URL: "https://s3.example.com",
 		},

--- a/pkg/cloudprovider/aws_test.go
+++ b/pkg/cloudprovider/aws_test.go
@@ -5,6 +5,61 @@ import (
 	"testing"
 )
 
+func TestValidateRejectsInternalSvcEndpoints(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	tests := []struct {
+		name          string
+		s3URL         string
+		publicURL     string
+		expectS3Svc   bool
+		expectPubSvc  bool
+	}{
+		{
+			name:        "internal .svc S3 endpoint",
+			s3URL:       "https://rook-ceph-rgw-ocs-storagecluster.openshift-storage.svc",
+			expectS3Svc: true,
+		},
+		{
+			name:         "internal .svc public endpoint",
+			publicURL:    "http://rgw.openshift-storage.svc",
+			expectPubSvc: true,
+		},
+		{
+			name:  "external S3 endpoint is allowed",
+			s3URL: "https://s3.example.com",
+		},
+		{
+			name:      "external route is allowed",
+			publicURL: "https://rgw-openshift-storage.apps.cluster.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := AWSProvider{
+				BaseProvider: BaseProvider{Role: BackupStorage},
+				Bucket:       "test-bucket",
+				S3URL:        tt.s3URL,
+				PublicURL:    tt.publicURL,
+			}
+			fields := p.Validate(nil)
+			hasS3Svc := false
+			hasPubSvc := false
+			for _, f := range fields {
+				if f == "S3URL-InternalEndpoint" {
+					hasS3Svc = true
+				}
+				if f == "PublicURL-InternalEndpoint" {
+					hasPubSvc = true
+				}
+			}
+			g.Expect(hasS3Svc).To(gomega.Equal(tt.expectS3Svc), "S3URL-InternalEndpoint")
+			g.Expect(hasPubSvc).To(gomega.Equal(tt.expectPubSvc), "PublicURL-InternalEndpoint")
+		})
+	}
+}
+
 func TestGetDisableSSL(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 

--- a/pkg/controller/migstorage/validation.go
+++ b/pkg/controller/migstorage/validation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
 
 	liberr "github.com/konveyor/controller/pkg/error"
 	migapi "github.com/konveyor/mig-controller/pkg/apis/migration/v1alpha1"
@@ -20,6 +21,7 @@ const (
 	InvalidBSProvider       = "InvalidBackupStorageProvider"
 	InvalidBSCredsSecretRef = "InvalidBackupStorageCredsSecretRef"
 	InvalidBSFields         = "InvalidBackupStorageSettings"
+	InternalEndpointUsed    = "InternalEndpointUsed"
 	InvalidVSProvider       = "InvalidVolumeSnapshotProvider"
 	InvalidVSCredsSecretRef = "InvalidVolumeSnapshotCredsSecretRef"
 	InvalidVSFields         = "InvalidVolumeSnapshotSettings"
@@ -136,16 +138,37 @@ func (r ReconcileMigStorage) validateBackupStorage(ctx context.Context, storage 
 	// Fields
 	fields := provider.Validate(secret)
 	if len(fields) > 0 {
-		storage.Status.SetCondition(migapi.Condition{
-			Type:     InvalidBSFields,
-			Status:   True,
-			Reason:   NotSupported,
-			Category: Critical,
-			Message: fmt.Sprintf("The `backupStorageConfig.credsSecretRef` must reference a valid `secret`,"+
-				" subject: %s, [].", path.Join(storage.Spec.BackupStorageConfig.CredsSecretRef.Namespace,
-				storage.Spec.BackupStorageConfig.CredsSecretRef.Name)),
-			Items: fields,
-		})
+		var internalEndpointFields []string
+		var otherFields []string
+		for _, f := range fields {
+			if strings.HasSuffix(f, "-InternalEndpoint") {
+				internalEndpointFields = append(internalEndpointFields, f)
+			} else {
+				otherFields = append(otherFields, f)
+			}
+		}
+		if len(internalEndpointFields) > 0 {
+			storage.Status.SetCondition(migapi.Condition{
+				Type:     InternalEndpointUsed,
+				Status:   True,
+				Reason:   NotSupported,
+				Category: Critical,
+				Message:  "The S3 endpoint uses an internal `.svc` hostname that is not accessible across clusters. Use an externally reachable endpoint (e.g. an Object Gateway route) for cross-cluster migrations.",
+				Items:    internalEndpointFields,
+			})
+		}
+		if len(otherFields) > 0 {
+			storage.Status.SetCondition(migapi.Condition{
+				Type:     InvalidBSFields,
+				Status:   True,
+				Reason:   NotSupported,
+				Category: Critical,
+				Message: fmt.Sprintf("The `backupStorageConfig.credsSecretRef` must reference a valid `secret`,"+
+					" subject: %s, [].", path.Join(storage.Spec.BackupStorageConfig.CredsSecretRef.Namespace,
+					storage.Spec.BackupStorageConfig.CredsSecretRef.Name)),
+				Items: otherFields,
+			})
+		}
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

Hi, I raised RFE-8920 after working a customer case where a cross-cluster MTC migration failed with misleading S3 errors. The root cause was that the replication repository was configured with an internal `.svc` S3 endpoint (from an OBC), which isn't reachable from the source cluster.

This PR adds early validation to catch this misconfiguration before the migration starts, instead of letting it fail at runtime with confusing errors.

## What this PR does

- In `pkg/cloudprovider/aws.go`: after the existing URL scheme validation, checks if the `S3URL` or `PublicURL` hostname ends with `.svc`. If so, marks the field as `S3URL-InternalEndpoint` or `PublicURL-InternalEndpoint`.
- In `pkg/controller/migstorage/validation.go`: separates internal endpoint errors from generic field errors and sets a dedicated `InternalEndpointUsed` condition with a clear message: *"The S3 endpoint uses an internal .svc hostname that is not accessible across clusters. Use an externally reachable endpoint (e.g. an Object Gateway route) for cross-cluster migrations."*
- Added unit tests covering internal `.svc` endpoints (rejected) and external endpoints (allowed).

## Why

The customer was using ODF Ceph RGW and the OBC automatically generated an internal `.svc` hostname as the S3 endpoint. In a cross-cluster migration, the source cluster can't resolve this. The resulting errors were misleading — S3 authentication failures and registry CrashLoopBackOff — which led to a long troubleshooting cycle before identifying the actual problem.

## Test plan

- [x] `go test ./pkg/cloudprovider/` — all existing + new tests pass
- [ ] Configure MigStorage with a `.svc` S3 endpoint and verify the condition is set
- [ ] Configure MigStorage with an external route endpoint and verify it passes validation

See: https://issues.redhat.com/browse/RFE-8920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects and rejects internal `.svc`/`.svc.cluster.local` endpoints in cloud storage configs and provides clearer guidance to use cross-cluster/public endpoints.

* **User-facing behavior**
  * Validation now surfaces separate, specific messages when internal endpoints are found versus other credential/config errors.

* **Tests**
  * Added tests covering detection and reporting of internal endpoint validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->