### PR TITLE
MIG-1963: Add csi.trident.netapp.io to accessModeList for correct access/volume mode detection

### DIFF
--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -805,6 +805,14 @@ var accessModeList = []provisionerAccessModes{
 		},
 	},
 	provisionerAccessModes{
+		Provisioner: "csi.trident.netapp.io",
+		// Note: some backends won't support RWX
+		AccessModes: map[kapi.PersistentVolumeMode][]kapi.PersistentVolumeAccessMode{
+			kapi.PersistentVolumeFilesystem: {kapi.ReadWriteOnce, kapi.ReadOnlyMany},
+			kapi.PersistentVolumeBlock:      {kapi.ReadWriteOnce, kapi.ReadOnlyMany, kapi.ReadWriteMany},
+		},
+	},
+	provisionerAccessModes{
 		Provisioner: "csi.kubevirt.io",
 		AccessModes: map[kapi.PersistentVolumeMode][]kapi.PersistentVolumeAccessMode{
 			kapi.PersistentVolumeFilesystem: {kapi.ReadWriteOnce},

--- a/pkg/apis/migration/v1alpha1/migcluster_types_test.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types_test.go
@@ -18,10 +18,12 @@ package v1alpha1
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -246,6 +248,98 @@ func TestMigCluster_GetRegistryLivenessTimeout(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("MigCluster.GetRegistryLivenessTimeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMigCluster_accessModesForProvisioner(t *testing.T) {
+	m := &MigCluster{}
+	tests := []struct {
+		name        string
+		provisioner string
+		volumeMode  kapi.PersistentVolumeMode
+		want        []kapi.PersistentVolumeAccessMode
+	}{
+		{
+			name:        "csi.trident.netapp.io Filesystem should return RWO and ROX",
+			provisioner: "csi.trident.netapp.io",
+			volumeMode:  kapi.PersistentVolumeFilesystem,
+			want:        []kapi.PersistentVolumeAccessMode{kapi.ReadWriteOnce, kapi.ReadOnlyMany},
+		},
+		{
+			name:        "csi.trident.netapp.io Block should return RWO, ROX, and RWX",
+			provisioner: "csi.trident.netapp.io",
+			volumeMode:  kapi.PersistentVolumeBlock,
+			want:        []kapi.PersistentVolumeAccessMode{kapi.ReadWriteOnce, kapi.ReadOnlyMany, kapi.ReadWriteMany},
+		},
+		{
+			name:        "legacy netapp.io/trident Filesystem should return RWO and ROX",
+			provisioner: "netapp.io/trident",
+			volumeMode:  kapi.PersistentVolumeFilesystem,
+			want:        []kapi.PersistentVolumeAccessMode{kapi.ReadWriteOnce, kapi.ReadOnlyMany},
+		},
+		{
+			name:        "legacy netapp.io/trident Block should return RWO, ROX, and RWX",
+			provisioner: "netapp.io/trident",
+			volumeMode:  kapi.PersistentVolumeBlock,
+			want:        []kapi.PersistentVolumeAccessMode{kapi.ReadWriteOnce, kapi.ReadOnlyMany, kapi.ReadWriteMany},
+		},
+		{
+			name:        "CSI and legacy Trident should return identical Filesystem modes",
+			provisioner: "csi.trident.netapp.io",
+			volumeMode:  kapi.PersistentVolumeFilesystem,
+			want:        m.accessModesForProvisioner("netapp.io/trident", kapi.PersistentVolumeFilesystem),
+		},
+		{
+			name:        "CSI and legacy Trident should return identical Block modes",
+			provisioner: "csi.trident.netapp.io",
+			volumeMode:  kapi.PersistentVolumeBlock,
+			want:        m.accessModesForProvisioner("netapp.io/trident", kapi.PersistentVolumeBlock),
+		},
+		{
+			name:        "rbd.csi.ceph.com suffix match for Filesystem should return RWO",
+			provisioner: "openshift-storage.rbd.csi.ceph.com",
+			volumeMode:  kapi.PersistentVolumeFilesystem,
+			want:        []kapi.PersistentVolumeAccessMode{kapi.ReadWriteOnce},
+		},
+		{
+			name:        "rbd.csi.ceph.com suffix match for Block should return RWO, ROX, and RWX",
+			provisioner: "openshift-storage.rbd.csi.ceph.com",
+			volumeMode:  kapi.PersistentVolumeBlock,
+			want:        []kapi.PersistentVolumeAccessMode{kapi.ReadWriteOnce, kapi.ReadOnlyMany, kapi.ReadWriteMany},
+		},
+		{
+			name:        "unknown provisioner Filesystem should fall back to RWO",
+			provisioner: "example.com/unknown-driver",
+			volumeMode:  kapi.PersistentVolumeFilesystem,
+			want:        []kapi.PersistentVolumeAccessMode{kapi.ReadWriteOnce},
+		},
+		{
+			name:        "unknown provisioner Block should fall back to nil",
+			provisioner: "example.com/unknown-driver",
+			volumeMode:  kapi.PersistentVolumeBlock,
+			want:        nil,
+		},
+		{
+			name:        "kubernetes.io/aws-ebs Filesystem should return RWO",
+			provisioner: "kubernetes.io/aws-ebs",
+			volumeMode:  kapi.PersistentVolumeFilesystem,
+			want:        []kapi.PersistentVolumeAccessMode{kapi.ReadWriteOnce},
+		},
+		{
+			name:        "kubernetes.io/aws-ebs Block should return nil (not in map)",
+			provisioner: "kubernetes.io/aws-ebs",
+			volumeMode:  kapi.PersistentVolumeBlock,
+			want:        nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := m.accessModesForProvisioner(tt.provisioner, tt.volumeMode)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("accessModesForProvisioner(%q, %q) = %v, want %v",
+					tt.provisioner, tt.volumeMode, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

MigCluster/MigPlan status incorrectly reports storage classes backed by the NetApp Trident CSI driver (`csi.trident.netapp.io`) as supporting only `ReadWriteOnce` + `volumeMode: Filesystem`, even when the underlying storage supports `ReadWriteMany` + `volumeMode: Block`. This blocks VM/Block-mode storage migrations for customers on NetApp Trident CSI.

**Root cause:** The `accessModeList` in `migcluster_types.go` only contained the legacy Trident provisioner name `netapp.io/trident` with exact string matching. Modern Trident CSI StorageClasses use provisioner `csi.trident.netapp.io`, which never matches, causing `accessModesForProvisioner()` to fall back to defaults: `[ReadWriteOnce]` for Filesystem and `nil` (dropped) for Block.

**Fix:** Add a new `accessModeList` entry for `csi.trident.netapp.io` alongside the existing legacy entry. This is purely additive — no existing entries or logic are modified.

- Jira: https://redhat.atlassian.net/browse/MIG-1963
- Related upstream issue: #1366

## Changes

| File | Change |
|------|--------|
| `pkg/apis/migration/v1alpha1/migcluster_types.go` | Added `csi.trident.netapp.io` entry to `accessModeList` (+8 lines) |
| `pkg/apis/migration/v1alpha1/migcluster_types_test.go` | Added 12 table-driven unit tests for `accessModesForProvisioner()` (+94 lines) |

## Test Evidence

### 1. Unit Tests — 12/12 PASS

```
=== RUN   TestMigCluster_accessModesForProvisioner
=== RUN   TestMigCluster_accessModesForProvisioner/csi.trident.netapp.io_Filesystem_should_return_RWO_and_ROX
=== RUN   TestMigCluster_accessModesForProvisioner/csi.trident.netapp.io_Block_should_return_RWO,_ROX,_and_RWX
=== RUN   TestMigCluster_accessModesForProvisioner/legacy_netapp.io/trident_Filesystem_should_return_RWO_and_ROX
=== RUN   TestMigCluster_accessModesForProvisioner/legacy_netapp.io/trident_Block_should_return_RWO,_ROX,_and_RWX
=== RUN   TestMigCluster_accessModesForProvisioner/CSI_and_legacy_Trident_should_return_identical_Filesystem_modes
=== RUN   TestMigCluster_accessModesForProvisioner/CSI_and_legacy_Trident_should_return_identical_Block_modes
=== RUN   TestMigCluster_accessModesForProvisioner/rbd.csi.ceph.com_suffix_match_for_Filesystem_should_return_RWO
=== RUN   TestMigCluster_accessModesForProvisioner/rbd.csi.ceph.com_suffix_match_for_Block_should_return_RWO,_ROX,_and_RWX
=== RUN   TestMigCluster_accessModesForProvisioner/unknown_provisioner_Filesystem_should_fall_back_to_RWO
=== RUN   TestMigCluster_accessModesForProvisioner/unknown_provisioner_Block_should_fall_back_to_nil
=== RUN   TestMigCluster_accessModesForProvisioner/kubernetes.io/aws-ebs_Filesystem_should_return_RWO
=== RUN   TestMigCluster_accessModesForProvisioner/kubernetes.io/aws-ebs_Block_should_return_nil_(not_in_map)
--- PASS: TestMigCluster_accessModesForProvisioner (0.00s)
    --- PASS: all 12 subtests
PASS
```

### 2. Cluster Integration Test — OCP 4.22.3

Tested against live OCP cluster (`api.swshende.vmware.gsslab.pnq2.redhat.com:6443`, OCP 4.22.3) with mock StorageClasses `ontap-san-trident-csi` (provisioner: `csi.trident.netapp.io`) and `ontap-san-trident-legacy` (provisioner: `netapp.io/trident`).

#### BEFORE (unfixed code) — Bug reproduced

`GetStorageClasses()` returns wrong access modes for `csi.trident.netapp.io`:

```json
{
  "name": "ontap-san-trident-csi",
  "provisioner": "csi.trident.netapp.io",
  "volumeAccessModes": [
    {
      "volumeMode": "Filesystem",
      "accessModes": ["ReadWriteOnce"]
    }
  ]
}
```

- ❌ Filesystem: only `ReadWriteOnce` (missing `ReadOnlyMany`)
- ❌ Block: **entirely missing** (`nil` — dropped from output)
- ✅ Legacy `netapp.io/trident`: correct

```
--- FAIL: TestIntegration/csi.trident.netapp.io_has_Filesystem_modes
    FAIL: Expected at least [RWO, ROX] for Filesystem, got [ReadWriteOnce]
--- FAIL: TestIntegration/csi.trident.netapp.io_has_Block_modes_with_RWX
    FAIL: Block access modes are nil — this is the bug!
--- PASS: TestIntegration/legacy_netapp.io/trident_still_works
```

#### AFTER (fixed code) — Bug fixed

```json
{
  "name": "ontap-san-trident-csi",
  "provisioner": "csi.trident.netapp.io",
  "volumeAccessModes": [
    {
      "volumeMode": "Filesystem",
      "accessModes": ["ReadWriteOnce", "ReadOnlyMany"]
    },
    {
      "volumeMode": "Block",
      "accessModes": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"]
    }
  ]
}
```

- ✅ Filesystem: `[ReadWriteOnce, ReadOnlyMany]`
- ✅ Block: `[ReadWriteOnce, ReadOnlyMany, ReadWriteMany]` (RWX present)
- ✅ Legacy `netapp.io/trident`: still correct (backward compatible)

```
--- PASS: TestIntegration/csi.trident.netapp.io_has_Filesystem_modes
--- PASS: TestIntegration/csi.trident.netapp.io_has_Block_modes_with_RWX
--- PASS: TestIntegration/legacy_netapp.io/trident_still_works
```

### 3. Full Test Suite — No Regressions

All packages that pass on unmodified master continue to pass with this change. Controller package failures (`fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory`) are pre-existing and unrelated.

### 4. Backward Compatibility

- Legacy `netapp.io/trident` entry is **untouched** — existing customers unaffected
- No logic changes — purely additive data entry in the lookup table
- No modifications to the fallback behavior for unknown provisioners

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting storage access modes for NetApp Trident CSI provisioners during persistent volume discovery.
  * Supports both filesystem and block volume modes.

* **Bug Fixes**
  * Improved access-mode handling for Trident and other known storage provisioners, including appropriate fallbacks for unsupported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->